### PR TITLE
update notebooks with outlined logo

### DIFF
--- a/01_Cheminfo_crash_course.ipynb
+++ b/01_Cheminfo_crash_course.ipynb
@@ -8,7 +8,7 @@
       },
       "source": [
         "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://raw.githubusercontent.com/MolSSI-Education/molssi-cheminformatics/0895b9e2d810fc260aaff344286a84a1b7d18a51/custom/molssi_main_horizontal.png\" style=\"display: block; margin: 0 auto; max-height:100px;\">\n",
+        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:325px;\">\n",
         "</div>\n",
         "\n",
         "# Digital Representation of Molecules\n",
@@ -753,18 +753,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "id": "LzrEG54AKY-W",
+      "metadata": {
+        "id": "LzrEG54AKY-W"
+      },
+      "outputs": [],
       "source": [
         "from urllib.request import urlretrieve\n",
         "url = (\"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/main/data/nsaids.txt\")\n",
         "filename = \"nsaids.txt\"\n",
         "urlretrieve(url, filename)"
-      ],
-      "metadata": {
-        "id": "LzrEG54AKY-W"
-      },
-      "id": "LzrEG54AKY-W",
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",

--- a/prep/A_python_basics.ipynb
+++ b/prep/A_python_basics.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "\n",
         "\n",
-        "<img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/custom/molssi_main_horizontal.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+        "<img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:325px;\">\n",
         "\n",
         "# Introduction to Python\n",
         "\n",
@@ -98,8 +98,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "_e1DP-Li6Q12"
+        "id": "_e1DP-Li6Q12",
+        "tags": []
       },
       "outputs": [],
       "source": []
@@ -128,8 +128,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "0yLHF6xQ6Q13"
+        "id": "0yLHF6xQ6Q13",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -161,8 +161,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "rwh5dZHt6Q13"
+        "id": "rwh5dZHt6Q13",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -230,8 +230,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "e3JOtxYk6Q15"
+        "id": "e3JOtxYk6Q15",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -253,8 +253,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "xjWwm0-I6Q15"
+        "id": "xjWwm0-I6Q15",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -276,8 +276,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "NEdXe7IV6Q15"
+        "id": "NEdXe7IV6Q15",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -305,8 +305,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "dxzyV0Ei6Q16"
+        "id": "dxzyV0Ei6Q16",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -326,8 +326,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "zAQ48wXN6Q16"
+        "id": "zAQ48wXN6Q16",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -348,8 +348,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "DKlZnioW6Q16"
+        "id": "DKlZnioW6Q16",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -376,8 +376,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "5FUptHHh6Q16"
+        "id": "5FUptHHh6Q16",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -403,8 +403,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "GuL4Wrc06Q17"
+        "id": "GuL4Wrc06Q17",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -425,8 +425,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "-CnmuFrV6Q17"
+        "id": "-CnmuFrV6Q17",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -456,8 +456,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "vPeEme_t6Q17"
+        "id": "vPeEme_t6Q17",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -478,8 +478,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "8iudc3W46Q17"
+        "id": "8iudc3W46Q17",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -547,8 +547,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "0vZUvpoJ6Q18"
+        "id": "0vZUvpoJ6Q18",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -574,8 +574,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "Sj8oxoGW6Q18"
+        "id": "Sj8oxoGW6Q18",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -603,8 +603,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "lwtrAAp56Q2B"
+        "id": "lwtrAAp56Q2B",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -631,8 +631,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "JVkY9icZ6Q2C"
+        "id": "JVkY9icZ6Q2C",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -668,8 +668,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "VIG-Xhhy6Q2C"
+        "id": "VIG-Xhhy6Q2C",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -694,8 +694,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "tags": [],
-        "id": "1nCZFepn6Q2C"
+        "id": "1nCZFepn6Q2C",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -714,8 +714,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "tags": [],
-        "id": "TbKB6K6U6Q2C"
+        "id": "TbKB6K6U6Q2C",
+        "tags": []
       },
       "source": [
         "## Formatted Strings\n",
@@ -747,6 +747,9 @@
     }
   ],
   "metadata": {
+    "colab": {
+      "provenance": []
+    },
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",
@@ -768,9 +771,6 @@
       "interpreter": {
         "hash": "16d4a7bb199d969b1271ebe46f77414b0d9cd01b3c3983c2b2742fc6cd4503d3"
       }
-    },
-    "colab": {
-      "provenance": []
     }
   },
   "nbformat": 4,

--- a/prep/B_molecule_representation.ipynb
+++ b/prep/B_molecule_representation.ipynb
@@ -4,12 +4,12 @@
       "cell_type": "markdown",
       "id": "6ead2fd2-c4c5-4f2f-9de6-a1a975c1011c",
       "metadata": {
-        "tags": [],
-        "id": "6ead2fd2-c4c5-4f2f-9de6-a1a975c1011c"
+        "id": "6ead2fd2-c4c5-4f2f-9de6-a1a975c1011c",
+        "tags": []
       },
       "source": [
         "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/custom/molssi_main_horizontal.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:325px;\">\n",
         "</div>\n",
         "\n",
         "\n",
@@ -234,6 +234,9 @@
     }
   ],
   "metadata": {
+    "colab": {
+      "provenance": []
+    },
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",
@@ -250,9 +253,6 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.12.2"
-    },
-    "colab": {
-      "provenance": []
     }
   },
   "nbformat": 4,

--- a/prep/C_rdkit_intro.ipynb
+++ b/prep/C_rdkit_intro.ipynb
@@ -8,7 +8,7 @@
       },
       "source": [
         "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/custom/molssi_main_horizontal.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:350px;\">\n",
         "</div>\n",
         "\n",
         "\n",
@@ -69,23 +69,23 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install rdkit"
-      ],
+      "execution_count": null,
+      "id": "eFjTn5wMHixe",
       "metadata": {
         "id": "eFjTn5wMHixe"
       },
-      "id": "eFjTn5wMHixe",
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "!pip install rdkit"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "afc9bc63",
       "metadata": {
-        "tags": [],
-        "id": "afc9bc63"
+        "id": "afc9bc63",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -119,8 +119,8 @@
       "execution_count": null,
       "id": "40b29a7c",
       "metadata": {
-        "tags": [],
-        "id": "40b29a7c"
+        "id": "40b29a7c",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -145,8 +145,8 @@
       "execution_count": null,
       "id": "99734c44",
       "metadata": {
-        "tags": [],
-        "id": "99734c44"
+        "id": "99734c44",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -194,8 +194,8 @@
       "execution_count": null,
       "id": "bbae7a92-6647-4361-b5ed-f45363f4d249",
       "metadata": {
-        "tags": [],
-        "id": "bbae7a92-6647-4361-b5ed-f45363f4d249"
+        "id": "bbae7a92-6647-4361-b5ed-f45363f4d249",
+        "tags": []
       },
       "outputs": [],
       "source": [
@@ -939,6 +939,9 @@
     }
   ],
   "metadata": {
+    "colab": {
+      "provenance": []
+    },
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",
@@ -960,9 +963,6 @@
       "interpreter": {
         "hash": "16d4a7bb199d969b1271ebe46f77414b0d9cd01b3c3983c2b2742fc6cd4503d3"
       }
-    },
-    "colab": {
-      "provenance": []
     }
   },
   "nbformat": 4,

--- a/prep/D_molecular_similarity.ipynb
+++ b/prep/D_molecular_similarity.ipynb
@@ -8,7 +8,7 @@
       },
       "source": [
         "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/custom/molssi_main_horizontal.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:350px;\">\n",
         "</div>\n",
         "\n",
         "\n",
@@ -80,15 +80,15 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install rdkit"
-      ],
+      "execution_count": null,
+      "id": "nn2PUoVduv_5",
       "metadata": {
         "id": "nn2PUoVduv_5"
       },
-      "id": "nn2PUoVduv_5",
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "!pip install rdkit"
+      ]
     },
     {
       "cell_type": "markdown",
@@ -584,6 +584,9 @@
     }
   ],
   "metadata": {
+    "colab": {
+      "provenance": []
+    },
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",
@@ -600,9 +603,6 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.12.2"
-    },
-    "colab": {
-      "provenance": []
     }
   },
   "nbformat": 4,

--- a/prep/E_pandas_seaborn.ipynb
+++ b/prep/E_pandas_seaborn.ipynb
@@ -7,7 +7,7 @@
       },
       "source": [
         "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/custom/molssi_main_horizontal.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:350px;\">\n",
         "</div>\n",
         "\n",
         "\n",
@@ -48,14 +48,14 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install pandas seaborn matplotlib rdkit"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "F72xtliv1KkY"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "!pip install pandas seaborn matplotlib rdkit"
+      ]
     },
     {
       "cell_type": "code",
@@ -118,8 +118,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "scrolled": true,
-        "id": "x3eBcLoG1BL7"
+        "id": "x3eBcLoG1BL7",
+        "scrolled": true
       },
       "outputs": [],
       "source": [
@@ -676,16 +676,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "zYBJIN5w3fPi"
+      },
+      "outputs": [],
       "source": [
         "url = (\"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/amino_acids.txt\")\n",
         "filename = \"amino_acids.txt\"\n",
         "urlretrieve(url, filename)"
-      ],
-      "metadata": {
-        "id": "zYBJIN5w3fPi"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
@@ -774,6 +774,9 @@
     }
   ],
   "metadata": {
+    "colab": {
+      "provenance": []
+    },
     "kernelspec": {
       "display_name": "Python 3 (ipykernel)",
       "language": "python",
@@ -790,9 +793,6 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.12.2"
-    },
-    "colab": {
-      "provenance": []
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
This changes the logo to use a MolSSI logo with a white outline so that it is visible when using dark mode in notebooks.