### PR TITLE
Format all notebooks using ruff

### DIFF
--- a/01_Cheminfo_crash_course.ipynb
+++ b/01_Cheminfo_crash_course.ipynb
@@ -1,1247 +1,1264 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "7d06a1a8-a729-47c1-973a-3b6afa520f18",
-      "metadata": {
-        "id": "7d06a1a8-a729-47c1-973a-3b6afa520f18"
-      },
-      "source": [
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:325px;\">\n",
-        "</div>\n",
-        "\n",
-        "# Digital Representation of Molecules\n",
-        "\n",
-        "This tutorial was written by Paul Craig (RIT Professor) and Jessica Nash (Software Scientist) for the [Cheminformatic-Driven Molecular Docking Workshop](https://pdb101.rcsb.org/news/67d9853eaddf75595bd158f7) held as a Crash Course with the Institute for Quantitative Biomedicine (IQB) and the Protein Data Bank (PDB).\n",
-        "\n",
-        "*This notebook is Part 1 of 4 in the notebook series.*\n",
-        "\n",
-        "Other notebooks in this series:\n",
-        "1. ***Digital Representation of Molecules*** (This notebook)\n",
-        "2. [Exploring Chemical and Biological Data with BindingDB and the RDKit](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/02_Cheminfo_crash_course.ipynb)\n",
-        "3. [Preparing Structures for Docking](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/03_Cheminfo_crash_course.ipynb)\n",
-        "4. [Molecular Docking using gnina](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/04_Cheminfo_crash_course.ipynb)\n",
-        "\n",
-        "In this notebook, we will learn how to represent chemical structures as SMILES, how to use SMILES to create RDKit mol objects, and how to explore and visualize chemical data using pandas dataframes. This notebook is based on notebooks 01-05 from the [MolSSI Cheminformatics course](https://github.com/MolSSI-Education/molssi-cheminformatics), which was created by Jessica Nash from The Molecular Sciences Software Institute.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "350c2869-274d-4bab-87c9-aa06fbfd9f89",
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 280
-        },
-        "id": "350c2869-274d-4bab-87c9-aa06fbfd9f89",
-        "outputId": "a203ef00-6869-40b8-f001-9e0134469b1d"
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
-            "text/html": [
-              "<style>\n",
-              "div.alert {\n",
-              "    color: #0056b3;\n",
-              "    background-color: #d9edf7;\n",
-              "    border-left: 5px solid #31708f;\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em;\n",
-              "    line-height: 1.5;\n",
-              "}\n",
-              "div.alert ul {\n",
-              "    margin: 0.5em 0;\n",
-              "}\n",
-              "div.alert li {\n",
-              "    margin-bottom: 0.5em;\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"alert alert-block alert-info\">\n",
-              "    <strong>Questions:</strong>\n",
-              "    <ul>\n",
-              "        <li>How are molecules represented on computers?</li>\n",
-              "        <li>What is a SMILES?</li>\n",
-              "        <li>What are common molecular file formats?</li>\n",
-              "   </ul>\n",
-              "\n",
-              "    <strong>Objectives:</strong>\n",
-              "    <ul>\n",
-              "        <li>Learn the basics of SMILES.</li>\n",
-              "        <li>Convert molecules from chemical formula and structures to SMILES.</li>\n",
-              "    </ul>\n",
-              "</div>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# @title Overview\n",
-        "%%html\n",
-        "<style>\n",
-        "div.alert {\n",
-        "    color: #0056b3;\n",
-        "    background-color: #d9edf7;\n",
-        "    border-left: 5px solid #31708f;\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em;\n",
-        "    line-height: 1.5;\n",
-        "}\n",
-        "div.alert ul {\n",
-        "    margin: 0.5em 0;\n",
-        "}\n",
-        "div.alert li {\n",
-        "    margin-bottom: 0.5em;\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "    <strong>Questions:</strong>\n",
-        "    <ul>\n",
-        "        <li>How are molecules represented on computers?</li>\n",
-        "        <li>What is a SMILES?</li>\n",
-        "        <li>What are common molecular file formats?</li>\n",
-        "   </ul>\n",
-        "\n",
-        "    <strong>Objectives:</strong>\n",
-        "    <ul>\n",
-        "        <li>Learn the basics of SMILES.</li>\n",
-        "        <li>Convert molecules from chemical formula and structures to SMILES.</li>\n",
-        "    </ul>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b8eb3cf1-79d9-40f6-a739-92b0ba19539e",
-      "metadata": {
-        "id": "b8eb3cf1-79d9-40f6-a739-92b0ba19539e"
-      },
-      "source": [
-        "## Molecular Representations of Biological Molecules for Computing\n",
-        "\n",
-        "In bioinformatics, if you work with genomics you are accustomed to working with DNA sequences. For example, this is a partial DNA sequence for human dihdydrofolate reductase, an important enzyme in nucelotide metabolism.\n",
-        "\n",
-        "```\n",
-        "GAATTCATGAAAACGTAGCTCGTCCTCAAAAAAAACAGAAGAGGAGTAATCATTTTAAGGGAGAAATATA\n",
-        "TACGAAAGGAACAAGATTTTGAAGCACCCAAGCTGCCACCTACATTAAAACACGGTAGGTGGCTAAACAC\n",
-        "CAGTCTTCAATGCCCTTCCACAGCCTCAGTCTGAAAAATACTGTGCAGGTGACCCAAGTGAGGGGTCACC\n",
-        "CTTGGGCTTTTCCTGTGGCAGTATCTCTGGTTTAAAAACAAACAAACGTACTTATTGCGTTGAAGGACGG\n",
-        "CAACAGGAAGGACTCCATGATTAGTCACATCTATACCATCCTAAGAAACTTTATCCACCCAAACTGTATT\n",
-        "TCAGACTTTATAATCTAAACTACAAAAAGTGTTCACTGGGGAACTGCACAATATGACTGCTTTTAACCGT\n",
-        "```\n",
-        "\n",
-        "The DNA sequence shown here is a simplified representation of a very complex 3D structure that is part of a chromosome, an enormously complex structure. The sequence that represents this gene can be used as a string in coding - computation with strings is orders of magnitude faster than computation with 3D structures. And we can still learn a great deal about this gene simply by exploring the sequence. Likewise we can represent the RNA transcribed from this sequence as a list of characters where T is replaced by U.\n",
-        "\n",
-        "If you study proteins or proteomics, you know that protein function depends on protein structure. Protein structures involve 20 (or more) building blocks so the sequences are more complex, but the principle of representing the protein as a simple string for ease with computing still applies. Here is the sequence of the dihydrofolate reductase protein that is coded in this gene sequence above.\n",
-        "\n",
-        "```\n",
-        "MVGSLNCIVAVSQNMGIGKNGDLPWPPLRNEFRYFQRMTTTSSVEGKQNLVIMGKKTWFSIPEKNRPLKG\n",
-        "RINLVLSRELKEPPQGAHFLSRSLDDALKLTEQPELANKVDMVWIVGGSSVYKEAMNHPGHLKLFVTRIM\n",
-        "QDFESDTFFPEIDLEKYKLLPEYPGVLSDVQEEKGIKYKFEVYEKND\n",
-        "```\n",
-        "\n",
-        "As we move into cheminformatics, we often want to convert small molecule structures, like the aspirin shown here, into strings for computing ease.\n",
-        "\n",
-        "![Aspirin.png](https://drive.google.com/uc?export=view&id=1hcWaacd-pIb09Wi9dceVSQIfkXgWC-vD)\n",
-        "\n",
-        "There are three well-known string conversions for small molecules, SMILES, InChI, and InChI Key. Here are the SMILES, InChI, and InChI Key strings for aspirin.\n",
-        "\n",
-        "SMILES: CC(=O)OC1=CC=CC=C1C(=O)O\n",
-        "\n",
-        "InChI: 1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)\n",
-        "\n",
-        "InChI Key: BSYNRYMUTXBXSQ-UHFFFAOYSA-N\n",
-        "\n",
-        "In this workshop we will use SMILES strings. SMILES syntax is explained below."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1a20ce5f-0392-40be-a64f-006929d49a5a",
-      "metadata": {
-        "id": "1a20ce5f-0392-40be-a64f-006929d49a5a"
-      },
-      "source": [
-        "## Simplified Molecular-Input Line-entry System: SMILES\n",
-        "\n",
-        "SMILES stands for \"Simplified Molecular-Input Line-Entry System\" and is a way to represent molecules as a string of characters.\n",
-        "\n",
-        "Consider the molecule ethanol. The image below shows a representation that we are used to seeing in chemistry:\n",
-        "\n",
-        "![ethanol](https://drive.google.com/uc?export=view&id=1pBnnNujVdkw43xpDOM27nzICgnn7EqJj)\n",
-        "\n",
-        "However, the SMILES representation of this molecule would be \"CCO\".\n",
-        "\n",
-        "You can read more about SMILES at [this tutorial](https://archive.epa.gov/med/med_archive_03/web/html/smiles.html), but rules for atoms and bonds are also repeated below.\n",
-        "\n",
-        "### Atoms\n",
-        "SMILES supports all elements in the periodic table. An atom is represented using its respective atomic symbol. Upper case letters refer to non-aromatic atoms; lower case letters refer to aromatic atoms. If the atomic symbol has more than one letter the second letter must be lower case.\n",
-        "\n",
-        "### Bonds\n",
-        "```\n",
-        "-\tSingle bond\n",
-        "=\tDouble bond\n",
-        "#\tTriple bond\n",
-        "*\tAromatic bond\n",
-        ".\tDisconnected structures\n",
-        "```\n",
-        "Single bonds are the default and therefore need not be entered. For example, 'CC' would mean that there is a non-aromatic carbon attached to another non-aromatic carbon by a single bond, and the computer would identify the structure as the chemical ethane. It is also assumed that the bond between two lower case atom symbols is aromatic. A blank terminates the SMILES string.\n",
-        "\n",
-        "### Branches\n",
-        "\n",
-        "A branch from a chain is specified by placing the SMILES symbol(s) for the branch between parenthesis. Some examples:\n",
-        "\n",
-        "```\n",
-        "\n",
-        "CC(O)C\t2-Propanol\n",
-        "CC(=O)C\t2-Propanone\n",
-        "```\n",
-        "\n",
-        "### Rings\n",
-        "\n",
-        "A ring is specified by placing a number directly after the SMILES symbol where the ring closure occurs. This number acts as a marker, indicating that the atoms with the same number are connected, thus forming a ring. For instance:\n",
-        "\n",
-        "```\n",
-        "C1CCCC1   cyclopentane\n",
-        "n1ccccc1  Pyridine\n",
-        "```\n",
-        "\n",
-        "### SMILES Examples\n",
-        "\n",
-        "![SMILES Example 1](https://drive.google.com/uc?export=view&id=1-MFSoAGwqOPiqIUD06reOkBPx4BTMhGC)\n",
-        "\n",
-        "![SMILES Example 2](https://drive.google.com/uc?export=view&id=18Ub9L98y8cL_lDLF9wl6pLQxCkt8JFqu)\n",
-        "\n",
-        "### Using Online Resources\n",
-        "Most of the time, you will not need to write a SMILES string by hand. You will be able to look up a molecule's SMILES string from a web database like [PubChem](https://pubchem.ncbi.nlm.nih.gov/).\n",
-        "\n",
-        "You can also use tools like this [molecule sketcher from the Protein Data Bank](https://www.rcsb.org/chemical-sketch)\n",
-        "to draw molecules and get their SMILES strings."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "928a5415-2bcb-4ef0-ac8a-1744714d8d3c",
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 370
-        },
-        "id": "928a5415-2bcb-4ef0-ac8a-1744714d8d3c",
-        "outputId": "a789c96a-648e-4d04-fa80-0b303b063a63"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.orange-alert {\n",
-              "    color: #854f00; /* Darker shade of orange for text */\n",
-              "    background-color: #ffe6cc; /* Light orange background */\n",
-              "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.orange-alert ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.orange-alert li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"orange-alert\">\n",
-              "\n",
-              "<strong>Exercise</strong>\n",
-              "<p>\n",
-              "Based on what you've learned about SMILES strings, answer the following questions:\n",
-              "</p>\n",
-              "    <ul>\n",
-              "        <li> What is the SMILES for ethanol?</li>\n",
-              "        <li> What is the SMILES for water?</li>\n",
-              "        <li> What is the SMILES for benzene?</li>\n",
-              "        <li> What molecule is represented by the SMILES O=C=O?</li>\n",
-              "        <li> What is the SMILES for an amide group?<//li>\n",
-              "        <li> What is the SMILES for a 4 membered carbon chain with an amide group on the second carbon?</li>\n",
-              "    </ul>\n",
-              "</p>\n",
-              "<p>Check your answers from this previous exercise using the PDB molecule sketcher. Notice that you can type in a SMILES string and have the sketcher draw the molecule for you.</p>\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title Exercise\n",
-        "%%html\n",
-        "<style>\n",
-        "div.orange-alert {\n",
-        "    color: #854f00; /* Darker shade of orange for text */\n",
-        "    background-color: #ffe6cc; /* Light orange background */\n",
-        "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.orange-alert ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.orange-alert li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"orange-alert\">\n",
-        "\n",
-        "<strong>Exercise</strong>\n",
-        "<p>\n",
-        "Based on what you've learned about SMILES strings, answer the following questions:\n",
-        "</p>\n",
-        "    <ul>\n",
-        "        <li> What is the SMILES for ethanol?</li>\n",
-        "        <li> What is the SMILES for water?</li>\n",
-        "        <li> What is the SMILES for benzene?</li>\n",
-        "        <li> What molecule is represented by the SMILES O=C=O?</li>\n",
-        "        <li> What is the SMILES for an amide group?<//li>\n",
-        "        <li> What is the SMILES for a 4 membered carbon chain with an amide group on the second carbon?</li>\n",
-        "    </ul>\n",
-        "</p>\n",
-        "<p>Check your answers from this previous exercise using the PDB molecule sketcher. Notice that you can type in a SMILES string and have the sketcher draw the molecule for you.</p>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6dcdb914-bf20-425d-859c-44c250ca991a",
-      "metadata": {
-        "id": "6dcdb914-bf20-425d-859c-44c250ca991a"
-      },
-      "outputs": [],
-      "source": [
-        "# Fill in your answers here:\n",
-        "# 1.\n",
-        "# 2.\n",
-        "# 3.\n",
-        "# 4.\n",
-        "# 5.\n",
-        "# 6. CC(C(=O)N)CC\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "4842145a-676e-4f1f-9b55-8b8296a81301",
-      "metadata": {
-        "id": "4842145a-676e-4f1f-9b55-8b8296a81301"
-      },
-      "source": [
-        "## Molecular File Formats\n",
-        "\n",
-        "Molecules can also be represented using a number of different file formats. As you work more in chemistry, you may see a number of these. Sometimes you will have to pick a file format based on the software you are using or the molecular information you want to save.\n",
-        "\n",
-        "| File Format | Description                                                                 | Features                                                              | Common Uses                              |\n",
-        "|-------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------|------------------------------------------|\n",
-        "| SMILES      | Simplified Molecular Input Line Entry System                                | Line notation for representing molecular structures                   | Database               |\n",
-        "| InChI       | International Chemical Identifier                                           | Textual identifier for chemical substances                            | Databases             |\n",
-        "| MOL/SDF     | MDL MOLfile and Structure-Data File                                         | Contains 2D/3D coordinates, atoms, bonds                              | Structure visualization, cheminformatics |\n",
-        "| PDB         | Protein Data Bank format                                                    | Often used for 3D structures of proteins and nucleic acids,but can also be used for small molecules. Often does not contain molecule information, and cannot store partial charges.                           | Structural biology, bioinformatics       |\n",
-        "| XYZ         | Cartesian coordinates                                                       | Simple text format with atom types and 3D coordinates                 | Computational chemistry, molecular dynamics |     |\n",
-        "| CIF         | Crystallographic Information File                                           | Text file format for representing crystal structure data              | Crystallography                          |\n",
-        "| PQR         | Extended PDB format with partial charges and radii                          | Includes atomic coordinates, partial charges, and radii               | Electrostatics calculations              |\n",
-        "| PDBQT       | PDB format with torsion angles and charges used in AutoDock                 | Includes atomic coordinates, partial charges, torsion angles          | Molecular docking                        |\n",
-        "|MOL2   |Tripos Mol2 format|\tContains atomic coordinates, bonds, molecule types, substructures, and partial charges|\tMolecular modeling, cheminformatics, computational chemistry\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "id": "3db21944-72a0-4523-a87d-f702baa98a4b",
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 245
-        },
-        "id": "3db21944-72a0-4523-a87d-f702baa98a4b",
-        "outputId": "ae6a9030-722d-4a69-8804-0729501e2dda"
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
-            "text/html": [
-              "<style>\n",
-              "div.alert {\n",
-              "    color: #0056b3;\n",
-              "    background-color: #d9edf7;\n",
-              "    border-left: 5px solid #31708f;\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em;\n",
-              "    line-height: 1.5;\n",
-              "}\n",
-              "div.alert ul {\n",
-              "    margin: 0.5em 0;\n",
-              "}\n",
-              "div.alert li {\n",
-              "    margin-bottom: 0.5em;\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"alert alert-block alert-info\">\n",
-              "    <strong>Questions:</strong>\n",
-              "    <ul>\n",
-              "        <li>What is RDKit?</li>\n",
-              "        <li>What is an RDKit mol object?</li>\n",
-              "        <li>What can I do with RDKit mol objects?</li>\n",
-              "   </ul>\n",
-              "\n",
-              "    <strong>Objectives:</strong>\n",
-              "    <ul>\n",
-              "        <li>Use RDKit to create mol objects in Python.</li>\n",
-              "    </ul>\n",
-              "</div>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# @title Introduction to RDKit Molecules\n",
-        "%%html\n",
-        "<style>\n",
-        "div.alert {\n",
-        "    color: #0056b3;\n",
-        "    background-color: #d9edf7;\n",
-        "    border-left: 5px solid #31708f;\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em;\n",
-        "    line-height: 1.5;\n",
-        "}\n",
-        "div.alert ul {\n",
-        "    margin: 0.5em 0;\n",
-        "}\n",
-        "div.alert li {\n",
-        "    margin-bottom: 0.5em;\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "    <strong>Questions:</strong>\n",
-        "    <ul>\n",
-        "        <li>What is RDKit?</li>\n",
-        "        <li>What is an RDKit mol object?</li>\n",
-        "        <li>What can I do with RDKit mol objects?</li>\n",
-        "   </ul>\n",
-        "\n",
-        "    <strong>Objectives:</strong>\n",
-        "    <ul>\n",
-        "        <li>Use RDKit to create mol objects in Python.</li>\n",
-        "    </ul>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "There are Python libraries that are made for working just with chemical data. One commonly\n",
-        "used library in Python for data science (or cheminformatics) is called\n",
-        "[RDKit](https://en.wikipedia.org/wiki/RDKit). RDKit is an open-source cheminformatics\n",
-        "library, primarily developed in C++ and has been under development since the year 2000.\n",
-        "We will be using the Python interface to RDKit, though there are interfaces in other languages.\n",
-        "</p>\n",
-        "\n",
-        "<p>\n",
-        "RDKit provides a molecule object that allows you to manipulate chemical structures. It has\n",
-        "capabilities for reading and writing molecular file formats, calculating molecular properties,\n",
-        "and performing substructure searches. In addition, it offers a wide range of cheminformatics\n",
-        "algorithms such as molecular fingerprint generation, similarity metrics calculation, and\n",
-        "molecular descriptor computation. This notebook introduces RDKit basics, but we will see more\n",
-        "of all of these topics in later notebooks.\n",
-        "</p>"
-      ],
-      "metadata": {
-        "id": "feS3YwAQ4_0A"
-      },
-      "id": "feS3YwAQ4_0A"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "id": "3949cd4d-3f71-4622-a774-bcf3542a74d8",
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 440
-        },
-        "id": "3949cd4d-3f71-4622-a774-bcf3542a74d8",
-        "outputId": "8171c6b8-ab1c-4a7f-cf27-ace07bac7e75"
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
-            "text/html": [
-              "<style>\n",
-              "div.purple-box {\n",
-              "    color: #4b0082; /* Indigo for text */\n",
-              "    background-color: #f3e5f5; /* Light lavender background */\n",
-              "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-              "}\n",
-              "div.purple-box ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.purple-box li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"purple-box\">\n",
-              "    <p>\n",
-              "       Most of this functionality is achieved through the RDKit `mol` object. In Python,\n",
-              "we use the word \"object\" to refer to a variable type with associated data and methods.\n",
-              "One example of an object we have seen in notebooks is a list - we could also call it\n",
-              "a \"list object\". An object has `attributes` (data) and `methods`.\n",
-              "You access information about objects with the syntax\n",
-              "    </p>\n",
-              "<pre>\n",
-              "\n",
-              "object.data\n",
-              "\n",
-              "</pre>\n",
-              "\n",
-              "where data is the attribute name.\n",
-              "\n",
-              "You access object methods with the syntax\n",
-              "\n",
-              "<pre>\n",
-              "\n",
-              "object.method(arguments)\n",
-              "\n",
-              "</pre>\n",
-              "        For example, for a list \"`append` is a method that was covered in the introductory lesson.\n",
-              "<pre>\n",
-              "\n",
-              "my_list = []\n",
-              "my_list.append(1) # \"append\" is a method\n",
-              "\n",
-              "<pre>\n",
-              "</div>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# @title Python Skills - Python Objects\n",
-        "%%html\n",
-        "<style>\n",
-        "div.purple-box {\n",
-        "    color: #4b0082; /* Indigo for text */\n",
-        "    background-color: #f3e5f5; /* Light lavender background */\n",
-        "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-        "}\n",
-        "div.purple-box ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.purple-box li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"purple-box\">\n",
-        "    <p>\n",
-        "       Most of this functionality is achieved through the RDKit `mol` object. In Python,\n",
-        "we use the word \"object\" to refer to a variable type with associated data and methods.\n",
-        "One example of an object we have seen in notebooks is a list - we could also call it\n",
-        "a \"list object\". An object has `attributes` (data) and `methods`.\n",
-        "You access information about objects with the syntax\n",
-        "    </p>\n",
-        "<pre>\n",
-        "\n",
-        "object.data\n",
-        "\n",
-        "</pre>\n",
-        "\n",
-        "where data is the attribute name.\n",
-        "\n",
-        "You access object methods with the syntax\n",
-        "\n",
-        "<pre>\n",
-        "\n",
-        "object.method(arguments)\n",
-        "\n",
-        "</pre>\n",
-        "        For example, for a list \"`append` is a method that was covered in the introductory lesson.\n",
-        "<pre>\n",
-        "\n",
-        "my_list = []\n",
-        "my_list.append(1) # \"append\" is a method\n",
-        "\n",
-        "<pre>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "In this lesson, we will create and manipulate RDKit `mol` objects. RDKit `mol` objects represent molecules and have\n",
-        "attributes (data) and methods (actions) associated with molecules.\n",
-        "\n",
-        "We are going to use a part of RDKit called `Chem`. To use `Chem`, we first have to install it in our environment, then import it into our notebook."
-      ],
-      "metadata": {
-        "id": "hwnTxVly5PSN"
-      },
-      "id": "hwnTxVly5PSN"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "Xovgh3LcqJA2",
-      "metadata": {
-        "id": "Xovgh3LcqJA2"
-      },
-      "outputs": [],
-      "source": [
-        "from google.colab import output\n",
-        "output.clear()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3c5c13a5-b369-4188-8b13-356445deeb5a",
-      "metadata": {
-        "id": "3c5c13a5-b369-4188-8b13-356445deeb5a"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install rdkit\n",
-        "from rdkit import Chem"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d84d6c70-fd6e-41bf-81c6-7145d6f87b0e",
-      "metadata": {
-        "id": "d84d6c70-fd6e-41bf-81c6-7145d6f87b0e"
-      },
-      "source": [
-        "## Creating Molecules with RDKit\n",
-        "\n",
-        "Throughout this tutorial, it will be helpful to have access to the [RDKit documentation](https://www.rdkit.org/docs/index.html).\n",
-        "\n",
-        "To get information about molecules in RDKit, we have to first create objects representing molecules. RDKit has a molecule object that can be used to retrieve information or calculate properties. To create a molecule object, we have to communicate the molecule identity in a way that computers understand.\n",
-        "\n",
-        "We will use SMILES strings to create our objects, though RDKit also has methods for creating molecules from the file formats listed in the previous notebook.\n",
-        "\n",
-        "### Creating molecules using SMILES\n",
-        "\n",
-        "In the last lesson, we learned about molecular representations using SMILES strings. Now we will use SMILES strings to create molecule objects in RDKIT.\n",
-        "\n",
-        "We can create a representation of methane using RDKit by using the `MolFromSmiles` function in `rdkit.Chem`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "b9415ede-7ab5-4a35-89e8-a32d25dfe1b9",
-      "metadata": {
-        "id": "b9415ede-7ab5-4a35-89e8-a32d25dfe1b9"
-      },
-      "outputs": [],
-      "source": [
-        "methane = Chem.MolFromSmiles(\"\")          # TO DO: Enter the SMILES string for methane between the quote signs"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "851ae0d6-b0a2-4474-9402-5db4abf49b1c",
-      "metadata": {
-        "id": "851ae0d6-b0a2-4474-9402-5db4abf49b1c"
-      },
-      "outputs": [],
-      "source": [
-        "methane"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6c305149-481a-4e52-83bc-a24ab48f45bf",
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 283
-        },
-        "id": "6c305149-481a-4e52-83bc-a24ab48f45bf",
-        "outputId": "15456f3c-aaba-4782-f4c6-d1ce302f5d5a"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.orange-alert {\n",
-              "    color: #854f00; /* Darker shade of orange for text */\n",
-              "    background-color: #ffe6cc; /* Light orange background */\n",
-              "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.orange-alert ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.orange-alert li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"orange-alert\">\n",
-              "\n",
-              "<p> Create RDKit molecules for the following molecules. You can look up the SMILES strings on <a href=\"https://pubchem.ncbi.nlm.nih.gov/\">PubChem</a>:\n",
-              "<p>\n",
-              "    <ul>\n",
-              "        <li> Propane\n",
-              "        <li> Ethene\n",
-              "        <li> Cyclohexane\n",
-              "        <li> Benzene </li>\n",
-              "        <li> Acetic Acid\n",
-              "    </ul>\n",
-              "</p>\n",
-              "<p>Create variables for each molecule. The variable names should be the molecule name (all lowercase)</p>\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title Check Your Understanding\n",
-        "%%html\n",
-        "<style>\n",
-        "div.orange-alert {\n",
-        "    color: #854f00; /* Darker shade of orange for text */\n",
-        "    background-color: #ffe6cc; /* Light orange background */\n",
-        "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.orange-alert ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.orange-alert li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"orange-alert\">\n",
-        "\n",
-        "<p> Create RDKit molecules for the following molecules. You can look up the SMILES strings on <a href=\"https://pubchem.ncbi.nlm.nih.gov/\">PubChem</a>:\n",
-        "<p>\n",
-        "    <ul>\n",
-        "        <li> Propane\n",
-        "        <li> Ethene\n",
-        "        <li> Cyclohexane\n",
-        "        <li> Benzene </li>\n",
-        "        <li> Acetic Acid\n",
-        "    </ul>\n",
-        "</p>\n",
-        "<p>Create variables for each molecule. The variable names should be the molecule name (all lowercase)</p>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "497025f0-e60a-42d1-a26e-77db46e5c495",
-      "metadata": {
-        "id": "497025f0-e60a-42d1-a26e-77db46e5c495"
-      },
-      "outputs": [],
-      "source": [
-        "# Your answers go here\n",
-        "propane = Chem.MolFromSmiles(\"\")                # TO DO: Insert the SMILES string for propane: CCC\n",
-        "ethene = Chem.MolFromSmiles(\"\")                 # TO DO: Insert the SMILES string for ethene\n",
-        "cyclohexane = Chem.MolFromSmiles(\"\")            # TO DO: Call the method and insert the SMILES string for cyclohexane\n",
-        "benzene = Chem.MolFromSmiles(\"\")                # TO DO: Call the method and insert the SMILES string for benzene\n",
-        "acetic_acid = Chem.MolFromSmiles(\"CC(=O)O\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f87d25a4-61b2-437a-a5a6-176a2a45a813",
-      "metadata": {
-        "id": "f87d25a4-61b2-437a-a5a6-176a2a45a813"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here just by typing the name of the variable that refers to the RDKit mol object\n",
-        "acetic_acid"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "4CzZhBBEGpGV",
-      "metadata": {
-        "id": "4CzZhBBEGpGV"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem.Draw import IPythonConsole as ipc\n",
-        "from rdkit.Chem import Draw\n",
-        "\n",
-        "# Configuration for displaying in Jupyter notebooks\n",
-        "ipc.ipython_useSVG = True  # Use SVG for higher quality images\n",
-        "ipc.drawOptions.addAtomIndices = True  # Show atom indices\n",
-        "ipc.molSize = 250,250 # Set size of image"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "474fcdab-a904-4c66-8243-5a59de5ebf90",
-      "metadata": {
-        "cellView": "form",
-        "id": "474fcdab-a904-4c66-8243-5a59de5ebf90"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Working with RDKit Molecules\n",
-        "%%html\n",
-        "<style>\n",
-        "div.purple-box {\n",
-        "    color: #4b0082; /* Indigo for text */\n",
-        "    background-color: #f3e5f5; /* Light lavender background */\n",
-        "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-        "}\n",
-        "div.purple-box ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.purple-box li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"purple-box\">\n",
-        "    <p>\n",
-        "RDKit molecule objects have a number of methods we can use to get more information about the molecule. In the next few cells, we'll look at some methods that can tell us some things about the molecules we've created. The next cell has settings for modifying drawing molecules. It adds labels of atom indices and sets the image size\n",
-        "When working with Python objects in the Jupyter notebook, you can\n",
-        "type a variable or object name to see the methods available on that object.\n",
-        "    </p>\n",
-        "    <p>\n",
-        "In the cell below, type\n",
-        "<pre>\n",
-        "  acetic_acid.\n",
-        "\n",
-        "</pre>\n",
-        "\n",
-        "Notice how there is a dot at the end\n",
-        "\n",
-        "    <pre>\n",
-        "      .\n",
-        "    </pre>\n",
-        "\n",
-        "Then press the `tab` key. A list of possible methods and attributes will come up.\n",
-        "\n",
-        "Look through the methods until you find one that gives you the number of atoms in the molecule.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "e1a331ad-3b4d-44e1-ad51-dc093008dacb",
-      "metadata": {
-        "id": "e1a331ad-3b4d-44e1-ad51-dc093008dacb"
-      },
-      "outputs": [],
-      "source": [
-        "# Pick a method that will tell you the number of atoms acetic acid has.\n",
-        "\n",
-        "x = acetic_acid                                  # TO DO: enter a . after acetic acid and then scroll down the list to find a method to give you the number of atoms\n",
-        "\n",
-        "print('Acetic acid has', x, 'heavy atoms.')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "56379e5a-44f0-4272-959d-91f652ba4128",
-      "metadata": {
-        "id": "56379e5a-44f0-4272-959d-91f652ba4128"
-      },
-      "source": [
-        "### Finding help\n",
-        "When you start working with RDKit mol objects, it will be an adjustment. This is a new type of variable and it will take time to adjust. One way to find help is to use a simple help command where the object of the help function is the name of the RDKit mol object. In the next cell, we will use help to learn more about the RDKit mol object, acetic_acid, that we just created."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1b7d32b7-f531-4a4f-b05e-4c6c51664d50",
-      "metadata": {
-        "id": "1b7d32b7-f531-4a4f-b05e-4c6c51664d50"
-      },
-      "outputs": [],
-      "source": [
-        "help(acetic_acid)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cc30f661-dc41-4c06-82cc-a4ae762d65e7",
-      "metadata": {
-        "id": "cc30f661-dc41-4c06-82cc-a4ae762d65e7"
-      },
-      "outputs": [],
-      "source": [
-        "# Add an argument to your function to get the total number of atoms in acetic_acid including hydrogens\n",
-        "\n",
-        "x = acetic_acid.GetNumAtoms()                             # This is the method we used in an earlier cell. Note that the parentheses are empty.\n",
-        "\n",
-        "y = acetic_acid.GetNumAtoms()                             # TO DO: To include the hydrogens in the atom count, insert the phrase onlyExplicit = False in the parentheses.\n",
-        "\n",
-        "print(f\"There are {x} heavy atoms in acetic acid and {y} total atoms in acetic acid.\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a47eba18-f0a2-4d59-88c0-b58b1605d9d4",
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 280
-        },
-        "id": "a47eba18-f0a2-4d59-88c0-b58b1605d9d4",
-        "outputId": "8132430b-612c-49ed-e88a-3193f9d949d6"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.alert {\n",
-              "    color: #0056b3;\n",
-              "    background-color: #d9edf7;\n",
-              "    border-left: 5px solid #31708f;\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em;\n",
-              "    line-height: 1.5;\n",
-              "}\n",
-              "div.alert ul {\n",
-              "    margin: 0.5em 0;\n",
-              "}\n",
-              "div.alert li {\n",
-              "    margin-bottom: 0.5em;\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"alert alert-block alert-info\">\n",
-              "    <strong>Questions:</strong>\n",
-              "    <ul>\n",
-              "        <li>How can I use pandas to work with molecules from rdkit?</li>\n",
-              "        <li>How can I visualize relationships between different parts of my data?</li>\n",
-              "   </ul>\n",
-              "\n",
-              "    <strong>Objectives:</strong>\n",
-              "    <ul>\n",
-              "        <li>Review the pandas dataframe</li>\n",
-              "        <li>Learn to visualize structures in a pandas dataframe</li>\n",
-              "        <li>Learn the <i>apply</i> tool for expanding a pandas dataframe</li>\n",
-              "    </ul>\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title Examining and Visualizing Data\n",
-        "%%html\n",
-        "<style>\n",
-        "div.alert {\n",
-        "    color: #0056b3;\n",
-        "    background-color: #d9edf7;\n",
-        "    border-left: 5px solid #31708f;\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em;\n",
-        "    line-height: 1.5;\n",
-        "}\n",
-        "div.alert ul {\n",
-        "    margin: 0.5em 0;\n",
-        "}\n",
-        "div.alert li {\n",
-        "    margin-bottom: 0.5em;\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "    <strong>Questions:</strong>\n",
-        "    <ul>\n",
-        "        <li>How can I use pandas to work with molecules from rdkit?</li>\n",
-        "        <li>How can I visualize relationships between different parts of my data?</li>\n",
-        "   </ul>\n",
-        "\n",
-        "    <strong>Objectives:</strong>\n",
-        "    <ul>\n",
-        "        <li>Review the pandas dataframe</li>\n",
-        "        <li>Learn to visualize structures in a pandas dataframe</li>\n",
-        "        <li>Learn the <i>apply</i> tool for expanding a pandas dataframe</li>\n",
-        "    </ul>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a4cc10b7-5d18-4853-bfac-a2448f722414",
-      "metadata": {
-        "id": "a4cc10b7-5d18-4853-bfac-a2448f722414"
-      },
-      "source": [
-        "[Pandas](https://pandas.pydata.org/docs/) is a Python library used for data analysis and manipulation. Within the world of data science, it is a ubiquitous and widely used library. If you are learning how to analyze data in Python, it will be almost impossible to avoid pandas.\n",
-        "\n",
-        "The central data structure of pandas is called a DataFrame. Pandas DataFrames work very closely with NumPy arrays and Pandas dataframes are specifically for data which is two dimensional (rows and columns). NumPy arrays, while similar in some ways, can work with higher dimensional data.\n",
-        "\n",
-        "Pandas is very powerful. In this session, we'll be learning how to access information in pandas dataframes and how to do some basic manipulation and analysis. We are going to be looking at a dataset which gives information about the elements in the periodic table."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f2e82ae2-4050-4955-a205-5ed86e42cc2b",
-      "metadata": {
-        "id": "f2e82ae2-4050-4955-a205-5ed86e42cc2b"
-      },
-      "outputs": [],
-      "source": [
-        "import pandas as pd                                     # importing the pandas library\n",
-        "\n",
-        "from rdkit.Chem import PandasTools                      # importing rdkit functions to work with pandas\n",
-        "\n",
-        "PandasTools.RenderImagesInAllDataFrames(images=True)    # to display chemical structures in dataframes"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "LzrEG54AKY-W",
-      "metadata": {
-        "id": "LzrEG54AKY-W"
-      },
-      "outputs": [],
-      "source": [
-        "from urllib.request import urlretrieve                  # importing a method that enables retrieval of a text file from a URL\n",
-        "\n",
-        "url = (\"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/paul/data/nsaids.csv\")\n",
-        "\n",
-        "filename = \"nsaids.csv\"\n",
-        "\n",
-        "urlretrieve(url, filename)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "6ed0f50a-7b42-49dc-acc4-f68c4cedc1a6",
-      "metadata": {
-        "id": "6ed0f50a-7b42-49dc-acc4-f68c4cedc1a6"
-      },
-      "source": [
-        "## Loading a collection of small molecules\n",
-        "\n",
-        "In the next few cells, we'll read a text file that lists the SMILES strings for some nonsteroidal antiinflammatory drugs (NSAIDS) and then use them to start building a pandas dataframe. The SMILES strings for the NSAIDS can be found in [nsaids.txt](https://docs.google.com/document/d/1RQeVIFBMeq4SWTrRNfgZXRvaaRNXVknLxgVZfTbJUDs/edit?usp=drive_link).\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6e09ef49-ad83-4f81-a0da-c90c83f02d3b",
-      "metadata": {
-        "id": "6e09ef49-ad83-4f81-a0da-c90c83f02d3b"
-      },
-      "outputs": [],
-      "source": [
-        "nsaids_file = \"nsaids.csv\"\n",
-        "\n",
-        "nsaids_df = pd.read_csv(nsaids_file)\n",
-        "\n",
-        "nsaids_df"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "26a9b6b3-10ff-4594-b660-5b605ac30e2e",
-      "metadata": {
-        "id": "26a9b6b3-10ff-4594-b660-5b605ac30e2e"
-      },
-      "source": [
-        "### The `.apply` method\n",
-        "\n",
-        "The `.apply` method in pandas is used to apply a function along a row or column of a dataframe.\n",
-        "This is useful when you have a custom function that you need to use on every value in a column, but there is not a NumPy or Pandas function for it.\n",
-        "\n",
-        "For example, we could apply the `len` function to our `Name` column to get the number of letters in the name for each element.\n",
-        "\n",
-        "```python\n",
-        "# Number of letters in name -\n",
-        "df[\"Name\"].apply(len)\n",
-        "```\n",
-        "\n",
-        "We are going to use ```apply``` to add a new column to nsaid_df that contains the rdkit molecule for each of the NSAIDs."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fb693a02-58a2-467d-80fa-723d61f62219",
-      "metadata": {
-        "id": "fb693a02-58a2-467d-80fa-723d61f62219"
-      },
-      "outputs": [],
-      "source": [
-        "nsaids_df[\"Molecule\"] = nsaids_df[\"SMILES\"].apply(Chem.MolFromSmiles)\n",
-        "\n",
-        "nsaids_df.head()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "WqeeyIxPiF-7",
-      "metadata": {
-        "id": "WqeeyIxPiF-7"
-      },
-      "source": [
-        "At this point, nsaid_df contains two columns: the SMILES string and the molecule. We will go one step further and use ```apply``` to add another column to the dataframe that contains a descriptor based on the rdkit molecule. Before we can do that we need to import a new sublibrary from rdkit.Chem called Descriptors. Notice that the new columns will be based on the Molecule column, which contains rdkit mol objects."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "v7lK6asEid7Q",
-      "metadata": {
-        "id": "v7lK6asEid7Q"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem import Descriptors\n",
-        "from rdkit.Chem import Lipinski\n",
-        "nsaids_df[\"Mol Wt\"] = nsaids_df[\"Molecule\"].apply(Descriptors.MolWt)\n",
-        "nsaids_df[\"logP\"] = nsaids_df[\"Molecule\"].apply(Descriptors.MolLogP)\n",
-        "nsaids_df[\"HBD\"] = nsaids_df[\"Molecule\"].apply(Lipinski.NHOHCount)            # Number of hydrogen bond donors\n",
-        "nsaids_df[\"HBA\"] = nsaids_df[\"Molecule\"].apply(Lipinski.NOCount)              # Number of hydrogen bond acceptors\n",
-        "nsaids_df.head()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "WLO4ia4B4lXG",
-      "metadata": {
-        "id": "WLO4ia4B4lXG"
-      },
-      "outputs": [],
-      "source": [
-        "nsaids_df.hist(figsize=(8,8), edgecolor='black', grid=False)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "dWKNKdDVkJxn",
-      "metadata": {
-        "id": "dWKNKdDVkJxn"
-      },
-      "outputs": [],
-      "source": [
-        "nsaids_df.plot.bar(x='Name', y='Mol Wt', figsize=(10,5))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "LEfWBGaI5-EJ",
-      "metadata": {
-        "id": "LEfWBGaI5-EJ"
-      },
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.11.11"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7d06a1a8-a729-47c1-973a-3b6afa520f18",
+   "metadata": {
+    "id": "7d06a1a8-a729-47c1-973a-3b6afa520f18"
+   },
+   "source": [
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:325px;\">\n",
+    "</div>\n",
+    "\n",
+    "# Digital Representation of Molecules\n",
+    "\n",
+    "This tutorial was written by Paul Craig (RIT Professor) and Jessica Nash (Software Scientist) for the [Cheminformatic-Driven Molecular Docking Workshop](https://pdb101.rcsb.org/news/67d9853eaddf75595bd158f7) held as a Crash Course with the Institute for Quantitative Biomedicine (IQB) and the Protein Data Bank (PDB).\n",
+    "\n",
+    "*This notebook is Part 1 of 4 in the notebook series.*\n",
+    "\n",
+    "Other notebooks in this series:\n",
+    "1. ***Digital Representation of Molecules*** (This notebook)\n",
+    "2. [Exploring Chemical and Biological Data with BindingDB and the RDKit](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/02_Cheminfo_crash_course.ipynb)\n",
+    "3. [Preparing Structures for Docking](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/03_Cheminfo_crash_course.ipynb)\n",
+    "4. [Molecular Docking using gnina](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/04_Cheminfo_crash_course.ipynb)\n",
+    "\n",
+    "In this notebook, we will learn how to represent chemical structures as SMILES, how to use SMILES to create RDKit mol objects, and how to explore and visualize chemical data using pandas dataframes. This notebook is based on notebooks 01-05 from the [MolSSI Cheminformatics course](https://github.com/MolSSI-Education/molssi-cheminformatics), which was created by Jessica Nash from The Molecular Sciences Software Institute.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "350c2869-274d-4bab-87c9-aa06fbfd9f89",
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 280
+    },
+    "id": "350c2869-274d-4bab-87c9-aa06fbfd9f89",
+    "outputId": "a203ef00-6869-40b8-f001-9e0134469b1d"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.alert {\n",
+       "    color: #0056b3;\n",
+       "    background-color: #d9edf7;\n",
+       "    border-left: 5px solid #31708f;\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em;\n",
+       "    line-height: 1.5;\n",
+       "}\n",
+       "div.alert ul {\n",
+       "    margin: 0.5em 0;\n",
+       "}\n",
+       "div.alert li {\n",
+       "    margin-bottom: 0.5em;\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"alert alert-block alert-info\">\n",
+       "    <strong>Questions:</strong>\n",
+       "    <ul>\n",
+       "        <li>How are molecules represented on computers?</li>\n",
+       "        <li>What is a SMILES?</li>\n",
+       "        <li>What are common molecular file formats?</li>\n",
+       "   </ul>\n",
+       "\n",
+       "    <strong>Objectives:</strong>\n",
+       "    <ul>\n",
+       "        <li>Learn the basics of SMILES.</li>\n",
+       "        <li>Convert molecules from chemical formula and structures to SMILES.</li>\n",
+       "    </ul>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title Overview\n",
+    "%%html\n",
+    "<style>\n",
+    "div.alert {\n",
+    "    color: #0056b3;\n",
+    "    background-color: #d9edf7;\n",
+    "    border-left: 5px solid #31708f;\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em;\n",
+    "    line-height: 1.5;\n",
+    "}\n",
+    "div.alert ul {\n",
+    "    margin: 0.5em 0;\n",
+    "}\n",
+    "div.alert li {\n",
+    "    margin-bottom: 0.5em;\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <strong>Questions:</strong>\n",
+    "    <ul>\n",
+    "        <li>How are molecules represented on computers?</li>\n",
+    "        <li>What is a SMILES?</li>\n",
+    "        <li>What are common molecular file formats?</li>\n",
+    "   </ul>\n",
+    "\n",
+    "    <strong>Objectives:</strong>\n",
+    "    <ul>\n",
+    "        <li>Learn the basics of SMILES.</li>\n",
+    "        <li>Convert molecules from chemical formula and structures to SMILES.</li>\n",
+    "    </ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8eb3cf1-79d9-40f6-a739-92b0ba19539e",
+   "metadata": {
+    "id": "b8eb3cf1-79d9-40f6-a739-92b0ba19539e"
+   },
+   "source": [
+    "## Molecular Representations of Biological Molecules for Computing\n",
+    "\n",
+    "In bioinformatics, if you work with genomics you are accustomed to working with DNA sequences. For example, this is a partial DNA sequence for human dihdydrofolate reductase, an important enzyme in nucelotide metabolism.\n",
+    "\n",
+    "```\n",
+    "GAATTCATGAAAACGTAGCTCGTCCTCAAAAAAAACAGAAGAGGAGTAATCATTTTAAGGGAGAAATATA\n",
+    "TACGAAAGGAACAAGATTTTGAAGCACCCAAGCTGCCACCTACATTAAAACACGGTAGGTGGCTAAACAC\n",
+    "CAGTCTTCAATGCCCTTCCACAGCCTCAGTCTGAAAAATACTGTGCAGGTGACCCAAGTGAGGGGTCACC\n",
+    "CTTGGGCTTTTCCTGTGGCAGTATCTCTGGTTTAAAAACAAACAAACGTACTTATTGCGTTGAAGGACGG\n",
+    "CAACAGGAAGGACTCCATGATTAGTCACATCTATACCATCCTAAGAAACTTTATCCACCCAAACTGTATT\n",
+    "TCAGACTTTATAATCTAAACTACAAAAAGTGTTCACTGGGGAACTGCACAATATGACTGCTTTTAACCGT\n",
+    "```\n",
+    "\n",
+    "The DNA sequence shown here is a simplified representation of a very complex 3D structure that is part of a chromosome, an enormously complex structure. The sequence that represents this gene can be used as a string in coding - computation with strings is orders of magnitude faster than computation with 3D structures. And we can still learn a great deal about this gene simply by exploring the sequence. Likewise we can represent the RNA transcribed from this sequence as a list of characters where T is replaced by U.\n",
+    "\n",
+    "If you study proteins or proteomics, you know that protein function depends on protein structure. Protein structures involve 20 (or more) building blocks so the sequences are more complex, but the principle of representing the protein as a simple string for ease with computing still applies. Here is the sequence of the dihydrofolate reductase protein that is coded in this gene sequence above.\n",
+    "\n",
+    "```\n",
+    "MVGSLNCIVAVSQNMGIGKNGDLPWPPLRNEFRYFQRMTTTSSVEGKQNLVIMGKKTWFSIPEKNRPLKG\n",
+    "RINLVLSRELKEPPQGAHFLSRSLDDALKLTEQPELANKVDMVWIVGGSSVYKEAMNHPGHLKLFVTRIM\n",
+    "QDFESDTFFPEIDLEKYKLLPEYPGVLSDVQEEKGIKYKFEVYEKND\n",
+    "```\n",
+    "\n",
+    "As we move into cheminformatics, we often want to convert small molecule structures, like the aspirin shown here, into strings for computing ease.\n",
+    "\n",
+    "![Aspirin.png](https://drive.google.com/uc?export=view&id=1hcWaacd-pIb09Wi9dceVSQIfkXgWC-vD)\n",
+    "\n",
+    "There are three well-known string conversions for small molecules, SMILES, InChI, and InChI Key. Here are the SMILES, InChI, and InChI Key strings for aspirin.\n",
+    "\n",
+    "SMILES: CC(=O)OC1=CC=CC=C1C(=O)O\n",
+    "\n",
+    "InChI: 1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)\n",
+    "\n",
+    "InChI Key: BSYNRYMUTXBXSQ-UHFFFAOYSA-N\n",
+    "\n",
+    "In this workshop we will use SMILES strings. SMILES syntax is explained below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a20ce5f-0392-40be-a64f-006929d49a5a",
+   "metadata": {
+    "id": "1a20ce5f-0392-40be-a64f-006929d49a5a"
+   },
+   "source": [
+    "## Simplified Molecular-Input Line-entry System: SMILES\n",
+    "\n",
+    "SMILES stands for \"Simplified Molecular-Input Line-Entry System\" and is a way to represent molecules as a string of characters.\n",
+    "\n",
+    "Consider the molecule ethanol. The image below shows a representation that we are used to seeing in chemistry:\n",
+    "\n",
+    "![ethanol](https://drive.google.com/uc?export=view&id=1pBnnNujVdkw43xpDOM27nzICgnn7EqJj)\n",
+    "\n",
+    "However, the SMILES representation of this molecule would be \"CCO\".\n",
+    "\n",
+    "You can read more about SMILES at [this tutorial](https://archive.epa.gov/med/med_archive_03/web/html/smiles.html), but rules for atoms and bonds are also repeated below.\n",
+    "\n",
+    "### Atoms\n",
+    "SMILES supports all elements in the periodic table. An atom is represented using its respective atomic symbol. Upper case letters refer to non-aromatic atoms; lower case letters refer to aromatic atoms. If the atomic symbol has more than one letter the second letter must be lower case.\n",
+    "\n",
+    "### Bonds\n",
+    "```\n",
+    "-\tSingle bond\n",
+    "=\tDouble bond\n",
+    "#\tTriple bond\n",
+    "*\tAromatic bond\n",
+    ".\tDisconnected structures\n",
+    "```\n",
+    "Single bonds are the default and therefore need not be entered. For example, 'CC' would mean that there is a non-aromatic carbon attached to another non-aromatic carbon by a single bond, and the computer would identify the structure as the chemical ethane. It is also assumed that the bond between two lower case atom symbols is aromatic. A blank terminates the SMILES string.\n",
+    "\n",
+    "### Branches\n",
+    "\n",
+    "A branch from a chain is specified by placing the SMILES symbol(s) for the branch between parenthesis. Some examples:\n",
+    "\n",
+    "```\n",
+    "\n",
+    "CC(O)C\t2-Propanol\n",
+    "CC(=O)C\t2-Propanone\n",
+    "```\n",
+    "\n",
+    "### Rings\n",
+    "\n",
+    "A ring is specified by placing a number directly after the SMILES symbol where the ring closure occurs. This number acts as a marker, indicating that the atoms with the same number are connected, thus forming a ring. For instance:\n",
+    "\n",
+    "```\n",
+    "C1CCCC1   cyclopentane\n",
+    "n1ccccc1  Pyridine\n",
+    "```\n",
+    "\n",
+    "### SMILES Examples\n",
+    "\n",
+    "![SMILES Example 1](https://drive.google.com/uc?export=view&id=1-MFSoAGwqOPiqIUD06reOkBPx4BTMhGC)\n",
+    "\n",
+    "![SMILES Example 2](https://drive.google.com/uc?export=view&id=18Ub9L98y8cL_lDLF9wl6pLQxCkt8JFqu)\n",
+    "\n",
+    "### Using Online Resources\n",
+    "Most of the time, you will not need to write a SMILES string by hand. You will be able to look up a molecule's SMILES string from a web database like [PubChem](https://pubchem.ncbi.nlm.nih.gov/).\n",
+    "\n",
+    "You can also use tools like this [molecule sketcher from the Protein Data Bank](https://www.rcsb.org/chemical-sketch)\n",
+    "to draw molecules and get their SMILES strings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "928a5415-2bcb-4ef0-ac8a-1744714d8d3c",
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 370
+    },
+    "id": "928a5415-2bcb-4ef0-ac8a-1744714d8d3c",
+    "outputId": "a789c96a-648e-4d04-fa80-0b303b063a63"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.orange-alert {\n",
+       "    color: #854f00; /* Darker shade of orange for text */\n",
+       "    background-color: #ffe6cc; /* Light orange background */\n",
+       "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.orange-alert ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.orange-alert li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"orange-alert\">\n",
+       "\n",
+       "<strong>Exercise</strong>\n",
+       "<p>\n",
+       "Based on what you've learned about SMILES strings, answer the following questions:\n",
+       "</p>\n",
+       "    <ul>\n",
+       "        <li> What is the SMILES for ethanol?</li>\n",
+       "        <li> What is the SMILES for water?</li>\n",
+       "        <li> What is the SMILES for benzene?</li>\n",
+       "        <li> What molecule is represented by the SMILES O=C=O?</li>\n",
+       "        <li> What is the SMILES for an amide group?<//li>\n",
+       "        <li> What is the SMILES for a 4 membered carbon chain with an amide group on the second carbon?</li>\n",
+       "    </ul>\n",
+       "</p>\n",
+       "<p>Check your answers from this previous exercise using the PDB molecule sketcher. Notice that you can type in a SMILES string and have the sketcher draw the molecule for you.</p>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title Exercise\n",
+    "%%html\n",
+    "<style>\n",
+    "div.orange-alert {\n",
+    "    color: #854f00; /* Darker shade of orange for text */\n",
+    "    background-color: #ffe6cc; /* Light orange background */\n",
+    "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.orange-alert ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.orange-alert li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"orange-alert\">\n",
+    "\n",
+    "<strong>Exercise</strong>\n",
+    "<p>\n",
+    "Based on what you've learned about SMILES strings, answer the following questions:\n",
+    "</p>\n",
+    "    <ul>\n",
+    "        <li> What is the SMILES for ethanol?</li>\n",
+    "        <li> What is the SMILES for water?</li>\n",
+    "        <li> What is the SMILES for benzene?</li>\n",
+    "        <li> What molecule is represented by the SMILES O=C=O?</li>\n",
+    "        <li> What is the SMILES for an amide group?<//li>\n",
+    "        <li> What is the SMILES for a 4 membered carbon chain with an amide group on the second carbon?</li>\n",
+    "    </ul>\n",
+    "</p>\n",
+    "<p>Check your answers from this previous exercise using the PDB molecule sketcher. Notice that you can type in a SMILES string and have the sketcher draw the molecule for you.</p>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6dcdb914-bf20-425d-859c-44c250ca991a",
+   "metadata": {
+    "id": "6dcdb914-bf20-425d-859c-44c250ca991a"
+   },
+   "outputs": [],
+   "source": [
+    "# Fill in your answers here:\n",
+    "# 1.\n",
+    "# 2.\n",
+    "# 3.\n",
+    "# 4.\n",
+    "# 5.\n",
+    "# 6. CC(C(=O)N)CC\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4842145a-676e-4f1f-9b55-8b8296a81301",
+   "metadata": {
+    "id": "4842145a-676e-4f1f-9b55-8b8296a81301"
+   },
+   "source": [
+    "## Molecular File Formats\n",
+    "\n",
+    "Molecules can also be represented using a number of different file formats. As you work more in chemistry, you may see a number of these. Sometimes you will have to pick a file format based on the software you are using or the molecular information you want to save.\n",
+    "\n",
+    "| File Format | Description                                                                 | Features                                                              | Common Uses                              |\n",
+    "|-------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------|------------------------------------------|\n",
+    "| SMILES      | Simplified Molecular Input Line Entry System                                | Line notation for representing molecular structures                   | Database               |\n",
+    "| InChI       | International Chemical Identifier                                           | Textual identifier for chemical substances                            | Databases             |\n",
+    "| MOL/SDF     | MDL MOLfile and Structure-Data File                                         | Contains 2D/3D coordinates, atoms, bonds                              | Structure visualization, cheminformatics |\n",
+    "| PDB         | Protein Data Bank format                                                    | Often used for 3D structures of proteins and nucleic acids,but can also be used for small molecules. Often does not contain molecule information, and cannot store partial charges.                           | Structural biology, bioinformatics       |\n",
+    "| XYZ         | Cartesian coordinates                                                       | Simple text format with atom types and 3D coordinates                 | Computational chemistry, molecular dynamics |     |\n",
+    "| CIF         | Crystallographic Information File                                           | Text file format for representing crystal structure data              | Crystallography                          |\n",
+    "| PQR         | Extended PDB format with partial charges and radii                          | Includes atomic coordinates, partial charges, and radii               | Electrostatics calculations              |\n",
+    "| PDBQT       | PDB format with torsion angles and charges used in AutoDock                 | Includes atomic coordinates, partial charges, torsion angles          | Molecular docking                        |\n",
+    "|MOL2   |Tripos Mol2 format|\tContains atomic coordinates, bonds, molecule types, substructures, and partial charges|\tMolecular modeling, cheminformatics, computational chemistry\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3db21944-72a0-4523-a87d-f702baa98a4b",
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 245
+    },
+    "id": "3db21944-72a0-4523-a87d-f702baa98a4b",
+    "outputId": "ae6a9030-722d-4a69-8804-0729501e2dda"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.alert {\n",
+       "    color: #0056b3;\n",
+       "    background-color: #d9edf7;\n",
+       "    border-left: 5px solid #31708f;\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em;\n",
+       "    line-height: 1.5;\n",
+       "}\n",
+       "div.alert ul {\n",
+       "    margin: 0.5em 0;\n",
+       "}\n",
+       "div.alert li {\n",
+       "    margin-bottom: 0.5em;\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"alert alert-block alert-info\">\n",
+       "    <strong>Questions:</strong>\n",
+       "    <ul>\n",
+       "        <li>What is RDKit?</li>\n",
+       "        <li>What is an RDKit mol object?</li>\n",
+       "        <li>What can I do with RDKit mol objects?</li>\n",
+       "   </ul>\n",
+       "\n",
+       "    <strong>Objectives:</strong>\n",
+       "    <ul>\n",
+       "        <li>Use RDKit to create mol objects in Python.</li>\n",
+       "    </ul>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title Introduction to RDKit Molecules\n",
+    "%%html\n",
+    "<style>\n",
+    "div.alert {\n",
+    "    color: #0056b3;\n",
+    "    background-color: #d9edf7;\n",
+    "    border-left: 5px solid #31708f;\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em;\n",
+    "    line-height: 1.5;\n",
+    "}\n",
+    "div.alert ul {\n",
+    "    margin: 0.5em 0;\n",
+    "}\n",
+    "div.alert li {\n",
+    "    margin-bottom: 0.5em;\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <strong>Questions:</strong>\n",
+    "    <ul>\n",
+    "        <li>What is RDKit?</li>\n",
+    "        <li>What is an RDKit mol object?</li>\n",
+    "        <li>What can I do with RDKit mol objects?</li>\n",
+    "   </ul>\n",
+    "\n",
+    "    <strong>Objectives:</strong>\n",
+    "    <ul>\n",
+    "        <li>Use RDKit to create mol objects in Python.</li>\n",
+    "    </ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "feS3YwAQ4_0A",
+   "metadata": {
+    "id": "feS3YwAQ4_0A"
+   },
+   "source": [
+    "There are Python libraries that are made for working just with chemical data. One commonly\n",
+    "used library in Python for data science (or cheminformatics) is called\n",
+    "[RDKit](https://en.wikipedia.org/wiki/RDKit). RDKit is an open-source cheminformatics\n",
+    "library, primarily developed in C++ and has been under development since the year 2000.\n",
+    "We will be using the Python interface to RDKit, though there are interfaces in other languages.\n",
+    "</p>\n",
+    "\n",
+    "<p>\n",
+    "RDKit provides a molecule object that allows you to manipulate chemical structures. It has\n",
+    "capabilities for reading and writing molecular file formats, calculating molecular properties,\n",
+    "and performing substructure searches. In addition, it offers a wide range of cheminformatics\n",
+    "algorithms such as molecular fingerprint generation, similarity metrics calculation, and\n",
+    "molecular descriptor computation. This notebook introduces RDKit basics, but we will see more\n",
+    "of all of these topics in later notebooks.\n",
+    "</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3949cd4d-3f71-4622-a774-bcf3542a74d8",
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 440
+    },
+    "id": "3949cd4d-3f71-4622-a774-bcf3542a74d8",
+    "outputId": "8171c6b8-ab1c-4a7f-cf27-ace07bac7e75"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.purple-box {\n",
+       "    color: #4b0082; /* Indigo for text */\n",
+       "    background-color: #f3e5f5; /* Light lavender background */\n",
+       "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+       "}\n",
+       "div.purple-box ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.purple-box li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"purple-box\">\n",
+       "    <p>\n",
+       "       Most of this functionality is achieved through the RDKit `mol` object. In Python,\n",
+       "we use the word \"object\" to refer to a variable type with associated data and methods.\n",
+       "One example of an object we have seen in notebooks is a list - we could also call it\n",
+       "a \"list object\". An object has `attributes` (data) and `methods`.\n",
+       "You access information about objects with the syntax\n",
+       "    </p>\n",
+       "<pre>\n",
+       "\n",
+       "object.data\n",
+       "\n",
+       "</pre>\n",
+       "\n",
+       "where data is the attribute name.\n",
+       "\n",
+       "You access object methods with the syntax\n",
+       "\n",
+       "<pre>\n",
+       "\n",
+       "object.method(arguments)\n",
+       "\n",
+       "</pre>\n",
+       "        For example, for a list \"`append` is a method that was covered in the introductory lesson.\n",
+       "<pre>\n",
+       "\n",
+       "my_list = []\n",
+       "my_list.append(1) # \"append\" is a method\n",
+       "\n",
+       "<pre>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title Python Skills - Python Objects\n",
+    "%%html\n",
+    "<style>\n",
+    "div.purple-box {\n",
+    "    color: #4b0082; /* Indigo for text */\n",
+    "    background-color: #f3e5f5; /* Light lavender background */\n",
+    "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+    "}\n",
+    "div.purple-box ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.purple-box li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"purple-box\">\n",
+    "    <p>\n",
+    "       Most of this functionality is achieved through the RDKit `mol` object. In Python,\n",
+    "we use the word \"object\" to refer to a variable type with associated data and methods.\n",
+    "One example of an object we have seen in notebooks is a list - we could also call it\n",
+    "a \"list object\". An object has `attributes` (data) and `methods`.\n",
+    "You access information about objects with the syntax\n",
+    "    </p>\n",
+    "<pre>\n",
+    "\n",
+    "object.data\n",
+    "\n",
+    "</pre>\n",
+    "\n",
+    "where data is the attribute name.\n",
+    "\n",
+    "You access object methods with the syntax\n",
+    "\n",
+    "<pre>\n",
+    "\n",
+    "object.method(arguments)\n",
+    "\n",
+    "</pre>\n",
+    "        For example, for a list \"`append` is a method that was covered in the introductory lesson.\n",
+    "<pre>\n",
+    "\n",
+    "my_list = []\n",
+    "my_list.append(1) # \"append\" is a method\n",
+    "\n",
+    "<pre>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "hwnTxVly5PSN",
+   "metadata": {
+    "id": "hwnTxVly5PSN"
+   },
+   "source": [
+    "In this lesson, we will create and manipulate RDKit `mol` objects. RDKit `mol` objects represent molecules and have\n",
+    "attributes (data) and methods (actions) associated with molecules.\n",
+    "\n",
+    "We are going to use a part of RDKit called `Chem`. To use `Chem`, we first have to install it in our environment, then import it into our notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Xovgh3LcqJA2",
+   "metadata": {
+    "id": "Xovgh3LcqJA2"
+   },
+   "outputs": [],
+   "source": [
+    "from google.colab import output\n",
+    "\n",
+    "output.clear()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c5c13a5-b369-4188-8b13-356445deeb5a",
+   "metadata": {
+    "id": "3c5c13a5-b369-4188-8b13-356445deeb5a"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rdkit\n",
+    "from rdkit import Chem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d84d6c70-fd6e-41bf-81c6-7145d6f87b0e",
+   "metadata": {
+    "id": "d84d6c70-fd6e-41bf-81c6-7145d6f87b0e"
+   },
+   "source": [
+    "## Creating Molecules with RDKit\n",
+    "\n",
+    "Throughout this tutorial, it will be helpful to have access to the [RDKit documentation](https://www.rdkit.org/docs/index.html).\n",
+    "\n",
+    "To get information about molecules in RDKit, we have to first create objects representing molecules. RDKit has a molecule object that can be used to retrieve information or calculate properties. To create a molecule object, we have to communicate the molecule identity in a way that computers understand.\n",
+    "\n",
+    "We will use SMILES strings to create our objects, though RDKit also has methods for creating molecules from the file formats listed in the previous notebook.\n",
+    "\n",
+    "### Creating molecules using SMILES\n",
+    "\n",
+    "In the last lesson, we learned about molecular representations using SMILES strings. Now we will use SMILES strings to create molecule objects in RDKIT.\n",
+    "\n",
+    "We can create a representation of methane using RDKit by using the `MolFromSmiles` function in `rdkit.Chem`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9415ede-7ab5-4a35-89e8-a32d25dfe1b9",
+   "metadata": {
+    "id": "b9415ede-7ab5-4a35-89e8-a32d25dfe1b9"
+   },
+   "outputs": [],
+   "source": [
+    "methane = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Enter the SMILES string for methane between the quote signs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "851ae0d6-b0a2-4474-9402-5db4abf49b1c",
+   "metadata": {
+    "id": "851ae0d6-b0a2-4474-9402-5db4abf49b1c"
+   },
+   "outputs": [],
+   "source": [
+    "methane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c305149-481a-4e52-83bc-a24ab48f45bf",
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 283
+    },
+    "id": "6c305149-481a-4e52-83bc-a24ab48f45bf",
+    "outputId": "15456f3c-aaba-4782-f4c6-d1ce302f5d5a"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.orange-alert {\n",
+       "    color: #854f00; /* Darker shade of orange for text */\n",
+       "    background-color: #ffe6cc; /* Light orange background */\n",
+       "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.orange-alert ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.orange-alert li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"orange-alert\">\n",
+       "\n",
+       "<p> Create RDKit molecules for the following molecules. You can look up the SMILES strings on <a href=\"https://pubchem.ncbi.nlm.nih.gov/\">PubChem</a>:\n",
+       "<p>\n",
+       "    <ul>\n",
+       "        <li> Propane\n",
+       "        <li> Ethene\n",
+       "        <li> Cyclohexane\n",
+       "        <li> Benzene </li>\n",
+       "        <li> Acetic Acid\n",
+       "    </ul>\n",
+       "</p>\n",
+       "<p>Create variables for each molecule. The variable names should be the molecule name (all lowercase)</p>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title Check Your Understanding\n",
+    "%%html\n",
+    "<style>\n",
+    "div.orange-alert {\n",
+    "    color: #854f00; /* Darker shade of orange for text */\n",
+    "    background-color: #ffe6cc; /* Light orange background */\n",
+    "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.orange-alert ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.orange-alert li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"orange-alert\">\n",
+    "\n",
+    "<p> Create RDKit molecules for the following molecules. You can look up the SMILES strings on <a href=\"https://pubchem.ncbi.nlm.nih.gov/\">PubChem</a>:\n",
+    "<p>\n",
+    "    <ul>\n",
+    "        <li> Propane\n",
+    "        <li> Ethene\n",
+    "        <li> Cyclohexane\n",
+    "        <li> Benzene </li>\n",
+    "        <li> Acetic Acid\n",
+    "    </ul>\n",
+    "</p>\n",
+    "<p>Create variables for each molecule. The variable names should be the molecule name (all lowercase)</p>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "497025f0-e60a-42d1-a26e-77db46e5c495",
+   "metadata": {
+    "id": "497025f0-e60a-42d1-a26e-77db46e5c495"
+   },
+   "outputs": [],
+   "source": [
+    "# Your answers go here\n",
+    "propane = Chem.MolFromSmiles(\"\")  # TO DO: Insert the SMILES string for propane: CCC\n",
+    "ethene = Chem.MolFromSmiles(\"\")  # TO DO: Insert the SMILES string for ethene\n",
+    "cyclohexane = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Call the method and insert the SMILES string for cyclohexane\n",
+    "benzene = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Call the method and insert the SMILES string for benzene\n",
+    "acetic_acid = Chem.MolFromSmiles(\"CC(=O)O\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f87d25a4-61b2-437a-a5a6-176a2a45a813",
+   "metadata": {
+    "id": "f87d25a4-61b2-437a-a5a6-176a2a45a813"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here just by typing the name of the variable that refers to the RDKit mol object\n",
+    "acetic_acid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4CzZhBBEGpGV",
+   "metadata": {
+    "id": "4CzZhBBEGpGV"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem.Draw import IPythonConsole as ipc\n",
+    "\n",
+    "# Configuration for displaying in Jupyter notebooks\n",
+    "ipc.ipython_useSVG = True  # Use SVG for higher quality images\n",
+    "ipc.drawOptions.addAtomIndices = True  # Show atom indices\n",
+    "ipc.molSize = 250, 250  # Set size of image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "474fcdab-a904-4c66-8243-5a59de5ebf90",
+   "metadata": {
+    "cellView": "form",
+    "id": "474fcdab-a904-4c66-8243-5a59de5ebf90"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Working with RDKit Molecules\n",
+    "%%html\n",
+    "<style>\n",
+    "div.purple-box {\n",
+    "    color: #4b0082; /* Indigo for text */\n",
+    "    background-color: #f3e5f5; /* Light lavender background */\n",
+    "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+    "}\n",
+    "div.purple-box ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.purple-box li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"purple-box\">\n",
+    "    <p>\n",
+    "RDKit molecule objects have a number of methods we can use to get more information about the molecule. In the next few cells, we'll look at some methods that can tell us some things about the molecules we've created. The next cell has settings for modifying drawing molecules. It adds labels of atom indices and sets the image size\n",
+    "When working with Python objects in the Jupyter notebook, you can\n",
+    "type a variable or object name to see the methods available on that object.\n",
+    "    </p>\n",
+    "    <p>\n",
+    "In the cell below, type\n",
+    "<pre>\n",
+    "  acetic_acid.\n",
+    "\n",
+    "</pre>\n",
+    "\n",
+    "Notice how there is a dot at the end\n",
+    "\n",
+    "    <pre>\n",
+    "      .\n",
+    "    </pre>\n",
+    "\n",
+    "Then press the `tab` key. A list of possible methods and attributes will come up.\n",
+    "\n",
+    "Look through the methods until you find one that gives you the number of atoms in the molecule.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1a331ad-3b4d-44e1-ad51-dc093008dacb",
+   "metadata": {
+    "id": "e1a331ad-3b4d-44e1-ad51-dc093008dacb"
+   },
+   "outputs": [],
+   "source": [
+    "# Pick a method that will tell you the number of atoms acetic acid has.\n",
+    "\n",
+    "x = acetic_acid  # TO DO: enter a . after acetic acid and then scroll down the list to find a method to give you the number of atoms\n",
+    "\n",
+    "print(\"Acetic acid has\", x, \"heavy atoms.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56379e5a-44f0-4272-959d-91f652ba4128",
+   "metadata": {
+    "id": "56379e5a-44f0-4272-959d-91f652ba4128"
+   },
+   "source": [
+    "### Finding help\n",
+    "When you start working with RDKit mol objects, it will be an adjustment. This is a new type of variable and it will take time to adjust. One way to find help is to use a simple help command where the object of the help function is the name of the RDKit mol object. In the next cell, we will use help to learn more about the RDKit mol object, acetic_acid, that we just created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b7d32b7-f531-4a4f-b05e-4c6c51664d50",
+   "metadata": {
+    "id": "1b7d32b7-f531-4a4f-b05e-4c6c51664d50"
+   },
+   "outputs": [],
+   "source": [
+    "help(acetic_acid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc30f661-dc41-4c06-82cc-a4ae762d65e7",
+   "metadata": {
+    "id": "cc30f661-dc41-4c06-82cc-a4ae762d65e7"
+   },
+   "outputs": [],
+   "source": [
+    "# Add an argument to your function to get the total number of atoms in acetic_acid including hydrogens\n",
+    "\n",
+    "x = (\n",
+    "    acetic_acid.GetNumAtoms()\n",
+    ")  # This is the method we used in an earlier cell. Note that the parentheses are empty.\n",
+    "\n",
+    "y = acetic_acid.GetNumAtoms()  # TO DO: To include the hydrogens in the atom count, insert the phrase onlyExplicit = False in the parentheses.\n",
+    "\n",
+    "print(f\"There are {x} heavy atoms in acetic acid and {y} total atoms in acetic acid.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a47eba18-f0a2-4d59-88c0-b58b1605d9d4",
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 280
+    },
+    "id": "a47eba18-f0a2-4d59-88c0-b58b1605d9d4",
+    "outputId": "8132430b-612c-49ed-e88a-3193f9d949d6"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.alert {\n",
+       "    color: #0056b3;\n",
+       "    background-color: #d9edf7;\n",
+       "    border-left: 5px solid #31708f;\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em;\n",
+       "    line-height: 1.5;\n",
+       "}\n",
+       "div.alert ul {\n",
+       "    margin: 0.5em 0;\n",
+       "}\n",
+       "div.alert li {\n",
+       "    margin-bottom: 0.5em;\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"alert alert-block alert-info\">\n",
+       "    <strong>Questions:</strong>\n",
+       "    <ul>\n",
+       "        <li>How can I use pandas to work with molecules from rdkit?</li>\n",
+       "        <li>How can I visualize relationships between different parts of my data?</li>\n",
+       "   </ul>\n",
+       "\n",
+       "    <strong>Objectives:</strong>\n",
+       "    <ul>\n",
+       "        <li>Review the pandas dataframe</li>\n",
+       "        <li>Learn to visualize structures in a pandas dataframe</li>\n",
+       "        <li>Learn the <i>apply</i> tool for expanding a pandas dataframe</li>\n",
+       "    </ul>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title Examining and Visualizing Data\n",
+    "%%html\n",
+    "<style>\n",
+    "div.alert {\n",
+    "    color: #0056b3;\n",
+    "    background-color: #d9edf7;\n",
+    "    border-left: 5px solid #31708f;\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em;\n",
+    "    line-height: 1.5;\n",
+    "}\n",
+    "div.alert ul {\n",
+    "    margin: 0.5em 0;\n",
+    "}\n",
+    "div.alert li {\n",
+    "    margin-bottom: 0.5em;\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <strong>Questions:</strong>\n",
+    "    <ul>\n",
+    "        <li>How can I use pandas to work with molecules from rdkit?</li>\n",
+    "        <li>How can I visualize relationships between different parts of my data?</li>\n",
+    "   </ul>\n",
+    "\n",
+    "    <strong>Objectives:</strong>\n",
+    "    <ul>\n",
+    "        <li>Review the pandas dataframe</li>\n",
+    "        <li>Learn to visualize structures in a pandas dataframe</li>\n",
+    "        <li>Learn the <i>apply</i> tool for expanding a pandas dataframe</li>\n",
+    "    </ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4cc10b7-5d18-4853-bfac-a2448f722414",
+   "metadata": {
+    "id": "a4cc10b7-5d18-4853-bfac-a2448f722414"
+   },
+   "source": [
+    "[Pandas](https://pandas.pydata.org/docs/) is a Python library used for data analysis and manipulation. Within the world of data science, it is a ubiquitous and widely used library. If you are learning how to analyze data in Python, it will be almost impossible to avoid pandas.\n",
+    "\n",
+    "The central data structure of pandas is called a DataFrame. Pandas DataFrames work very closely with NumPy arrays and Pandas dataframes are specifically for data which is two dimensional (rows and columns). NumPy arrays, while similar in some ways, can work with higher dimensional data.\n",
+    "\n",
+    "Pandas is very powerful. In this session, we'll be learning how to access information in pandas dataframes and how to do some basic manipulation and analysis. We are going to be looking at a dataset which gives information about the elements in the periodic table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2e82ae2-4050-4955-a205-5ed86e42cc2b",
+   "metadata": {
+    "id": "f2e82ae2-4050-4955-a205-5ed86e42cc2b"
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd  # importing the pandas library\n",
+    "\n",
+    "from rdkit.Chem import PandasTools  # importing rdkit functions to work with pandas\n",
+    "\n",
+    "PandasTools.RenderImagesInAllDataFrames(\n",
+    "    images=True\n",
+    ")  # to display chemical structures in dataframes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "LzrEG54AKY-W",
+   "metadata": {
+    "id": "LzrEG54AKY-W"
+   },
+   "outputs": [],
+   "source": [
+    "from urllib.request import (\n",
+    "    urlretrieve,\n",
+    ")  # importing a method that enables retrieval of a text file from a URL\n",
+    "\n",
+    "url = \"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/paul/data/nsaids.csv\"\n",
+    "\n",
+    "filename = \"nsaids.csv\"\n",
+    "\n",
+    "urlretrieve(url, filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ed0f50a-7b42-49dc-acc4-f68c4cedc1a6",
+   "metadata": {
+    "id": "6ed0f50a-7b42-49dc-acc4-f68c4cedc1a6"
+   },
+   "source": [
+    "## Loading a collection of small molecules\n",
+    "\n",
+    "In the next few cells, we'll read a text file that lists the SMILES strings for some nonsteroidal antiinflammatory drugs (NSAIDS) and then use them to start building a pandas dataframe. The SMILES strings for the NSAIDS can be found in [nsaids.txt](https://docs.google.com/document/d/1RQeVIFBMeq4SWTrRNfgZXRvaaRNXVknLxgVZfTbJUDs/edit?usp=drive_link).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e09ef49-ad83-4f81-a0da-c90c83f02d3b",
+   "metadata": {
+    "id": "6e09ef49-ad83-4f81-a0da-c90c83f02d3b"
+   },
+   "outputs": [],
+   "source": [
+    "nsaids_file = \"nsaids.csv\"\n",
+    "\n",
+    "nsaids_df = pd.read_csv(nsaids_file)\n",
+    "\n",
+    "nsaids_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26a9b6b3-10ff-4594-b660-5b605ac30e2e",
+   "metadata": {
+    "id": "26a9b6b3-10ff-4594-b660-5b605ac30e2e"
+   },
+   "source": [
+    "### The `.apply` method\n",
+    "\n",
+    "The `.apply` method in pandas is used to apply a function along a row or column of a dataframe.\n",
+    "This is useful when you have a custom function that you need to use on every value in a column, but there is not a NumPy or Pandas function for it.\n",
+    "\n",
+    "For example, we could apply the `len` function to our `Name` column to get the number of letters in the name for each element.\n",
+    "\n",
+    "```python\n",
+    "# Number of letters in name -\n",
+    "df[\"Name\"].apply(len)\n",
+    "```\n",
+    "\n",
+    "We are going to use ```apply``` to add a new column to nsaid_df that contains the rdkit molecule for each of the NSAIDs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb693a02-58a2-467d-80fa-723d61f62219",
+   "metadata": {
+    "id": "fb693a02-58a2-467d-80fa-723d61f62219"
+   },
+   "outputs": [],
+   "source": [
+    "nsaids_df[\"Molecule\"] = nsaids_df[\"SMILES\"].apply(Chem.MolFromSmiles)\n",
+    "\n",
+    "nsaids_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "WqeeyIxPiF-7",
+   "metadata": {
+    "id": "WqeeyIxPiF-7"
+   },
+   "source": [
+    "At this point, nsaid_df contains two columns: the SMILES string and the molecule. We will go one step further and use ```apply``` to add another column to the dataframe that contains a descriptor based on the rdkit molecule. Before we can do that we need to import a new sublibrary from rdkit.Chem called Descriptors. Notice that the new columns will be based on the Molecule column, which contains rdkit mol objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "v7lK6asEid7Q",
+   "metadata": {
+    "id": "v7lK6asEid7Q"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem import Descriptors\n",
+    "from rdkit.Chem import Lipinski\n",
+    "\n",
+    "nsaids_df[\"Mol Wt\"] = nsaids_df[\"Molecule\"].apply(Descriptors.MolWt)\n",
+    "nsaids_df[\"logP\"] = nsaids_df[\"Molecule\"].apply(Descriptors.MolLogP)\n",
+    "nsaids_df[\"HBD\"] = nsaids_df[\"Molecule\"].apply(\n",
+    "    Lipinski.NHOHCount\n",
+    ")  # Number of hydrogen bond donors\n",
+    "nsaids_df[\"HBA\"] = nsaids_df[\"Molecule\"].apply(\n",
+    "    Lipinski.NOCount\n",
+    ")  # Number of hydrogen bond acceptors\n",
+    "nsaids_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "WLO4ia4B4lXG",
+   "metadata": {
+    "id": "WLO4ia4B4lXG"
+   },
+   "outputs": [],
+   "source": [
+    "nsaids_df.hist(figsize=(8, 8), edgecolor=\"black\", grid=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dWKNKdDVkJxn",
+   "metadata": {
+    "id": "dWKNKdDVkJxn"
+   },
+   "outputs": [],
+   "source": [
+    "nsaids_df.plot.bar(x=\"Name\", y=\"Mol Wt\", figsize=(10, 5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "LEfWBGaI5-EJ",
+   "metadata": {
+    "id": "LEfWBGaI5-EJ"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/02_Cheminfo_crash_course.ipynb
+++ b/02_Cheminfo_crash_course.ipynb
@@ -66,7 +66,8 @@
    "source": [
     "%%capture\n",
     "import sys\n",
-    "IN_COLAB = 'google.colab' in sys.modules\n",
+    "\n",
+    "IN_COLAB = \"google.colab\" in sys.modules\n",
     "if IN_COLAB:\n",
     "    !pip install pandas mols2grid seaborn rdkit matplotlib useful_rdkit_utils scikit-learn ipywidgets"
    ]
@@ -129,7 +130,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.read_csv(\"https://raw.githubusercontent.com/PatWalters/practical_cheminformatics_tutorials/refs/heads/main/pdb/monomers_12285.tsv\",sep=\"\\t\")"
+    "df = pd.read_csv(\n",
+    "    \"https://raw.githubusercontent.com/PatWalters/practical_cheminformatics_tutorials/refs/heads/main/pdb/monomers_12285.tsv\",\n",
+    "    sep=\"\\t\",\n",
+    ")"
    ]
   },
   {
@@ -165,8 +169,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.rename(columns={'Ligand SMILES':'SMILES'},inplace=True)\n",
-    "df.rename(columns={'BindingDB Ligand Name':'Name'},inplace=True)"
+    "df.rename(columns={\"Ligand SMILES\": \"SMILES\"}, inplace=True)\n",
+    "df.rename(columns={\"BindingDB Ligand Name\": \"Name\"}, inplace=True)"
    ]
   },
   {
@@ -207,7 +211,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mols2grid.display(df,smiles_col=\"SMILES\",subset=[\"img\",\"IC50 (nM)\"])"
+    "mols2grid.display(df, smiles_col=\"SMILES\", subset=[\"img\", \"IC50 (nM)\"])"
    ]
   },
   {
@@ -245,9 +249,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.set(rc={'figure.figsize': (5,5 )})\n",
-    "sns.set_style('whitegrid')\n",
-    "sns.set_context('notebook')"
+    "sns.set(rc={\"figure.figsize\": (5, 5)})\n",
+    "sns.set_style(\"whitegrid\")\n",
+    "sns.set_context(\"notebook\")"
    ]
   },
   {
@@ -328,7 +332,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[\"activity\"] = pd.cut(df.pIC50,bins=[0,6,7,100],labels=[\"low\",\"med\",\"high\"],right=False)"
+    "df[\"activity\"] = pd.cut(\n",
+    "    df.pIC50, bins=[0, 6, 7, 100], labels=[\"low\", \"med\", \"high\"], right=False\n",
+    ")"
    ]
   },
   {
@@ -338,7 +344,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = sns.histplot(x=\"pIC50\",hue=\"activity\",data=df,bins=np.arange(4,9,0.5))"
+    "ax = sns.histplot(x=\"pIC50\", hue=\"activity\", data=df, bins=np.arange(4, 9, 0.5))"
    ]
   },
   {
@@ -364,7 +370,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['mol'] = df.SMILES.apply(Chem.MolFromSmiles)"
+    "df[\"mol\"] = df.SMILES.apply(Chem.MolFromSmiles)"
    ]
   },
   {
@@ -382,8 +388,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['MW'] = df.mol.apply(uru.MolWt)\n",
-    "df['LogP'] = df.mol.apply(uru.MolLogP)"
+    "df[\"MW\"] = df.mol.apply(uru.MolWt)\n",
+    "df[\"LogP\"] = df.mol.apply(uru.MolLogP)"
    ]
   },
   {
@@ -401,7 +407,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = sns.scatterplot(x=\"MW\",y=\"LogP\",hue=\"activity\",data=df)\n",
+    "ax = sns.scatterplot(x=\"MW\", y=\"LogP\", hue=\"activity\", data=df)\n",
     "sns.move_legend(ax, \"upper left\", bbox_to_anchor=(1, 1))"
    ]
   },
@@ -439,7 +445,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['mol'] = df[\"SMILES\"].apply(Chem.MolFromSmiles)"
+    "df[\"mol\"] = df[\"SMILES\"].apply(Chem.MolFromSmiles)"
    ]
   },
   {
@@ -494,7 +500,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "uru.rd_set_image_size(300,300)\n",
+    "uru.rd_set_image_size(300, 300)\n",
     "df.mol.values[0].GetSubstructMatch(pat)\n",
     "df.mol.values[0]"
    ]
@@ -514,7 +520,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['Scaffold'] = df.mol.apply(GetScaffoldForMol)"
+    "df[\"Scaffold\"] = df.mol.apply(GetScaffoldForMol)"
    ]
   },
   {
@@ -532,7 +538,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['Scaffold_SMILES'] = df.Scaffold.apply(Chem.MolToSmiles)"
+    "df[\"Scaffold_SMILES\"] = df.Scaffold.apply(Chem.MolToSmiles)"
    ]
   },
   {
@@ -550,7 +556,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scaffold_counts_df = uru.value_counts_df(df,\"Scaffold_SMILES\")\n",
+    "scaffold_counts_df = uru.value_counts_df(df, \"Scaffold_SMILES\")\n",
     "scaffold_counts_df.head()"
    ]
   },
@@ -569,8 +575,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mols2grid.display(scaffold_counts_df,smiles_col=\"Scaffold_SMILES\",subset=[\"img\",\"count\"],size=(250,250),\n",
-    "                  n_items_per_page=6)"
+    "mols2grid.display(\n",
+    "    scaffold_counts_df,\n",
+    "    smiles_col=\"Scaffold_SMILES\",\n",
+    "    subset=[\"img\", \"count\"],\n",
+    "    size=(250, 250),\n",
+    "    n_items_per_page=6,\n",
+    ")"
    ]
   },
   {
@@ -588,7 +599,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "uru.value_counts_df(df,\"Scaffold_SMILES\").query(\"count > 5\")"
+    "uru.value_counts_df(df, \"Scaffold_SMILES\").query(\"count > 5\")"
    ]
   },
   {
@@ -616,13 +627,15 @@
    "outputs": [],
    "source": [
     "output_list = []\n",
-    "for k,v in df.groupby('Scaffold_SMILES'):\n",
+    "for k, v in df.groupby(\"Scaffold_SMILES\"):\n",
     "    if len(v) > 5:\n",
     "        mol = Chem.MolFromSmiles(k)\n",
     "        mol_image = uru.mol_to_base64_image(mol)\n",
     "        boxplot_image = uru.boxplot_base64_image(v.pIC50.values)\n",
-    "        output_list.append([mol_image, len(v),boxplot_image])\n",
-    "output_df = pd.DataFrame(output_list,columns=[\"Scaffold\",\"Num Examples\",\"pIC50 Distribution\"])        "
+    "        output_list.append([mol_image, len(v), boxplot_image])\n",
+    "output_df = pd.DataFrame(\n",
+    "    output_list, columns=[\"Scaffold\", \"Num Examples\", \"pIC50 Distribution\"]\n",
+    ")"
    ]
   },
   {
@@ -640,7 +653,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "HTML(output_df.sort_values(\"Num Examples\",ascending=False).to_html(escape=False))"
+    "HTML(output_df.sort_values(\"Num Examples\", ascending=False).to_html(escape=False))"
    ]
   },
   {
@@ -660,7 +673,7 @@
    "outputs": [],
    "source": [
     "smi2fp = uru.Smi2Fp()\n",
-    "df['morgan_fp'] = df.SMILES.apply(smi2fp.get_fp)"
+    "df[\"morgan_fp\"] = df.SMILES.apply(smi2fp.get_fp)"
    ]
   },
   {
@@ -678,7 +691,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['cluster'] = uru.taylor_butina_clustering(df.morgan_fp)"
+    "df[\"cluster\"] = uru.taylor_butina_clustering(df.morgan_fp)"
    ]
   },
   {
@@ -732,7 +745,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "columns_to_keep = [\"SMILES\",\"Name\",\"IC50 (nM)\",\"cluster\"]"
+    "columns_to_keep = [\"SMILES\", \"Name\", \"IC50 (nM)\", \"cluster\"]"
    ]
   },
   {
@@ -768,7 +781,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "unique_cluster_df[columns_to_keep].sort_values(\"cluster\").to_csv(\"US20240293380_examples.csv\",index=False)"
+    "unique_cluster_df[columns_to_keep].sort_values(\"cluster\").to_csv(\n",
+    "    \"US20240293380_examples.csv\", index=False\n",
+    ")"
    ]
   },
   {

--- a/03_Cheminfo_crash_course.ipynb
+++ b/03_Cheminfo_crash_course.ipynb
@@ -1,2993 +1,3062 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/03_Cheminfo_crash_course.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bbS_dv_XZbmq"
-      },
-      "source": [
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:325px;\">\n",
-        "</div>\n",
-        "\n",
-        "# Preparing Molecules and Proteins for Docking\n",
-        "*This tutorial was created by Levi Naden (Software Scientist) at The Molecular Sciences Software Institue for the [Cheminformatic-Driven Molecular Docking Workshop](https://pdb101.rcsb.org/news/67d9853eaddf75595bd158f7) held as a Crash Course with the Institute for Quantitative Biomedicine (IQB) and the Protein Data Bank (RCSB).*\n",
-        "\n",
-        "*Special thanks to Jessica Nash and Pat Walters for code samples and alternate tool suggestions that helped make up this notebook.*\n",
-        "\n",
-        "*This notebook is Part 3 of 4 in the notebook series.*\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 315
-        },
-        "id": "x70dQt37e9o5",
-        "outputId": "d764af9e-c1aa-42fd-a3c1-8f6d4b01051e"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.alert {\n",
-              "    color: #0056b3;\n",
-              "    background-color: #d9edf7;\n",
-              "    border-left: 5px solid #31708f;\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em;\n",
-              "    line-height: 1.5;\n",
-              "}\n",
-              "div.alert ul {\n",
-              "    margin: 0.5em 0;\n",
-              "}\n",
-              "div.alert li {\n",
-              "    margin-bottom: 0.5em;\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"alert alert-block alert-info\">\n",
-              "    <strong>Questions:</strong>\n",
-              "    <ul>\n",
-              "        <li>Why can't we just go from RCSB files to Docking?</li>\n",
-              "        <li>What are the steps to take to ensure the molecule(s) and prtiens are ready?</li>\n",
-              "        <li>What are steps we can optionally perform to get better or more tailored results?</li>\n",
-              "    </ul>\n",
-              "\n",
-              "    <strong>Objectives:</strong>\n",
-              "    <ul>\n",
-              "        <li>Learn about the \"missing\" information in molecular structure files</li>\n",
-              "        <li>Learn how to use a specific set of tools (among many) to prepare your files</li>\n",
-              "        <li>Understand nuance of the programs we work with to modify our preparation workflow</li>\n",
-              "    </ul>\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title Overview\n",
-        "%%html\n",
-        "<style>\n",
-        "div.alert {\n",
-        "    color: #0056b3;\n",
-        "    background-color: #d9edf7;\n",
-        "    border-left: 5px solid #31708f;\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em;\n",
-        "    line-height: 1.5;\n",
-        "}\n",
-        "div.alert ul {\n",
-        "    margin: 0.5em 0;\n",
-        "}\n",
-        "div.alert li {\n",
-        "    margin-bottom: 0.5em;\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "    <strong>Questions:</strong>\n",
-        "    <ul>\n",
-        "        <li>Why can't we just go from RCSB files to Docking?</li>\n",
-        "        <li>What are the steps to take to ensure the molecule(s) and prtiens are ready?</li>\n",
-        "        <li>What are steps we can optionally perform to get better or more tailored results?</li>\n",
-        "    </ul>\n",
-        "\n",
-        "    <strong>Objectives:</strong>\n",
-        "    <ul>\n",
-        "        <li>Learn about the \"missing\" information in molecular structure files</li>\n",
-        "        <li>Learn how to use a specific set of tools (among many) to prepare your files</li>\n",
-        "        <li>Understand nuance of the programs we work with to modify our preparation workflow</li>\n",
-        "    </ul>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "iSUEJHDGfxJY"
-      },
-      "source": [
-        "This notebook will walk you through the process for going from RCSB files crystallographic data to docking-ready input files. The structures from the RCSB, and the corresponding files, are incomplete for the purposes of Docking (and molecular mechanics simulations generally). We'll walk through both the programmatic and visual issues with the protein and molecule files, and explicitly show what data are missing.\n",
-        "\n",
-        "For this notebook, you'll install one particular set of tools for this prep workflow, but many are available and some are linked throughout this lesson.\n",
-        "\n",
-        "\n",
-        "# Set Up\n",
-        "\n",
-        "Before going into any details, we'll be installing all the packages we need for this notebook. Specifically for the actual prep workflow we'll install:\n",
-        "* `PDBFixer`\n",
-        "* `MDAnalysis`\n",
-        "* `RDKit`\n",
-        "* `OpenMM` (and `OpenMMForceFields`)\n",
-        "* `OpenBabel`\n",
-        "* `Scrubber` (package: \"`molscrub`\")\n",
-        "\n",
-        "We'll also install a few helper packages for visualization  and analysis. These are not explicitly needed for the workflow, but will aid in seeing what we are doing."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "CdTmiOgEGyhR"
-      },
-      "outputs": [],
-      "source": [
-        "# Initial setup to enable Conda installable packages through CoLab\n",
-        "!pip install -q condacolab\n",
-        "import condacolab\n",
-        "condacolab.install()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Z8us0ezuJyYY"
-      },
-      "outputs": [],
-      "source": [
-        "# Install our main workflow packages, this should take about a minute\n",
-        "%%capture output\n",
-        "!conda install -c conda-forge rdkit pdbfixer openmm openmmforcefields mdanalysis molscrub"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "G-Kx7_XUmwv0"
-      },
-      "outputs": [],
-      "source": [
-        "# Install OpenBabel into the system as well\n",
-        "# OpenBabel is also available through Conda-Forge and PyPI (pip), but we wanted to show that you need not be limited by where a package comes from, just get it.\n",
-        "%%capture output\n",
-        "!apt install openbabel"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "35pTzMcBKAZO"
-      },
-      "outputs": [],
-      "source": [
-        "# Install our visual renderer for the workbook.\n",
-        "%%capture output\n",
-        "!pip install py3Dmol"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_FgzTMQSIRnp"
-      },
-      "source": [
-        "## Downloading Protein Structure Files\n",
-        "\n",
-        "First and foremost, we need a protein to work with. We're going to look at the [SARS-CoV-2 3CL Protease structure of 7LME from the RCSB](https://www.rcsb.org/structure/7LME).\n",
-        "\n",
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://cdn.rcsb.org/images/structures/7lme_assembly-1.jpeg?raw=true\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
-        "</div>\n",
-        "\n",
-        "Image from RCSB\n",
-        "\n",
-        "We'll start by downloading this using the Python built-in `requests` package to make a `GET` REST request for the file. Effectively, this is our Python interpreter asking the RCSB site for a file directly at a specific location, a URL in this case. You can try this in your browser too! If you download or visit the page: https://files.rcsb.org/download/7LME.pdb, you'll get this exact text file; we're just doing it programmatically.\n",
-        "\n",
-        "For our molecule, we know what ligand is bound to the structure from the RCSB page, `Y6J`, and we'll extract that as part of the process.\n",
-        "\n",
-        "Note: You don't have to know the terminology of HTTP methods such as `GET` for this course, but it's helpful to know REST APIs are how most websites serve their information.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "_ij8X3Z9OqVp"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "import requests\n",
-        "\n",
-        "pdb_id = \"7LME\" # The Protein ID we're looking at\n",
-        "\n",
-        "# Start by making a directory for us to work in and stage our intermediate files\n",
-        "protein_directory = \"docking_files\"\n",
-        "protein_filename = f\"{pdb_id}.pdb\"\n",
-        "protein_filepath = os.path.join(protein_directory, protein_filename)\n",
-        "# Actually make the directory, the exist_ok flag lets the command execute even if the folder already exists. It does NOT overwrite existing data.\n",
-        "os.makedirs(protein_directory, exist_ok=True)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "7ba7-a03nAVY"
-      },
-      "outputs": [],
-      "source": [
-        "# Download the protein file\n",
-        "print(f\"Downloading protein {pdb_id}...\")\n",
-        "protein_url = f\"https://files.rcsb.org/download/{pdb_id}.pdb\"\n",
-        "# Dont break the RCSB!\n",
-        "protein_url = f\"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/main/data/{pdb_id}.pdb\"\n",
-        "# Send the request and save the returned JSON blob as a variable\n",
-        "protein_request = requests.get(protein_url)\n",
-        "protein_request.raise_for_status() # Check for errors"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "5EDsODvVna0R"
-      },
-      "outputs": [],
-      "source": [
-        "# Save the actual text of the returned JSON blob as the PDB file we're used to\n",
-        "with open(protein_filepath, \"w\") as f:\n",
-        "    f.write(protein_request.text)\n",
-        "print(f\"Saved protein to {protein_filepath}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "eT9cjO4MnvTa"
-      },
-      "source": [
-        "## Visualizing the raw PDB File\n",
-        "\n",
-        "We've downloaded our file from the RCSB, let's take a look at what we have and identify some issues for docking."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ktFtsE9HoBTD"
-      },
-      "outputs": [],
-      "source": [
-        "import py3Dmol\n",
-        "v = py3Dmol.view()\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
-        "v.setStyle({'chain':'A'}, {'cartoon': {'color': '#0e9674'}})\n",
-        "v.setStyle({'chain':'B'}, {'cartoon': {'color': '#c46225'}})\n",
-        "v.zoomTo({'model':0})\n",
-        "v.rotate(90, \"z\")\n",
-        "v.rotate(-25, \"y\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "agfLHnkltUf3"
-      },
-      "source": [
-        "The rendered molecule rotation and colors should be approximately  the same as the image from the RCSB's page.\n",
-        "\n",
-        "On its face, it looks good. But let's add a few small changes to how we're doing the rendering to see more."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "rZrdekxU2u4M"
-      },
-      "outputs": [],
-      "source": [
-        "v = py3Dmol.view()\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
-        "v.setStyle({'chain':'A'}, {'cartoon': {'color': '#0e9674'}})\n",
-        "v.setStyle({'chain':'B'}, {'cartoon': {'color': '#c46225'}})\n",
-        "# Selecting HETATM\n",
-        "v.setStyle({'hetflag': True}, {'stick': {'color': 'spectrum'}})\n",
-        "# Selecting objects with no bonds, i.e. water\n",
-        "v.setStyle({\"bonds\": 0},{\"sphere\":{\"radius\":0.5}})\n",
-        "v.zoomTo({'model':0})\n",
-        "v.rotate(90, \"z\")\n",
-        "v.rotate(-25, \"y\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aWcA3mI32vNQ"
-      },
-      "source": [
-        "You can see from the render that py3Dmol is rendering much more than just the dimer and its chains. There is some of this present inside the RCSB image as well, but here we have much more. Before we delve into exactly why we can't just use this for docking, let's cover what we actually need for a docking run:\n",
-        "\n",
-        "* Atomistic level coordinates of receptor (here: protein)\n",
-        "* Connectivity of receptor (*can* be inferred, not always)\n",
-        "* Polar hydrogen and partial charges for receptor\n",
-        "* Where on the receptor we want to dock\n",
-        "* Atomistic level coordinates of ligand (here: small molecule)\n",
-        "* Partial charge and protonation states for ligand\n",
-        "* Descriptor of how atoms interact with each other\n",
-        "\n",
-        "This may seem like a daunting list to compile from just a PDB file, but the software we're using makes many of these steps automatic for us."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 99
-        },
-        "id": "WFny3Wrmj-gS",
-        "outputId": "03fdbb9f-216c-4f2b-c507-98f9f4e69aa2"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.info { /* Based on Bootstrap Secondary Alert */\n",
-              "    color: #0c5460; /* Darker shade of blue for text */\n",
-              "    background-color: #d1ecf1; /* Light blue background */\n",
-              "    border-left: 5px solid #459db9; /* Bright blue border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.info ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.info li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"info\">\n",
-              "\n",
-              "<strong>Note: Not all docking needs all of these items</strong>\n",
-              "\n",
-              "<p>This list is not fully accurate for shape-based docking; this workshop focuses on force/physics/simulation-based docking.\n",
-              "\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title\n",
-        "%%html\n",
-        "<style>\n",
-        "div.info { /* Based on Bootstrap Secondary Alert */\n",
-        "    color: #0c5460; /* Darker shade of blue for text */\n",
-        "    background-color: #d1ecf1; /* Light blue background */\n",
-        "    border-left: 5px solid #459db9; /* Bright blue border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.info ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.info li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"info\">\n",
-        "\n",
-        "<strong>Note: Not all docking needs all of these items</strong>\n",
-        "\n",
-        "<p>This list is not fully accurate for shape-based docking; this workshop focuses on force/physics/simulation-based docking.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_7xLGokmk_eC"
-      },
-      "source": [
-        "## Building Atomistic Receptor Model\n",
-        "\n",
-        "Only looking at the render above, it's not immediately  obvious if we have all the coordinates. One way we can look at this is by checking the PDB file we downloaded. The box below loads the file we pulled down here, but you can use any editor you like to view the file."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "MQFpbLQvApQ5"
-      },
-      "outputs": [],
-      "source": [
-        "from IPython.display import display, HTML\n",
-        "\n",
-        "def render_text(text_blob):\n",
-        "  # Helper function for displaying text in Jupyter Notebooks in a scrollable object\n",
-        "  html = f\"\"\"\n",
-        "      <div style=\"height:400px; overflow:auto;\">\n",
-        "          <pre>{text_blob}</pre>\n",
-        "      </div>\n",
-        "      \"\"\"\n",
-        "  display(HTML(html))\n",
-        "\n",
-        "\n",
-        "render_text(protein_request.text)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3TBTDjyZBsyj"
-      },
-      "source": [
-        "Searching for the word \"missing\" shows at `REMARK` 465 and 470 that there are missing residues and atoms respectively. If we were doing shape-based docking, we might be able to get away with not having those residues if they don't contribute to the docking site, but is that a risk we really want to take? And we're not doing shape-based docking anyways, so we need those residues and atoms.\n",
-        "\n",
-        "For instance, let’s look at the tyrosines in our molecule to show the problem."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "k6KHQ9AOC_MT"
-      },
-      "outputs": [],
-      "source": [
-        "v = py3Dmol.view()\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
-        "v.setStyle()  # Clear all other styles\n",
-        "# Select all tyrosines that are not our problematic one\n",
-        "v.setStyle({'resn': 'TYR', 'not': {'resi': 154}}, {\"stick\": {\"radius\":.1, 'color':'blue'}})\n",
-        "# Missing atoms tyrosine\n",
-        "v.setStyle({'resi': 154}, {\"stick\": {\"radius\":.1, 'color':'red'}})\n",
-        "v.zoomTo({'model':0})\n",
-        "v.rotate(90, \"z\")\n",
-        "v.rotate(-25, \"y\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aBfH4Ls_-Wnu"
-      },
-      "source": [
-        "As you can see, those red residues are not fully atomistic tyrosines. That is something we'll have to fix.\n",
-        "\n",
-        "Beyond just missing and incomplete residues, there are atoms in our PDB file which are simply not the receptor (protein). Specifically the crystallographic waters and the bound ligand in the PDB."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "VhYREiXcuR50"
-      },
-      "outputs": [],
-      "source": [
-        "v = py3Dmol.view()\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
-        "# Select ligand\n",
-        "v.setStyle({'hetflag': True, 'not':{'resname': 'HOH'}}, {'stick': {'color': 'spectrum'}})\n",
-        "# Select waters\n",
-        "v.setStyle({'resn': 'HOH', 'elem': 'O'}, {\"sphere\": {\"radius\":0.5, 'color':'red'}})\n",
-        "v.setStyle({'resn': 'HOH', 'elem': 'H'}, {\"sphere\": {\"radius\":0.5, 'color':'blue'}})\n",
-        "v.zoomTo({'model':0})\n",
-        "v.rotate(90, \"z\")\n",
-        "v.rotate(-25, \"y\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Nolxz_qy_0tz"
-      },
-      "source": [
-        "The rendering above shows that there are two ligands (stick representation) and many crystallographic waters (red dots). We expect there to be two bound ligands here that are roughly in symmetric locations because this is a dimer structure made of two chains.\n",
-        "\n",
-        "Since we're exploring docking of different molecules in the binding sites, we're going to want to remove the currently present ligand so we can test other ones. We're also going to want to remove the crystallographic waters as they usually (not always) contribute to binding and will slow down our docking procedure. We'll also only be picking one of the binding sites (specifically the pocket in \"Chain A\") to reduce computational time.\n",
-        "\n",
-        "## Cleaning the Receptor PDB Structure\n",
-        "\n",
-        "The good news for most of the issues with the receptor structure is its a regular protein with standard residues. We've studied those and can fill in the missing information reliably.\n",
-        "\n",
-        "For this workshop, we're going to be using a tool from the OpenMM Library called `PDBFixer` which is a tool that you can use to \"fix\" PDB files and prepare them for physics-based calculations. There are many other tools which can do these steps for you as well, but we're keeping within the OpenMM ecosystem of tools as an example of a way to approach a docking pipeline.\n",
-        "\n",
-        "Examples of other tools to fix PDB structures are\n",
-        "[Modeller](https://salilab.org/modeller/),\n",
-        "[Amber's LEaP](https://ambermd.org/tutorials/pengfei/), and\n",
-        "[GalaxyFill (which is used by CHARMM-GUI)](https://seoklab.github.io/GalaxyFill/). Others also exist, so find the one that works for you.\n",
-        "\n",
-        "We could have instructed that everyone should just \"run these commands\" since the protein is regular in its construction, but understanding why the commands are needed is important for novel research and issues which may arise in your own works. We'll see this at the end when we jump a bit ahead to look at the impact some of our choice made."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "3m5I1YrlCSfs"
-      },
-      "outputs": [],
-      "source": [
-        "# Load the PDB into the PDBFixer class\n",
-        "from pdbfixer import PDBFixer\n",
-        "fixer = PDBFixer(filename=f\"{protein_directory}/{pdb_id}.pdb\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "W98orn1xDrsf"
-      },
-      "source": [
-        "Next we're going to solve the missing residues problem through the `findMissingResidues` method. This doesn't actually do anything to the structure, yet, its just compiling a list of atoms and coordinates on each chain that it *will* add when we call the corresponding command. That way, the user has the option to customize what is \"fixed\" on the protein."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "JU3b0NmiEV-z"
-      },
-      "outputs": [],
-      "source": [
-        "fixer.findMissingResidues()\n",
-        "fixer.missingResidues"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "LP-xn3keEfy1"
-      },
-      "source": [
-        "You can see that our list of missing residues matches the one in the `REMARK` section of the base PDB file.\n",
-        "\n",
-        "Next we're going to identify any non-standard residues in our structure as well as provide suggested replacements. We'll also be issuing the command to make the suggested substitutions. You can customize what is substituted by modifying the `nonstandardResidues` attribute, or do mutations with `applyMutations`. Neither are required for this structure, but helpful to have in your pipeline as this can allow you to substitute residues."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "B0pQgiFcFPdA"
-      },
-      "outputs": [],
-      "source": [
-        "fixer.findNonstandardResidues()\n",
-        "print(fixer.nonstandardResidues)\n",
-        "fixer.replaceNonstandardResidues()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "LomqlRQsGIm9"
-      },
-      "source": [
-        "Next, we'll strip out all of the crystallographic waters and the ligands from our structure by telling `PDBFixer` to remove the \"heterogen\" atoms. We'll also see a list of things which have been removed from the structure. You may notice that `PDBFixer` notes a Chain 2, 3, and 4 instead of Chain A, B as present in the PDB file. That is because `PDBFixer` distinguishes \"chains\" as atom groupings for bookkeeping purposes, but correctly will reassemble them in the topology at the end."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "yHgA0apSGUF6"
-      },
-      "outputs": [],
-      "source": [
-        "fixer.removeHeterogens(keepWater=False)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HiQZUSnkHp5R"
-      },
-      "source": [
-        "We took care of the missing residues, but that doesn't account for existing residues with missing atoms. The next step is adding the missing heavy atoms of our protein from the residues already present. This command will also identify missing terminals and add those as well. In theory, we could have done this before removing the water and ligands, but because this command can actually add in the missing terminals (if needed), we recommend removing waters first so there is less chance of steric clashes with the addition of an C/N-terminal from free-standing waters."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "o2Z3JMppH1mn"
-      },
-      "outputs": [],
-      "source": [
-        "fixer.findMissingAtoms()\n",
-        "print(fixer.missingAtoms)\n",
-        "print(fixer.missingTerminals)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "X_e5gsnnIAdX"
-      },
-      "source": [
-        "Now we can fix our missing heavy atoms (hydrogens are more complicated) with one command. This will take care of both missing and incomplete residues because we collected them all earlier with `findMissingResidues` and `findMissingAtoms`. This step takes a small amount of time because there is an energy minimization step going on behind the scenes to reduce steric clashes from injecting new atoms into our structure."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "3aQjOpMBIGxg"
-      },
-      "outputs": [],
-      "source": [
-        "fixer.addMissingAtoms()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7ln1_Be_KVg5"
-      },
-      "source": [
-        "Let's write out our PDB file and see what it looks like"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "QD7I2UylKUcX"
-      },
-      "outputs": [],
-      "source": [
-        "from openmm.app import PDBFile\n",
-        "with open(f\"{protein_directory}/{pdb_id}_fix_heavy.pdb\", 'w') as f:\n",
-        "  # Toplology, Positions, file stream, and keep chain ID's\n",
-        "  PDBFile.writeFile(fixer.topology, fixer.positions, f, True)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "sCCkIi_jO_bm"
-      },
-      "outputs": [],
-      "source": [
-        "# Property to get a topology object, works well as a quick summary of structure.\n",
-        "fixer.topology"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qxWh-dxxLCr9"
-      },
-      "outputs": [],
-      "source": [
-        "v = py3Dmol.view()\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}_fix_heavy.pdb\").read())\n",
-        "v.setStyle({'chain':'A'}, {'cartoon': {'color': '#0e9674'}})\n",
-        "v.setStyle({'chain':'B'}, {'cartoon': {'color': '#c46225'}})\n",
-        "# Check for ligand\n",
-        "v.setStyle({'hetflag': True, 'not':{'resname': 'HOH'}}, {'stick': {'color': 'spectrum'}})\n",
-        "# Check for water\n",
-        "v.setStyle({'resn': 'HOH', 'elem': 'O'}, {\"sphere\": {\"radius\":0.5, 'color':'red'}})\n",
-        "v.setStyle({'resn': 'HOH', 'elem': 'H'}, {\"sphere\": {\"radius\":0.5, 'color':'blue'}})\n",
-        "# Look at our problematic tyrosines again to see they are all-atom finally\n",
-        "v.setStyle({'resi': 154}, {\"stick\": {\"radius\":.2, 'color':'red'}})\n",
-        "v.zoomTo({'model':0})\n",
-        "v.rotate(90, \"z\")\n",
-        "v.rotate(-25, \"y\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VkqXlQOmJkse"
-      },
-      "source": [
-        "What we can see is that all the atoms we wanted are gone, all the atoms we added are present, and we have our protein structure of heavy atoms. We'll now deal with the fact that the hydrogens are all still missing as we need those for our physics-based docking.\n",
-        "\n",
-        "More specifically, we need the correct protonation states for a given pH on our residues. If you're working with a united atom or more generally coarse-grained model, you technically don't need to have atomistic hydrogens. However, we're working with a fully atomistic model, so we'll be including them.\n",
-        "\n",
-        "`PDBFixer` takes in pH information and optionally an atomic Force Field to add its hydrogens. If no force field is provided, it will assume positions that are generally reasonable, but not optimized. It should also be noted that no extensive electrostatic analysis is performed here, assuming default residue pKa's. For this example, we'll be pulling positions from the [Amber ff14SB](https://pubs.acs.org/doi/10.1021/acs.jctc.5b00255) force field natively available to OpenMM."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Qiu22MrmN44_"
-      },
-      "outputs": [],
-      "source": [
-        "# Import the ForceField object to access built-ins (or custom if you have them)\n",
-        "from openmm.app import ForceField\n",
-        "# Use the Amber ff14SB Force Field. This path is relative to OpenMM's internal\n",
-        "# references, not the local directory.\n",
-        "forcefield = ForceField(\"amber/protein.ff14SB.xml\")\n",
-        "# also accepts a \"pH\" argument, default is pH=7.0\n",
-        "fixer.addMissingHydrogens(forcefield=forcefield)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jrmZyhi8bLst"
-      },
-      "source": [
-        "Note that we didn't specify a pH here, so the default of 7.0 is assumed. The expierment for the 7LME structure was done at a pH of 7.5. Does this matter for our result? \"Maybe.\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "1nK1Js3yOohT"
-      },
-      "outputs": [],
-      "source": [
-        "with open(f\"{protein_directory}/{pdb_id}_all_atom.pdb\", 'w') as f:\n",
-        "  # Toplology, Positions, file stream, and keep chain ID's\n",
-        "  PDBFile.writeFile(fixer.topology, fixer.positions, f, True)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "v0CvkE8vOvbB"
-      },
-      "outputs": [],
-      "source": [
-        "v = py3Dmol.view()\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}_all_atom.pdb\").read())\n",
-        "v.setStyle({'chain':'A'}, {'cartoon': {'color': '#0e9674'}})\n",
-        "v.setStyle({'chain':'B'}, {'cartoon': {'color': '#c46225'}})\n",
-        "v.zoomTo({'model':0})\n",
-        "v.rotate(90, \"z\")\n",
-        "v.rotate(-25, \"y\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "TT_GKvNfG-UB"
-      },
-      "outputs": [],
-      "source": [
-        "fixer.topology"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "N5cSIUVaPqcf"
-      },
-      "source": [
-        "By re-building our protein file with this pipeline, we've also taken care of the connectivity and the partial charges of the hydrogens on our receptor.\n",
-        "\n",
-        "### Additional Considerations for our Receptor Structure\n",
-        "\n",
-        "Because we're doing physics-based docking; we need to take into account the physics we are attempting to understand with respect to not only what we've done to our receptor, but also what methods and algorithms we're going to be subjecting to it.\n",
-        "\n",
-        "Let us first look ahead to figure out what program we're going to run for docking. We'll be using a program called [`gnina`](https://github.com/gnina/gnina) which is based on [smina](https://sourceforge.net/projects/smina/), which itself is based on [AutoDock Vina](https://github.com/ccsb-scripps/AutoDock-Vina), which itself uses a type of [Iterated Local Search](https://pmc.ncbi.nlm.nih.gov/articles/PMC3041641/) optimizer. For our purposes, all of that means we're only going to need the polar hydrogens on our receptor. The rest of the hydrogens can be ignored... or can they?\n",
-        "\n",
-        "Depending on the program(s) you chose, the behavior of your calculations may change even with the same input. `gnina`, the program we're using, assumes any hydrogens present on the input file we're going to generate here are polar hydrogens and uses them for calculations, it won't check first for us with how we're making our files. The instructors looked ahead and found if you leave all the hydrogens on your receptor, you get less accurate results for the reason that they're all treated as polar. Other codes may check this for you and simply remove or disable the non-polar hydrogens."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 158
-        },
-        "id": "BnhqwY97UPpT",
-        "outputId": "76b1a2e0-469e-4d38-cfaf-342d68df8cb3"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.warning { /* Based on Bootstrap Warning */\n",
-              "    color: #856404; /* Darker shade of yellow-brown for text */\n",
-              "    background-color: #fff3cd; /* Light faded yellow background */\n",
-              "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.info ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.info li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"warning\">\n",
-              "\n",
-              "<strong>Important: Understand your methods and software!</strong>\n",
-              "\n",
-              "<p>We're going to show actions you can do to modify your structure as examples.\n",
-              "<p> Most of this remaining section uses ideas and methods which themselves are based in physics and can make intuitive sense, but\n",
-              "  make this particular system less accurate when we dock with Gnina.\n",
-              "\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title\n",
-        "\n",
-        "%%html\n",
-        "<style>\n",
-        "div.warning { /* Based on Bootstrap Warning */\n",
-        "    color: #856404; /* Darker shade of yellow-brown for text */\n",
-        "    background-color: #fff3cd; /* Light faded yellow background */\n",
-        "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.info ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.info li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"warning\">\n",
-        "\n",
-        "<strong>Important: Understand your methods and software!</strong>\n",
-        "\n",
-        "<p>We're going to show actions you can do to modify your structure as examples.\n",
-        "<p> Most of this remaining section uses ideas and methods which themselves are based in physics and can make intuitive sense, but\n",
-        "  make this particular system less accurate when we dock with Gnina.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "eVbE2g8PV0yV"
-      },
-      "source": [
-        "## Relaxing the Receptor Structure with Hydrogens Present"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 61
-        },
-        "id": "3TPbk1pPV1HR",
-        "outputId": "736e8592-01b5-467c-918d-5e345caf00d7"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.warning { /* Based on Bootstrap Warning */\n",
-              "    color: #856404; /* Darker shade of yellow-brown for text */\n",
-              "    background-color: #fff3cd; /* Light faded yellow background */\n",
-              "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.info ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.info li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"warning\">\n",
-              "\n",
-              "<strong>Reminder: Additional energy minimization makes our current system worse for docking.</strong>\n",
-              "\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title\n",
-        "%%html\n",
-        "<style>\n",
-        "div.warning { /* Based on Bootstrap Warning */\n",
-        "    color: #856404; /* Darker shade of yellow-brown for text */\n",
-        "    background-color: #fff3cd; /* Light faded yellow background */\n",
-        "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.info ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.info li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"warning\">\n",
-        "\n",
-        "<strong>Reminder: Additional energy minimization makes our current system worse for docking.</strong>\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FDBPHZBQTm3s"
-      },
-      "source": [
-        "We have added new atoms to our structure based on their predictable location as standard residues, specifically the hydrogens. However, standard residues or not, the atoms we added may still cause large steric and electrostatic clashes that we want to relax before docking.\n",
-        "\n",
-        "There was a short minimization which took place when we ran the `addMissingAtoms` commands, but that was only with the heavy atoms and only on the pairwise interactions the atoms which were added vs atoms which were already present (i.e. nonbonded interactions between unmodified atoms were ignored for speed, something you only know when [looking at the source code](https://github.com/openmm/pdbfixer/blob/master/pdbfixer/pdbfixer.py#L1277-L1279)). This process effectively minimized the impact removing the crystallographic waters and the ligand had- as well as the addition of hydrogens had on the structure of the protein."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 158
-        },
-        "id": "Oypyds6OYYFe",
-        "outputId": "c5ec4fad-8502-415a-af21-6dc4566705a2"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.info { /* Based on Bootstrap Secondary Alert */\n",
-              "    color: #0c5460; /* Darker shade of blue for text */\n",
-              "    background-color: #d1ecf1; /* Light blue background */\n",
-              "    border-left: 5px solid #459db9; /* Bright blue border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.info ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.info li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"info\">\n",
-              "\n",
-              "<strong>Do neglecting those changes we made impact the structure and docking? Maybe!</strong>\n",
-              "\n",
-              "<p>Each system is different and many papers have been written about each of the\n",
-              "  steps we've done and will do and their potential impact.\n",
-              "<p> Take our current protein as a specific example. Consider how the protein structure was found and at what temperature it was generated.\n",
-              "  The 7LME structure we're crystalized by <a href=\"https://www.rcsb.org/experimental/7LME\">room temperature droplets for X-ray diffraction</a>; however, other structures may have been found via Cryo-EM and be generated at different temperatures.\n",
-              "\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title\n",
-        "%%html\n",
-        "<style>\n",
-        "div.info { /* Based on Bootstrap Secondary Alert */\n",
-        "    color: #0c5460; /* Darker shade of blue for text */\n",
-        "    background-color: #d1ecf1; /* Light blue background */\n",
-        "    border-left: 5px solid #459db9; /* Bright blue border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.info ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.info li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"info\">\n",
-        "\n",
-        "<strong>Do neglecting those changes we made impact the structure and docking? Maybe!</strong>\n",
-        "\n",
-        "<p>Each system is different and many papers have been written about each of the\n",
-        "  steps we've done and will do and their potential impact.\n",
-        "<p> Take our current protein as a specific example. Consider how the protein structure was found and at what temperature it was generated.\n",
-        "  The 7LME structure we're crystalized by <a href=\"https://www.rcsb.org/experimental/7LME\">room temperature droplets for X-ray diffraction</a>; however, other structures may have been found via Cryo-EM and be generated at different temperatures.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NAUNyY1RYYMj"
-      },
-      "source": [
-        "Let's assume we actually do want a fully relaxed structure. If we were to do another energy minimization now, the binding sites would likely start to collapse due to the removal of the ligand. This would most likely be observed if we were to run an equilibration dynamics simulation to a much more extreme degree. We do wish to have some preservation of the binding site's in our minimization so we can dock new ligands in place.\n",
-        "\n",
-        "An alternate option would be to re-insert the ligand, do an energy minimization, and then run a short dynamics simulation to generate a structure from the equilibrium distribution at the conditions you're interested in. This is often something you'll need to do if you don't have a starting crystal structure! However, molecular mechanics/dynamics are beyond the scope of this course, even if we'll be taking similar initial steps.\n",
-        "\n",
-        "Did the addition of the hydrogens and the removal of the waters matter here? \"Maybe.\" Could we skip this step entirely? \"Maybe.\" It's important to understand the protein and the site you're working with on a case-by-case basis to accurately answer these questions. You can always just try and see what happens! We happen to know the answer is \"yes, we can skip it\" for our current problem, but that's not always the case."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qeIoAyFUfNMU"
-      },
-      "source": [
-        "#### Simple Energy Minimization\n",
-        "\n",
-        "Energy minimizations of structures generally don't perturb the structure all that much when we're looking at before and after coordinates. If you consider the [Lennard-Jones](https://en.wikipedia.org/wiki/Lennard-Jones_potential) + point-charge potential that many classical molecular mechanics codes use for their pairwise potentials, steric clashes (and even electrostatic ones) are dominated by a $1/r^{12}$ scaling energy term at short ranges. Although the interactions are more complicated than this, energy minimization algorithms primarily help minimize that term, so the binding site *might* be minimally perturbed by a simple minimization. Even when we set-up a more complex minimization later, we'll still end with these basic steps.\n",
-        "\n",
-        "We'll perform a simple minimization with OpenMM while also exploring a bit about how OpenMM defines molecular environments for dynamics. Every program will be different, and as we've alluded to, knowing your programs are important for accurate scientific results. To setup this minimization, we'll first define a minimal simulation environment with OpenMM.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "t6KDtkQnhpjJ"
-      },
-      "outputs": [],
-      "source": [
-        "# Create OpenMM system for minimization\n",
-        "system = forcefield.createSystem(fixer.topology)\n",
-        "\n",
-        "# Show our forces as OpenMM understands them\n",
-        "system.getForces()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gYBMP4Wrhtu0"
-      },
-      "source": [
-        "OpenMM defines its `System` object as the collection of `Forces` which act on a set of mass-bearing particles in a molecular \"system.\" That is, neither the positions nor the time evolution of these forces, but instead just the collection of interactions. The concept of bonds, chains, residue names, and all the information in the PDB has been converted into a base 0-indexed list of generic particles in the `System`.\n",
-        "\n",
-        "We can take the molecular `System` in combination with an `Integrator` to say how the `Forces` should propagate to define our `Simulation`. For that, we will need an integrator to satisfy OpenMM, even though its logic is not used for the energy minimization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "XzrLs3EAi_J6"
-      },
-      "outputs": [],
-      "source": [
-        "from openmm import VerletIntegrator\n",
-        "from openmm.app import Simulation\n",
-        "import openmm.unit as unit\n",
-        "\n",
-        "# Use a generic VerletIntegrator\n",
-        "integrator = VerletIntegrator(0.001 * unit.picoseconds)\n",
-        "\n",
-        "# Create simulation for minimization\n",
-        "# Optional, if you have access to a CUDA GPU, comment out the next line and uncomment the one after it\n",
-        "platform = None\n",
-        "# platform = Platform.getPlatformByName('CUDA')\n",
-        "\n",
-        "# Define the OpenMM Simulation object, which serves as a convenince wrapper for the OpenMM Context and Reporter objects\n",
-        "simulation = Simulation(fixer.topology, system, integrator, platform)\n",
-        "# Set the position of our atoms\n",
-        "simulation.context.setPositions(fixer.positions)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8NbMONjujKzB"
-      },
-      "source": [
-        "A small peak under the hood: The data `System` have been fed into the `Context` class constructor along with the `Integrator` which the `Simulation` class wraps around. The `System` is then compiled into a platform-specific implementation (CPU, CUDA, OpenCL) and bound to the `Integrator`. The `Integrator` is the class used to step forward in time, the `System` is decoupled, and the `Context` could be used entirely without a `Simulation` object.\n",
-        "\n",
-        "We have now set up a simulation-ready object, so we can now do our minimzation which will update the positions. This step will take a small amount of time.\n",
-        "\n",
-        "OpenMM did most of these steps for us when we ran `addMissingAtoms` earlier, it just had extra logic for only minimizing new atom positions rather than all atom positions."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "L_C8iZ3CkmPP"
-      },
-      "outputs": [],
-      "source": [
-        "# Minimize energy\n",
-        "print('Minimizing energy...')\n",
-        "simulation.minimizeEnergy()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aYkDM7tfkqH_"
-      },
-      "source": [
-        "Up until now, we've also done similar steps if we wanted to take our molecular system and run dynamics on it. We would need enough atoms to define our system (all-atom here), and then a minimized structure under some physical conditions. Because we are using the leap-frog Verlet Integrator which has no temperature coupling (like a Langevin Integrator), and because we have no pressure coupling (which OpenMM uses a Monte Carlo Barostat `Force` to scale box vectors), we would be running a constant number of particles, volume, energy simulation (NVE) if we were to propagate time. It would be a 1 fs timestep, which may take a while to sample enough configurations to run statistics, but it would run.\n",
-        "\n",
-        "For now, let's leave the world of molecular dynamics and get back to docking by getting our minimized coordinates out of the RAM of the compute hardware to save."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "WmjyS2NzkxOP"
-      },
-      "outputs": [],
-      "source": [
-        "# Get minimized positions. We have to copy the positions of the compiled object back into Python's memory\n",
-        "minimized_positions = simulation.context.getState(getPositions=True).getPositions()\n",
-        "\n",
-        "# Write minimized structure to a PDB file\n",
-        "with open(f\"{protein_directory}/{pdb_id}_fixed.pdb\", 'w') as output:\n",
-        "    PDBFile.writeFile(fixer.topology, minimized_positions, output)\n",
-        "\n",
-        "print(f'Minimization complete. Minimized structure saved to {protein_directory}/{pdb_id}_fixed_simple.pdb')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "We also may want to actually look at our binding site at some point, so let's define some helper objects to select the residues around the binding site with MDAnalysis"
-      ],
-      "metadata": {
-        "id": "icYnXoCWl0hI"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Determine residues nearby the ligand with MDAnalysis\n",
-        "import MDAnalysis as mda\n",
-        "\n",
-        "# Load the original PDB\n",
-        "u = mda.Universe(f\"{protein_directory}/{pdb_id}.pdb\")\n",
-        "\n",
-        "# Select atoms using the MDAnalysis selection language\n",
-        "ligand_select = \"segid A and record_type HETATM and not resname HOH\"\n",
-        "ligand = u.select_atoms(ligand_select)\n",
-        "\n",
-        "# Find and residues within a certain distance from the ligand\n",
-        "active_site = u.select_atoms(f\"around 3.5 group ligand and segid A\",\n",
-        "                             periodic=False,\n",
-        "                             ligand=ligand)  # Uses generic select_name=object as kwargs\n",
-        "print(active_site.residues.resids)\n",
-        "print(ligand.residues.resids)"
-      ],
-      "metadata": {
-        "id": "_xdsRn1el9jP"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "38zdzUtRxR8_"
-      },
-      "source": [
-        "#### Restrained Minimzation"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 99
-        },
-        "id": "GQke3jnNwxQc",
-        "outputId": "619d7426-ae9b-49ac-e32e-27c06d298a88"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.warning { /* Based on Bootstrap Warning */\n",
-              "    color: #856404; /* Darker shade of yellow-brown for text */\n",
-              "    background-color: #fff3cd; /* Light faded yellow background */\n",
-              "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.info ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.info li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"warning\">\n",
-              "\n",
-              "<strong>This section is skipped in the online workshop for time and complexity.</strong>\n",
-              "<p> However, this is a powerful tool in OpenMM and for dynamics generally.\n",
-              "\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title\n",
-        "%%html\n",
-        "<style>\n",
-        "div.warning { /* Based on Bootstrap Warning */\n",
-        "    color: #856404; /* Darker shade of yellow-brown for text */\n",
-        "    background-color: #fff3cd; /* Light faded yellow background */\n",
-        "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.info ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.info li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"warning\">\n",
-        "\n",
-        "<strong>This section is skipped in the online workshop for time and complexity.</strong>\n",
-        "<p> However, this is a powerful tool in OpenMM and for dynamics generally.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bA8-EeeWfFqT"
-      },
-      "source": [
-        "Sometimes, we may want to run a minimization or dynamics in a way where certain regions may want to be preserved. One way to do that is to restrain the binding site to a certain shape.\n",
-        "\n",
-        "To help preserve our binding site, we're going to select the residues near the original ligand and restrain the heavy atoms with a spherical harmonic restraint around their coordinates. We'll be applying a bit of a simple approach by looking at the residues within a certain distance from the ligand in one chain. Remember: we're not looking for a perfect structure, just one that doesn't have steric clashes which will cause problems for docking. `PDBFixer` can't do this for us, so we either need to measure the distances ourselves and pick out the residues with vector math, or we can use other tools like `MDAnalysis`, [ProLIF](https://prolif.readthedocs.io/en/stable/), and others."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "LArGO6gn0lgd"
-      },
-      "source": [
-        "Using list of residues around our binding site, we can visualize the binding site. In this rendering, we're only showing the residues near the ligand and the ligand itself. The colors on the surface are just for visual distinction and do not indicate any electronegativity."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "z5OQfeoof-A_"
-      },
-      "outputs": [],
-      "source": [
-        "v = py3Dmol.view()\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
-        "v.setStyle()\n",
-        "v.setStyle({'resi':ligand.residues.resids.tolist(), \"chain\": \"A\"}, {'stick': {'color': 'spectrum'}})\n",
-        "v.addSurface(\"VDW\", {'opacity':0.5}, {'resi':active_site.residues.resids.tolist(), \"chain\":\"A\"})\n",
-        "v.zoomTo({'chain':\"A\"})\n",
-        "v.rotate(90, \"z\")\n",
-        "v.rotate(-25, \"y\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gm0PjLYmmIkt"
-      },
-      "source": [
-        "We've now picked out our ligand and the nearby residues we want to select from. Now we want to perform a small energy minimization procedure with OpenMM while keeping the heavy atoms restrained in spherical harmonic shells to keep the binding site open. To setup this modified minimization, we'll first define a new simulation environment with OpenMM. We could have re-used the system we previously made, but to keep things separate we'll make a new one."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "eoC4HPtTm51g"
-      },
-      "outputs": [],
-      "source": [
-        "# Create OpenMM system for minimization\n",
-        "system_restrain = forcefield.createSystem(fixer.topology)\n",
-        "\n",
-        "# Show our forces\n",
-        "system_restrain.getForces()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Erc0gQI-nZ7O"
-      },
-      "source": [
-        "This is so far identical to our original system.\n",
-        "\n",
-        "We're now going to create a new force by defining a `Force` object with OpenMM, specifically the `CustomExternalForce`. OpenMM's `Custom*Force` objects allow us to write potential energy strings which can be added to any `System` and subsequent simulation and behave as a force just like nonbonded, bonded, and other forces. We'll be borrowing from [the OpenMM Cookbook](https://openmm.github.io/openmm-cookbook/latest/notebooks/cookbook/Restraining%20Atom%20Positions.html) for this step, so feel free to look their for additional information."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "EXu2QbN4pX0y"
-      },
-      "outputs": [],
-      "source": [
-        "from openmm import CustomExternalForce\n",
-        "import openmm.unit as unit\n",
-        "\n",
-        "# Define the external force for our particles using a string\n",
-        "# This one is a simple spring harmonic force\n",
-        "# Uses built-in function for handling harmonics over periodic distances\n",
-        "restraint = CustomExternalForce('k*periodicdistance(x, y, z, x0, y0, z0)^2')\n",
-        "# Add the force to our system.\n",
-        "# WARNING: If you run this cell again, it will add this force, again, and double up its effect\n",
-        "system_restrain.addForce(restraint)\n",
-        "# Define what the custom per-particle and global parameters are\n",
-        "# This can be done before or after adding the force to the System because\n",
-        "# the Python-side objects have not been converted into hardware-specific/compiled code\n",
-        "restraint.addGlobalParameter('k', 100.0*unit.kilojoules_per_mole/unit.nanometer**2)\n",
-        "restraint.addPerParticleParameter('x0')\n",
-        "restraint.addPerParticleParameter('y0')\n",
-        "restraint.addPerParticleParameter('z0')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "yYw0bpIjrNIZ"
-      },
-      "source": [
-        "Now let's add the heavy atoms of the residues near the binding site to our `CustomNonbondedForce` (`restraint`) to keep them in place."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "zHDO8xzAs13u"
-      },
-      "outputs": [],
-      "source": [
-        "# Cycle through residues with generator. We could also start on chains and then\n",
-        "# break after 1 cycle for tiny optimization, not really needed here.\n",
-        "for residue in fixer.topology.residues():\n",
-        "  # Skip over residues we dont care about\n",
-        "  # Both MDAnalysis and OpenMM are 0-index based, no need to shift by 1\n",
-        "  if residue.index in active_site.residues.resids:\n",
-        "    # Loop over atoms in the residue with generator\n",
-        "    for atom in residue.atoms():\n",
-        "      # Check for heavy atoms\n",
-        "      if atom.element.symbol != \"H\":\n",
-        "        # Add atom to the restraint force\n",
-        "        # We add the index (which topology and system match) as first arg\n",
-        "        # We then add the iterable of the per-particle parameters, which in\n",
-        "        # this case is the coordinate, as the centroid of the harmonic restraint\n",
-        "        restraint.addParticle(atom.index, fixer.positions[atom.index])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "RuJv2YctyVUd"
-      },
-      "source": [
-        "We've now added the heavy atoms to our `restraint` `CustomExternalForce` which has also already been added to our `System` object. We can check that the number of atoms added to the restraint is less than the number of atoms in the system by looking at the particle count the restraint is tracking."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "E2qkRYQ7vAC8"
-      },
-      "outputs": [],
-      "source": [
-        "restraint.getNumParticles()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rCVUd8T6yvwx"
-      },
-      "source": [
-        "And if we look at our `system`, we can see our new restraint there and ready to be set up for a simulation."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "_z0BN1kgy0lQ"
-      },
-      "outputs": [],
-      "source": [
-        "system_restrain.getForces()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "UTS19Ztjy56p"
-      },
-      "source": [
-        "The rest of the setup for a new minimization is the same as before. We'll need to make a new `Integrator` since our original one is bound to our original simulation."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "rzJg2M8gnW3u"
-      },
-      "outputs": [],
-      "source": [
-        "# Use a generic VerletIntegrator\n",
-        "integrator_restrain = VerletIntegrator(0.001 * unit.picoseconds)\n",
-        "\n",
-        "# Create simulation for minimization\n",
-        "# Optional, if you have access to a CUDA GPU, comment out the next line and uncomment the one after it\n",
-        "platform = None\n",
-        "# platform = Platform.getPlatformByName('CUDA')\n",
-        "\n",
-        "# Define the OpenMM Simulation object, which serves as a convenince wrapper for the OpenMM Context and Reporter objects\n",
-        "simulation_restrain = Simulation(fixer.topology, system_restrain, integrator_restrain, platform)\n",
-        "# Set the position of our atoms\n",
-        "simulation_restrain.context.setPositions(fixer.positions)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3GyANE0M0gQ7"
-      },
-      "source": [
-        "And just like last time, we run our minimization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "aYyKPinO0wwm"
-      },
-      "outputs": [],
-      "source": [
-        "# Minimize energy\n",
-        "print('Minimizing energy...')\n",
-        "simulation_restrain.minimizeEnergy()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Gp0-ZGiA1j0u"
-      },
-      "source": [
-        "And save our final coordinates."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "N_OLAqVm1mza"
-      },
-      "outputs": [],
-      "source": [
-        "# Get minimized positions. We have to copy the positions of the compiled object back into Python's memory\n",
-        "min_res_positions = simulation_restrain.context.getState(getPositions=True).getPositions()\n",
-        "\n",
-        "# Write minimized structure to a PDB file\n",
-        "with open(f\"{protein_directory}/{pdb_id}_restrain.pdb\", 'w') as output:\n",
-        "    PDBFile.writeFile(fixer.topology, min_res_positions, output)\n",
-        "\n",
-        "print(f'Minimization complete. Minimized structure saved to {protein_directory}/{pdb_id}_restrain.pdb')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dWGoujcC4Ft5"
-      },
-      "source": [
-        "## Comparing the minimized structure to the original"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "MTQxMQIf4lcL"
-      },
-      "source": [
-        "To see the impact of our efforts, we can visualize our structure, and compare it to the original."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Oc4ZH6-22KSe"
-      },
-      "outputs": [],
-      "source": [
-        "v = py3Dmol.view()\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}_fixed.pdb\").read())\n",
-        "v.setStyle({'chain':'A'}, {'cartoon': {'color': '#0e9674'}})\n",
-        "v.setStyle({'chain':'B'}, {'cartoon': {'color': '#c46225'}})\n",
-        "v.zoomTo({'model':0})\n",
-        "v.rotate(90, \"z\")\n",
-        "v.rotate(-25, \"y\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "hRxzrol52ILk"
-      },
-      "source": [
-        "On quick visual inspection, it might be hard to see if anything is different. Instead, we will superimpose our final structure superimposed over our original, using MDAnalysis to align them. The entire block below may seem daunting, but that is only because our final structure has a different number of atoms compared to our original structure, we have to be clever about how to pick a set of atoms from each structure to get equal sized sets."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Am0ezUW34R-F"
-      },
-      "outputs": [],
-      "source": [
-        "from MDAnalysis.analysis import align\n",
-        "\n",
-        "# Load the final PDB\n",
-        "u_fixed = mda.Universe(f\"{protein_directory}/{pdb_id}_fixed.pdb\")\n",
-        "\n",
-        "# IF the number of CA atoms matched between the structures, this next line\n",
-        "# would be all you need. Instead, we have to do a bit more.\n",
-        "\n",
-        "#align.alignto(u_fixed, u, select=\"name CA\", weights=\"mass\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 99
-        },
-        "id": "0-fbQdEi6VT8",
-        "outputId": "b7be35c8-0e57-4e52-e948-154d8def54ec"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.info { /* Based on Bootstrap Secondary Alert */\n",
-              "    color: #0c5460; /* Darker shade of blue for text */\n",
-              "    background-color: #d1ecf1; /* Light blue background */\n",
-              "    border-left: 5px solid #459db9; /* Bright blue border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.info ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.info li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"info\">\n",
-              "\n",
-              "<strong>Note: This is just one possible choice of alignment!</strong>\n",
-              "\n",
-              "<p>I'm choosing to align to the Alpha Carbons, but you may want to align to something else.\n",
-              "\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title\n",
-        "%%html\n",
-        "<style>\n",
-        "div.info { /* Based on Bootstrap Secondary Alert */\n",
-        "    color: #0c5460; /* Darker shade of blue for text */\n",
-        "    background-color: #d1ecf1; /* Light blue background */\n",
-        "    border-left: 5px solid #459db9; /* Bright blue border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.info ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.info li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"info\">\n",
-        "\n",
-        "<strong>Note: This is just one possible choice of alignment!</strong>\n",
-        "\n",
-        "<p>I'm choosing to align to the Alpha Carbons, but you may want to align to something else.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "JwUJ-jfy561M"
-      },
-      "outputs": [],
-      "source": [
-        "# Note: Other options would work besides alpha carbons\n",
-        "fixed_alphas = u_fixed.select_atoms(\"name CA\")\n",
-        "ref_alphas = u.select_atoms(\"name CA\")\n",
-        "\n",
-        "unmatched_fixed_residues = []\n",
-        "ref_res_index = 0\n",
-        "for idx, residue in enumerate(fixed_alphas.residues):\n",
-        "  # Check for exceeding the original structure. Some new residues may not be aligned, thats okay\n",
-        "  if ref_res_index > len(ref_alphas.residues) - 1:\n",
-        "    continue\n",
-        "  # A simple check to see if its the same residue at an index\n",
-        "  fixed_res_name = residue.resname\n",
-        "  ref_res_name = ref_alphas.residues[ref_res_index].resname\n",
-        "  if fixed_res_name != ref_res_name:  # Residues are different, which will only happen because we added the missing ones\n",
-        "    unmatched_fixed_residues.append(idx)\n",
-        "    # Move on the main one to find the next out of place resiude\n",
-        "    continue\n",
-        "  ref_res_index += 1\n",
-        "\n",
-        "# Not an elegant selection string, but works well enough for us\n",
-        "ref_select = \"name CA and segid A\"\n",
-        "fixed_select = \"name CA and segid A and not \" + \"(resid \" + \" or resid \".join(str(fix) for fix in unmatched_fixed_residues) + \")\"\n",
-        "selection_dict = {\"mobile\": fixed_select,\n",
-        "                  \"reference\": ref_select}\n",
-        "print(f\"Fixed Structure Selection String: '{fixed_select}'\")\n",
-        "print(f\"Original Structure Selection String: '{ref_select}'\")\n",
-        "\n",
-        "align.alignto(u_fixed, u, select=selection_dict, weights=\"mass\")\n",
-        "\n",
-        "# Now write the aligned structure out.\n",
-        "all_fixed_atoms = u_fixed.select_atoms(\"all\")\n",
-        "all_fixed_atoms.write(f\"{protein_directory}/{pdb_id}_aligned.pdb\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "R2v_NroR6_r8"
-      },
-      "source": [
-        "Our aligned structure is now just another PDB, so lets load the two structures together."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "TjfCTTIZSKAp"
-      },
-      "outputs": [],
-      "source": [
-        "# Visualize the alignment\n",
-        "v = py3Dmol.view()\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}_aligned.pdb\").read())\n",
-        "v.setStyle({'model': 0}, {'cartoon': {'color': '#0e9674'}})\n",
-        "v.setStyle({'model':1}, {'cartoon': {'color': '#c46225'}})\n",
-        "v.zoomTo({'model':0})\n",
-        "v.rotate(90, \"z\")\n",
-        "v.rotate(-25, \"y\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vNaLxzkx7U61"
-      },
-      "source": [
-        "And we can look at how our binding site has changed (if at all)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2I8S7XZB7FA0"
-      },
-      "outputs": [],
-      "source": [
-        "v = py3Dmol.view()\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}_aligned.pdb\").read())\n",
-        "v.setStyle()\n",
-        "v.addSurface(\"VDW\", {'opacity':0.75, \"color\": '#0e9674'}, {'resi':active_site.residues.resids.tolist(), \"chain\":\"A\", \"model\": 0})\n",
-        "v.addSurface(\"VDW\", {'opacity':0.75, \"color\": '#c46225'}, {'resi':active_site.residues.resids.tolist(), \"chain\":\"A\", \"model\": 1})\n",
-        "v.zoomTo({'chain':\"A\"})\n",
-        "v.rotate(90, \"z\")\n",
-        "v.rotate(-25, \"y\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4fnK3Rjk7r09"
-      },
-      "source": [
-        "We now have the protein in a relaxed structure with all atoms present while performing minimal adjustments to the binding site."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 61
-        },
-        "id": "RjaLOAs-7qL8",
-        "outputId": "2564a82e-1538-4904-bc3f-87b2c8784665"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.warning { /* Based on Bootstrap Warning */\n",
-              "    color: #856404; /* Darker shade of yellow-brown for text */\n",
-              "    background-color: #fff3cd; /* Light faded yellow background */\n",
-              "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.info ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.info li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"warning\">\n",
-              "\n",
-              "<strong>The next visualization requires the Restrained Minimization from above to have been run</strong>\n",
-              "\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title\n",
-        "%%html\n",
-        "<style>\n",
-        "div.warning { /* Based on Bootstrap Warning */\n",
-        "    color: #856404; /* Darker shade of yellow-brown for text */\n",
-        "    background-color: #fff3cd; /* Light faded yellow background */\n",
-        "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.info ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.info li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"warning\">\n",
-        "\n",
-        "<strong>The next visualization requires the Restrained Minimization from above to have been run</strong>\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0l5KLWxE9lMw"
-      },
-      "source": [
-        "If you ran the restrained minimization, we can also compare its binding pocket as well. Overlapping three visual surfaces probably isn't very clear, so you may wish to use a more quantitative measure such as RMSD."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "S4xtq_1E7_Cy"
-      },
-      "outputs": [],
-      "source": [
-        "# We'll skip some steps and align our \"fixed\" structure to our \"restrained\" structure\n",
-        "u_res = mda.Universe(f\"{protein_directory}/{pdb_id}_restrain.pdb\")\n",
-        "align.alignto(u_res, u_fixed, select=\"name CA\", weights=\"mass\")\n",
-        "\n",
-        "# Now write the aligned structure out.\n",
-        "all_restrained_atoms = u_res.select_atoms(\"all\")\n",
-        "all_restrained_atoms.write(f\"{protein_directory}/{pdb_id}_restrain_aligned.pdb\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "S-ZUSI5886au"
-      },
-      "outputs": [],
-      "source": [
-        "v = py3Dmol.view()\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}_aligned.pdb\").read())\n",
-        "v.addModel(open(f\"{protein_directory}/{pdb_id}_restrain_aligned.pdb\").read())\n",
-        "v.setStyle()\n",
-        "v.addSurface(\"VDW\", {'opacity':0.75, \"color\": '#0e9674'}, {'resi':active_site.residues.resids.tolist(), \"chain\":\"A\", \"model\": 0})\n",
-        "v.addSurface(\"VDW\", {'opacity':0.75, \"color\": '#c46225'}, {'resi':active_site.residues.resids.tolist(), \"chain\":\"A\", \"model\": 1})\n",
-        "v.addSurface(\"VDW\", {'opacity':0.75, \"color\": '#4287f5'}, {'resi':active_site.residues.resids.tolist(), \"chain\":\"A\", \"model\": 2})\n",
-        "v.zoomTo({'chain':\"A\"})\n",
-        "v.rotate(90, \"z\")\n",
-        "v.rotate(-25, \"y\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "B4JEGQd7-N0I"
-      },
-      "outputs": [],
-      "source": [
-        "from MDAnalysis.analysis.rms import RMSD\n",
-        "\n",
-        "# Select our residues\n",
-        "residue_select = \"resid \" + \" or resid \".join(str(x) for x in active_site.residues.resids)\n",
-        "residue_select = \"name CA and (\" + residue_select + \")\"\n",
-        "print(residue_select)\n",
-        "\n",
-        "fixed_select_rmsd = u_fixed.select_atoms(residue_select)\n",
-        "restrined_select_rmsd = u_res.select_atoms(residue_select)\n",
-        "ref_select_rmsd = u.select_atoms(residue_select)\n",
-        "\n",
-        "rmsd_fixed = RMSD(fixed_select_rmsd,\n",
-        "                  reference=ref_select_rmsd,\n",
-        "                  weights=\"mass\").run().results.rmsd\n",
-        "rmsd_restrined = RMSD(restrined_select_rmsd,\n",
-        "                      reference=ref_select_rmsd,\n",
-        "                      weights=\"mass\").run().results.rmsd\n",
-        "print(f\"RMSD of binding site Alpha Carbons after basic minimization: {rmsd_fixed}\")\n",
-        "print(f\"RMSD of binding site Alpha Carbons after restrained minimization: {rmsd_restrined}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "fds1KWNBTcZA"
-      },
-      "source": [
-        "## Adding Partial Charge Information to the Receptor for Docking\n",
-        "\n",
-        "Molecular docking can sometimes require charge information about the protein in order to correctly handle the physics calculations. Many programs for docking specifically (i.e. the `gnina` program we'll use next, or e.g. Autodock VINA) can use an extended PDB format called PDBQT. Although we technically assigned charges when we did the minimization with the Amber ff14SB force field, those were kept in OpenMM for dynamics simulations. If we want those partial charges in our docking, we need to either take those partial charges from our `System` and write them out to a PDBQT file (for which OpenMM does not have nor should have a writer for), OR, we can use a program like `OpenBabel` to write the file for us from our completed structure.\n",
-        "\n",
-        "This workshop will use docking scoring functions that don't require the partial charges, but we'll show you how to generate them should you choose to need them.\n",
-        "\n",
-        "Technically speaking, MDAnalysis can write to PDBQT file formats, but doesn't have auto-charge generation. We're choosing to show another program which also supports auto-charge generation and is still quite popular today."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "R4gRY0NhXNmQ"
-      },
-      "outputs": [],
-      "source": [
-        "# Invoke OpenBabel's CLI from Python. Can also use subprocess as its safer, but os.system works fine here.\n",
-        "receptor_pdbqt_path = f\"{protein_directory}/{pdb_id}.pdbqt\"\n",
-        "recepetor_fixed_path = f\"{protein_directory}/{pdb_id}_fixed.pdb\"\n",
-        "# Generate the PDBQT file.\n",
-        "# We could have \"--partialcharge <method>\" as a flag if we wanted to compute the partial charges, but this will just assume they are all \"0\"\n",
-        "# The \"-xh\" flag preserves the hydrogens we worked so hard to get.\n",
-        "os.system(f\"obabel -ipdb {recepetor_fixed_path} -opdbqt -O {receptor_pdbqt_path}\")\n",
-        "\n",
-        "# If you get a status code \"2\" here, rerun it. You want status code 0"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HG6yVycDDXI_"
-      },
-      "source": [
-        "OpenBabel is doing quite alot behind the scenes for us. Because we've specified that we want a PDBQT file, OpenBabel is stripping out all of the non-polar hydrogens from our system. We could have added an [additional flag](https://open-babel.readthedocs.io/en/latest/FileFormats/AutoDock_PDBQT_format.html) to the command in the form of `-xh`, which tells the PDBQT writter to keep all hydrogens (`x` indicates flags for outputs, `h` is hydrogen). We also could have specified a `--partialcharge` method in the command to have OpenBabel place partial charges on our receptor.\n",
-        "\n",
-        "Did we need to do either of those flags though? For our case: No. In fact, for our case, its actually a bad idea. Why though? We have to understand our tools to know why.\n",
-        "\n",
-        "What impact does the `-xh` flag have?\n",
-        "* If we only provide a PDB file to `gnina`, it will automatically strip out any non-polar hydrogens.\n",
-        "* If we give a PDBQT file to `gnina` though, it will use the file **as is**. That means all hydrogens present in the file will be treated as polar hydrogens; which can and do give erroneous results. Not all codes will make this assumption though.\n",
-        "\n",
-        "What impact does the `--partialcharge` flag have?\n",
-        "* We're not using a docking method that need partial charges, so adding the charges doesn't change the result at all (we tested this to make sure). Some actually do use this information and without the flag, it assigns a partial charge of 0 to all atoms, which will give you incorrect results when charges are needed.\n",
-        "* Computing partial charges does take more time, so if you're running this command with some regularity, its just adding empty compute time when not needed."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bFsiJwDSGCcm"
-      },
-      "source": [
-        "Congratulations! We've now prepped our receptor protein molecule for docking. We still need to do the ligand, which has less regular data we can draw from (such as adding in missing hydrogens based on standard residues), but the process is still straightforward, and in fewer steps often.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 61
-        },
-        "id": "LIZPRaHiF_-_",
-        "outputId": "3a172a6a-6055-4ee0-f4c6-8d2450e3bb1e"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.info { /* Based on Bootstrap Secondary Alert */\n",
-              "    color: #0c5460; /* Darker shade of blue for text */\n",
-              "    background-color: #d1ecf1; /* Light blue background */\n",
-              "    border-left: 5px solid #459db9; /* Bright blue border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.info ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.info li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"info\">\n",
-              "\n",
-              "<strong>Workshop: Checkpoint for Questions</strong>\n",
-              "\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title\n",
-        "%%html\n",
-        "<style>\n",
-        "div.info { /* Based on Bootstrap Secondary Alert */\n",
-        "    color: #0c5460; /* Darker shade of blue for text */\n",
-        "    background-color: #d1ecf1; /* Light blue background */\n",
-        "    border-left: 5px solid #459db9; /* Bright blue border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.info ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.info li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"info\">\n",
-        "\n",
-        "<strong>Workshop: Checkpoint for Questions</strong>\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7wdporBGXN4b"
-      },
-      "source": [
-        "# Building Atomistic Ligand Model\n",
-        "\n",
-        "Let's review what we need to prepare our ligand for docking from our list above:\n",
-        "\n",
-        "* Where on the receptor we want to dock\n",
-        "* Atomistic level coordinates of ligand (here: small molecule)\n",
-        "* Partial charge and protonation states for ligand\n",
-        "* Descriptor of how atoms interact with each other\n",
-        "\n",
-        "Going down the list one at a time, we can work to build our ligand."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Qya8dZfGwdUg"
-      },
-      "source": [
-        "## Where on the Receptor We Want to Dock\n",
-        "\n",
-        "The location we want to dock to can be programmatically determined from the experimentally bound ligand itself. Some docking programs, including the `gnina` program we'll be using, determine the docking location based on an existing ligand and a buffer zone around it. We'll need to make sure its location is well defined, especially because we pulled it's experimental positions out of the binding site earlier before relaxing. In practice, this step will be resolved with the following ones on its own. We could also use a tool like `MDAnalysis` to define our binding region (similar to how we identified nearby residues to the ligand) and provide that for the search grid into our program.\n",
-        "\n",
-        "This process works well when you already know the rough region of the receptor you want to dock to. You'll have to identify active and/or target sites through other means if you don't already have this information; which in itself is a whole field of research beyond the scope here.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VXo-0dpZwfAl"
-      },
-      "source": [
-        "## Atomistic Level Coordinates of Ligand\n",
-        "\n",
-        "Looking at the original PDB file, we can see that our ligand doesn't have hydrogens either. That is not surprising, however, we can't \"fix\" this problem in the same was as we did the protein because a ligand doesn't have the concept of \"standard\" components the same way a protein does. It still follows chemistry though, so we can still fill in the missing information; lucky us!\n",
-        "\n",
-        "The RCSB keeps a record of all the ligands it has in its structures as well. Much in the same way it codes proteins, it does the same for ligands. We'll pull down the \"ideal\" structure for this ligand to make sure we get the correct chemistry for it, and then modify it for our purposes. The \"ideal\" structures are those which have been constructed with optimized bonds, collisions, and alignments for computational analysis; as opposed to the coordinates found in experimental structures. They will be 3D, but you might not always have a ligand which has a 3D structure provided (especially given the information there are $10^{60}$ possible small molecules following Lipinski's rule-of-five and at least 166.4 billion enumerated since 2015; see [The Chemical Space Project](https://pubs.acs.org/doi/10.1021/ar500432k)). For now, let's focus on what we do have.\n",
-        "\n",
-        "We know the ID for this ligand from the PDB file is \"Y6J\" and *could* use that in our code. However, if you're screening many compounds, you may not want to manually look at every PDF file to find the alpha-numeric ID for the ligand(s), so lets extract it programmatically with tools we already have."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Reloading the fixed protein in case restrained minimization block wasn't run\n",
-        "import MDAnalysis as mda\n",
-        "\n",
-        "# Load the original PDB\n",
-        "u = mda.Universe(f\"{protein_directory}/{pdb_id}.pdb\")"
-      ],
-      "metadata": {
-        "id": "tRy31gUqtONM"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "rJEggYkPhTwB"
-      },
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "\n",
-        "# This works well enough for single bound ligand, but is not general for more complicated or non-standard PDB codes\n",
-        "ligands = u.select_atoms(\"not protein and not water\")\n",
-        "ligand_residue_names = ligands.residues.resnames\n",
-        "# This is a dimer, so pull out one name.\n",
-        "ligand_id = np.unique(ligand_residue_names)[0]\n",
-        "print(ligand_id)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "eGrw95tElNA-"
-      },
-      "outputs": [],
-      "source": [
-        "# Pull the ideal ligand from the RCSB\n",
-        "ligand_directory = \"ligand_structures\"\n",
-        "os.makedirs(ligand_directory, exist_ok=True)\n",
-        "\n",
-        "ideal_ligand_filename = f\"{ligand_id}_ideal.sdf\"\n",
-        "print(f\"Downloading ligand {ligand_id}...\")\n",
-        "ligand_url = f\"https://files.rcsb.org/ligands/download/{ideal_ligand_filename}\"\n",
-        "# dont break the RCSB for the workshop\n",
-        "ligand_url = f\"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/main/data/{ideal_ligand_filename}\"\n",
-        "ligand_request = requests.get(ligand_url)\n",
-        "ligand_request.raise_for_status() # Check for errors\n",
-        "\n",
-        "ideal_filepath = f\"{ligand_directory}/{ideal_ligand_filename}\"\n",
-        "\n",
-        "with open(ideal_filepath, \"w\") as f:\n",
-        "    f.write(ligand_request.text)\n",
-        "print(f\"Saved ligand to {ideal_filepath}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EmgTv6d6m09r"
-      },
-      "source": [
-        "And we can look at this file much like we did the PDB"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Bcr5zy1xm0bY"
-      },
-      "outputs": [],
-      "source": [
-        "# Helper function from above\n",
-        "render_text(ligand_request.text)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "fxEeOi5cm_Zy"
-      },
-      "source": [
-        "The Structured Data File (SDF) format is great for small molecules, including multiple molecules in one file, full coordinates for all atoms, bond type information, formal charge information (although 0 here), and supports other metadata not present in this particular file.\n",
-        "\n",
-        "This ideal structure has plenty of information that the structure in the experimental PDB is missing, however, it also has coordinates which have no relation to how this molecule will be configured in the active site we're investigating. So we'll need to map the information from one to the other. We can start by pulling the coordinates from the PDB file and saving those. Even if we test other ligands that were not experimentally bound, we'll need the originally bound ligand in our specific workflow to define the active site box."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "CqFT47FWptS8"
-      },
-      "outputs": [],
-      "source": [
-        "# Split the ligand out into its own PDB file from the experimental one\n",
-        "\n",
-        "# Use only Chain A since this is a dimer and our target site for docking\n",
-        "single_pose_ligand = ligand.select_atoms(\"segid A\")\n",
-        "single_pose_ligand.write(f\"{ligand_directory}/{ligand_id}_fromPDB.pdb\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tQKnlr6Are6N"
-      },
-      "source": [
-        "MDAnalyis [cannot write SDF files](https://userguide.mdanalysis.org/stable/formats/index.html#id10), but we're only really interested in the heavy atom coordinates so the PDB file format is fine for our purposes.\n",
-        "\n",
-        "The tools we've worked with so far in prep are not built to handle bond orders and other types of chemistry we'll need to map the two ligands onto each other. So we'll instead be using RDKit to do that. Specifically, we need to map the bond orders and hydrogens from our ideal molecule onto the coordinates from the experimental pose. RDKit can handle that in a few lines."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "RavzgbRMskJ9"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit import Chem\n",
-        "from rdkit.Chem import AllChem\n",
-        "\n",
-        "# Load and remove the hydrogens that we can't map anyways yet.\n",
-        "ideal_mol = Chem.MolFromMolFile(f\"{ligand_directory}/{ligand_id}_ideal.sdf\", removeHs=True)\n",
-        "pose_mol = Chem.MolFromPDBFile(f\"{ligand_directory}/{ligand_id}_fromPDB.pdb\", removeHs=True)\n",
-        "\n",
-        "# Assign bond orders from the template to the pose molecule\n",
-        "corrected_pose = AllChem.AssignBondOrdersFromTemplate(ideal_mol, pose_mol)\n",
-        "\n",
-        "# Add hydrogens back to the corrected pose\n",
-        "corrected_pose_with_H = Chem.AddHs(corrected_pose, addCoords=True)\n",
-        "\n",
-        "# Sanity to check to make sure the molecule is right (check smiles of both)\n",
-        "assert Chem.MolToSmiles(corrected_pose) == Chem.MolToSmiles(ideal_mol)\n",
-        "\n",
-        "# Save the corrected pose to an SDF file\n",
-        "ligand_corrected_pose_file = f\"{ligand_directory}/{ligand_id}_corrected_pose.sdf\"\n",
-        "writer = Chem.SDWriter(ligand_corrected_pose_file)\n",
-        "writer.write(corrected_pose_with_H)\n",
-        "writer.close()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "GpiMRNYdtuhK"
-      },
-      "outputs": [],
-      "source": [
-        "# Compare the two models\n",
-        "v = py3Dmol.view()\n",
-        "v.addModel(open(f\"{ligand_directory}/{ligand_id}_fromPDB.pdb\").read())\n",
-        "v.addModel(open(f\"{ligand_corrected_pose_file}\").read())\n",
-        "#v.setStyle()\n",
-        "v.setStyle({\"model\":0}, {'stick': {'color': '#0e9674'}})\n",
-        "v.setStyle({\"model\":1}, {'stick': {'color': '#c46225'}})\n",
-        "v.zoomTo({'model':0})"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "6IdSfQaguwBc"
-      },
-      "source": [
-        "You can see in the overlaid rendering here that both the original experimental pose (green) and the structure corrected pose (brown) are present, but the structure corrected one has the added hydrogens.\n",
-        "\n",
-        "We now have a fully atomistic ligand and for some docking programs, this is all we need to do. We've got a bit more to do to have the docking program we want to use, `gnina` behave."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xegDiRrFzOba"
-      },
-      "source": [
-        "### Partial Charge for the Ligand\n",
-        "\n",
-        "We won't explicitly be needing the partial charges for our small molecule as we won't need them pre-defined for docking here. If you want to make your own partial charges for ligands, you can use an array of tools such as\n",
-        "[Amber's `antechamber`](https://ambermd.org/antechamber/ac.html#antechamber),\n",
-        "[Open Free Energy's charging CLI](https://docs.openfree.energy/en/latest/tutorials/charge_molecules_cli_tutorial.html),\n",
-        "[OpenEye's `molcharge`](https://docs.eyesopen.com/toolkits/cpp/quacpactk/molchargetheory.html),\n",
-        "and OpenBabel (like we'll do here) to name a few.\n",
-        "\n",
-        "We'll be generating a PDBQT file for our ligand just like we did with the receptor due to a quirk in how `gnina` runs its code. If you do *not* provide a PDBQT file, `gnina` will run OpenBabel behind the scenes and strip out all the hydrogens we worked so hard to build up. Not every code does this mind you, but in order to preserve our work, we're going to make a PDBQT file for our ligand so the hydrogens will be preserved.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "30SRmo5N7a1Z"
-      },
-      "outputs": [],
-      "source": [
-        "# Create our PDBQT to keep our hydrogens\n",
-        "ligand_simple_pdbqt_filename = f\"{ligand_directory}/{ligand_id}_obabel.pdbqt\"\n",
-        "os.system(f\"obabel {ligand_corrected_pose_file} -O {ligand_simple_pdbqt_filename} -xh\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "84ki26MC9ZLf"
-      },
-      "source": [
-        "If you want just a single basic resonant structure of your ligand, than you're likely ready to go! However, we may not always want just one structure, especially if we can build tautomers."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oBGUCfnf0P32"
-      },
-      "source": [
-        "### Building Ligand Tautomers and Protomers\n",
-        "\n",
-        "Tautomers and protomers, especially in the biosciences, can drastically change the interactions between a ligand and receptor. One example of this is in drug chemistry where one tautomer may form in compounding, and then decay to another while the drug is on the shelf. If we only explore resonance structures, or only one tautomer of a ligand, then we may miss critical interactions which have real-world impacts later.\n",
-        "\n",
-        "For the purposes of this workshop, I'm referring to \"protomer\" as the moving of a single proton on a small molecule to generate different tautomers, usually as a result of pH. As such, I'll treat them roughly the same and will just use \"tautomer\" for word choice, even if you can get multiple tautomers at a fixed pH.\n",
-        "\n",
-        "Generating tautomers is no easy task, I strongly recommend looking through the literature on this topic to better understand what we'll be doing here. We'll be using `RDKit` and [`Scrubber`](https://github.com/forlilab/molscrub); from the lab which also makes [`meeko`](https://meeko.readthedocs.io/en/release-doc/); to generate our tautomers. You can use these programs separately, or together (`Scrubber` uses `RDKit` under the hood with extra logic). There is also an [excellent blog post by Jeremy Monat](https://bertiewooster.github.io/2024/05/01/Tautomer-Sources-Comparison.html) which compares tautomer generation codes from 2024, one of which we'll be using here.\n",
-        "\n",
-        "Even though tautomers themselves can be complicated, our tool developers have taken great strides to make it as straightforward as possible to generate said tautomers."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 131
-        },
-        "id": "btmju_oV-wTd",
-        "outputId": "a928e583-7d08-4399-9890-ec2dc5f1f91e"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.warning { /* Based on Bootstrap Warning */\n",
-              "    color: #856404; /* Darker shade of yellow-brown for text */\n",
-              "    background-color: #fff3cd; /* Light faded yellow background */\n",
-              "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.info ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.info li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"warning\">\n",
-              "\n",
-              "<strong>Meeko doesn't work for this protein system</strong>\n",
-              "\n",
-              "<p>We didn't use Meeko to prepare our protein because it makes infernces based on atomic distances about bonds.\n",
-              "\n",
-              "<p>This dimer structure has interatomic distances which make some atoms bonded that should not be, so we had to take other steps to prepare the receptor.\n",
-              "\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title\n",
-        "%%html\n",
-        "<style>\n",
-        "div.warning { /* Based on Bootstrap Warning */\n",
-        "    color: #856404; /* Darker shade of yellow-brown for text */\n",
-        "    background-color: #fff3cd; /* Light faded yellow background */\n",
-        "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.info ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.info li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"warning\">\n",
-        "\n",
-        "<strong>Meeko doesn't work for this protein system</strong>\n",
-        "\n",
-        "<p>We didn't use Meeko to prepare our protein because it makes infernces based on atomic distances about bonds.\n",
-        "\n",
-        "<p>This dimer structure has interatomic distances which make some atoms bonded that should not be, so we had to take other steps to prepare the receptor.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "8-bdg56H44cH"
-      },
-      "outputs": [],
-      "source": [
-        "# Check our molecule from RDKit. Doesn't have rotation, but its neat to see in a Jupyer Notebook for just invoking it\n",
-        "corrected_pose_with_H"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bRMB2GZinpSS"
-      },
-      "source": [
-        "RDKit can help us generate tautomers, however, RDKit also works on the principal that hydrogens are generally implicit (i.e. `removeHs=True`, default). If you leave hydrogens in your structure, [you can get some very odd and incorrect results depending on what you are doing](https://www.rdkit.org/docs/source/rdkit.Chem.rdmolops.html#rdkit.Chem.rdmolops.AddHs). So we'll work with the structure before we added hydrogens."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 99
-        },
-        "id": "AzRt3wzerSly",
-        "outputId": "ec994b30-8143-403a-ad4c-a7fc08d03689"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.info { /* Based on Bootstrap Secondary Alert */\n",
-              "    color: #0c5460; /* Darker shade of blue for text */\n",
-              "    background-color: #d1ecf1; /* Light blue background */\n",
-              "    border-left: 5px solid #459db9; /* Bright blue border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.info ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.info li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"info\">\n",
-              "\n",
-              "<strong>RDKit's Tautomer Enumeration routine generates ALL POSSIBLE tautomers</strong>\n",
-              "\n",
-              "<p>Not all tautomers are stable, or even energetically favored, especially with at certain pH. Without additional logic and code, this is just a set of all possible ones.\n",
-              "\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title\n",
-        "%%html\n",
-        "<style>\n",
-        "div.info { /* Based on Bootstrap Secondary Alert */\n",
-        "    color: #0c5460; /* Darker shade of blue for text */\n",
-        "    background-color: #d1ecf1; /* Light blue background */\n",
-        "    border-left: 5px solid #459db9; /* Bright blue border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.info ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.info li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"info\">\n",
-        "\n",
-        "<strong>RDKit's Tautomer Enumeration routine generates ALL POSSIBLE tautomers</strong>\n",
-        "\n",
-        "<p>Not all tautomers are stable, or even energetically favored, especially with at certain pH. Without additional logic and code, this is just a set of all possible ones.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "C5yBSTWDrNMh"
-      },
-      "source": [
-        "Further Reading: [RDKit has a blogpost](https://rdkit.blogspot.com/2020/01/trying-out-new-tautomer.html) with a helpful function to re-order tautomers with the canonical one first. Take a look if you're interested. Note: [\"Canonical\" does not mean most stable, and is likely not the most stable](https://www.rdkit.org/docs/cppapi/classRDKit_1_1MolStandardize_1_1TautomerEnumerator.html#a7e4f2a393b92f09ee1447d2af50918dc)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "IdiqdjPf5hjp"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem.MolStandardize import rdMolStandardize\n",
-        "# Initialize enumerator\n",
-        "tautomer_enumerator = rdMolStandardize.TautomerEnumerator()\n",
-        "# Provide RDKit Mol object to generate.\n",
-        "# We already made this, but you may start from a SMILE string or other source\n",
-        "# Remember, use the structure with implicit hydrogens!\n",
-        "tautomers = tautomer_enumerator.Enumerate(corrected_pose)\n",
-        "# Take the TautomerEnumerationResults object and iterate over to get a list of structures\n",
-        "tautomers_list = [t for t in tautomers]\n",
-        "\n",
-        "'''\n",
-        "Note! This may generate duplicate structures,\n",
-        "You may want to cast these Mol objects into SMILES strings, de-duplicate,\n",
-        "then rebuild the Mol objects to map their coordinates back onto the reference structure\n",
-        "'''\n",
-        "\n",
-        "# Cast to a set to make unique, then back to a list (as some tautomers can be enumerated again for some structures)\n",
-        "smiles_set_tautomers = set(Chem.MolToSmiles(t) for t in tautomers_list)\n",
-        "tautomer_list_unique = list(smiles_set_tautomers)\n",
-        "# We know the Y6J structure does have unique tautomers, this is just a sanity check\n",
-        "assert len(tautomers_list) == len(tautomer_list_unique)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "vTbCvLJ85_Hn"
-      },
-      "outputs": [],
-      "source": [
-        "ligand_tautomers = f\"{ligand_directory}/{ligand_id}_tautomers.sdf\"\n",
-        "writer = Chem.SDWriter(ligand_tautomers)\n",
-        "for t in tautomers_list:\n",
-        "  writer.write(t)\n",
-        "writer.close()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "kBoaBf6U7tSv"
-      },
-      "source": [
-        "Rendering all these tautomers at once in 3D, or looking through the SDF file isn't going to show many differences, so let's instead just look at the SMILES strings."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Yx4zsrq58R0n"
-      },
-      "outputs": [],
-      "source": [
-        "for t in tautomer_list_unique:\n",
-        "  print(t)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aFjmLV0yqTBp"
-      },
-      "source": [
-        "However, rendering their 2D smiles strings can be done with a built-in RDKit module and function. Neat!"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "hZcCDj7emckn"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem import Draw\n",
-        "Draw.MolsToGridImage([Chem.MolFromSmiles(t) for t in tautomer_list_unique])"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 125
-        },
-        "id": "mWrk-IGOqtMy",
-        "outputId": "90fcb358-784c-41c8-d863-b8f4e5ee0905"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<style>\n",
-              "div.warning { /* Based on Bootstrap Warning */\n",
-              "    color: #856404; /* Darker shade of yellow-brown for text */\n",
-              "    background-color: #fff3cd; /* Light faded yellow background */\n",
-              "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.info ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.info li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"warning\">\n",
-              "\n",
-              "<strong>SMILES strings from explicit hydrogen structures breaks RDKit</strong>\n",
-              "\n",
-              "<p>If we made the tautomers with explicit hydrogens, we would have made 24 and RDKit could not have rebuilt the Mol objects from the strings; throwing errors because of too many valence electrons.\n",
-              "\n",
-              "</div>\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# @title\n",
-        "%%html\n",
-        "<style>\n",
-        "div.warning { /* Based on Bootstrap Warning */\n",
-        "    color: #856404; /* Darker shade of yellow-brown for text */\n",
-        "    background-color: #fff3cd; /* Light faded yellow background */\n",
-        "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.info ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.info li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"warning\">\n",
-        "\n",
-        "<strong>SMILES strings from explicit hydrogen structures breaks RDKit</strong>\n",
-        "\n",
-        "<p>If we made the tautomers with explicit hydrogens, we would have made 24 and RDKit could not have rebuilt the Mol objects from the strings; throwing errors because of too many valence electrons.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WaDnfUbw-H7D"
-      },
-      "source": [
-        "We've now generated many tautomers we could use for docking. The good news is, many docking codes, including `gnina` will accept multi-ligand input files for us. We could convert the SDF file into a set of PDBQT files for `gnina` like we did with `OpenBabel`, but consider that we've only enumerated *all* tautomers, not the most likely ones for pH. We could do that with `RDKit` and our own logic, or we can use `Scrubber` which has a handy command-line utility we can just call."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ieMr_SAX_vDl"
-      },
-      "outputs": [],
-      "source": [
-        "print(f\"{ligand_directory}/{ligand_id}_corrected_pose.sdf\")\n",
-        "print(f\"{ligand_directory}/{ligand_id}.pdbqt\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Y31WsDZL_mFW"
-      },
-      "outputs": [],
-      "source": [
-        "!scrub.py ligand_structures/Y6J_corrected_pose.sdf -o ligand_structures/Y6J.sdf"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "zBH6tftqAEO-"
-      },
-      "source": [
-        "Scrubber took a pre-set pH, did the following actions for us (from [their documentation](https://github.com/forlilab/molscrub)) using RDKit under the hood:\n",
-        "* Generate 3D coordinates using RDKit's ETKDGv3 and UFF minimization\n",
-        "* Enumerate tautomers (aiming at low energy states only)\n",
-        "* Enumerate pH corrections\n",
-        "* Convert boats to chairs (6-member rings) and enumerate both chair states\n",
-        "\n",
-        "There are plenty of command line options and a Python API for Scrubber as well.\n",
-        "\n",
-        "And now with our SDF file which has been \"scrubbed,\" we can finally generate our ready-to-feed-into `gnina` PDBQT file that we'll use for docking."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "1TmiRxslADpi"
-      },
-      "outputs": [],
-      "source": [
-        "# Create our PDBQT to keep our hydrogens\n",
-        "ligand_pdbqt_filename = f\"{ligand_directory}/{ligand_id}.pdbqt\"\n",
-        "os.system(f\"obabel {ligand_corrected_pose_file} -O {ligand_pdbqt_filename} -xh\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8zdAfY3B0NGL"
-      },
-      "source": [
-        "And now we have 1 ligand ready to go for docking. But what if we want to have multiple ligands, such as the ones we made from the [second notebook of this workshop?](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/02_Cheminfo_crash_course.ipynb)\n",
-        "\n",
-        "## Preparing multiple ligands from SMILES strings\n",
-        "\n",
-        "If you want to upload your own CSV file of SMILES strings, feel free to do so. Or you can pull down a sample output by running the code below. There are other codes which can go about this, but this is one example where we can prep from data we've already worked with."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "jw2FL0M_ccoq"
-      },
-      "outputs": [],
-      "source": [
-        "# Run this cell if you want some sample SMILE strings from the\n",
-        "# US20240293380 set for 7LME docking. You can also use your own.\n",
-        "!wget https://github.com/MolSSI-Education/iqb-2025/raw/refs/heads/main/data/US20240293380_examples.csv"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VAM3CXltd-gU"
-      },
-      "source": [
-        "We'll be using RDKit to pull these SMILES strings back into `Mol` objects (which if we were doing this whole workshop in one notebook we could have skipped), then casting the molecules to SDF, and then back into 3D structures with `Scrubber`. The back and forth between the programs may seem a bit silly because we had the `Mol` objects earlier, but sometimes you will only have SMILE strings to start your research, so we'll work from that basis here."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "aWXB5EF3fQjW"
-      },
-      "outputs": [],
-      "source": [
-        "# Load the SMILES strings into RDKit and write back out an SDF file.\n",
-        "# Default delimiter is tab (\\t), so we need to specify \",\"\n",
-        "smiles_supplier = Chem.SmilesMolSupplier(\"US20240293380_examples.csv\", delimiter=\",\")\n",
-        "mols = []  # Could do this in list comprehension, adding a sanity check\n",
-        "for mol in smiles_supplier:\n",
-        "  print(Chem.MolToSmiles(mol))  # Sanity check that we got the smiles strings and not metadata\n",
-        "  mols.append(mol)\n",
-        "\n",
-        "# Write out our molecules\n",
-        "ligands_to_dock_dirty = f\"{ligand_directory}/ligands_to_dock_dirty.sdf\"\n",
-        "writer = Chem.SDWriter(ligands_to_dock_dirty)\n",
-        "for m in mols:\n",
-        "  writer.write(m)\n",
-        "writer.close()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "THd3to70h-71"
-      },
-      "source": [
-        "The file is labeled as \"dirty\" since there is more preparation work to do before these molecules are ready to insert into docking. Because we started with SMILES, we got a 2D structure by default with RDKit. we can see that by just declaring the most recent `mol` object from our list."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2x9SqbOCiIZA"
-      },
-      "outputs": [],
-      "source": [
-        "mol"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-EtTtZR9iNWy"
-      },
-      "source": [
-        "We can also see that there are some erroneous fields here because we did a very, very simple read of the CSV file with our SMILES strings. We don't need that information here, but you might in the future; make sure you parse your data correctly as needed. (e.g. with the Python built-in `csv` module or manipulate the Pandas `DataFrame` directly). We'll use `Scrubber` to clean up our structures for us all at once."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "0-IvNYnwjFSb"
-      },
-      "outputs": [],
-      "source": [
-        "!scrub.py ligand_structures/ligands_to_dock_dirty.sdf -o ligand_structures/ligands_to_dock.sdf"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EVnXg8m8jf8P"
-      },
-      "source": [
-        "We got some text output, but did that do what we wanted? We could assume we did, or we can make sure."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "VEu5EJRfjoIO"
-      },
-      "outputs": [],
-      "source": [
-        "# Sanity check we got a structure with hydrogens\n",
-        "# RDKit automatically removes hydrogens by default (needed for most of the kit to work)\n",
-        "# But we're explicitly looking for them here, we can just load them and check\n",
-        "supplier = Chem.SDMolSupplier(f\"{ligand_directory}/ligands_to_dock.sdf\", removeHs=False)\n",
-        "reloaded_ligands = [mol for mol in supplier]\n",
-        "# The last structure will be the same as the last in list comprehension above\n",
-        "reloaded_ligands[-1]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XZdrl6_6cYIj"
-      },
-      "source": [
-        "Our receptor, experimental ligand, and additional ligands have now been downloaded, separated, cleaned, and modified starting from both a single structure on the RCSB and through BindingDB. We applied our bioinformatics and molecular modeling tools to create computational-ready models that we will now feed into docking."
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.11.11"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/03_Cheminfo_crash_course.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bbS_dv_XZbmq"
+   },
+   "source": [
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:325px;\">\n",
+    "</div>\n",
+    "\n",
+    "# Preparing Molecules and Proteins for Docking\n",
+    "*This tutorial was created by Levi Naden (Software Scientist) at The Molecular Sciences Software Institue for the [Cheminformatic-Driven Molecular Docking Workshop](https://pdb101.rcsb.org/news/67d9853eaddf75595bd158f7) held as a Crash Course with the Institute for Quantitative Biomedicine (IQB) and the Protein Data Bank (RCSB).*\n",
+    "\n",
+    "*Special thanks to Jessica Nash and Pat Walters for code samples and alternate tool suggestions that helped make up this notebook.*\n",
+    "\n",
+    "*This notebook is Part 3 of 4 in the notebook series.*\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 315
+    },
+    "id": "x70dQt37e9o5",
+    "outputId": "d764af9e-c1aa-42fd-a3c1-8f6d4b01051e"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.alert {\n",
+       "    color: #0056b3;\n",
+       "    background-color: #d9edf7;\n",
+       "    border-left: 5px solid #31708f;\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em;\n",
+       "    line-height: 1.5;\n",
+       "}\n",
+       "div.alert ul {\n",
+       "    margin: 0.5em 0;\n",
+       "}\n",
+       "div.alert li {\n",
+       "    margin-bottom: 0.5em;\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"alert alert-block alert-info\">\n",
+       "    <strong>Questions:</strong>\n",
+       "    <ul>\n",
+       "        <li>Why can't we just go from RCSB files to Docking?</li>\n",
+       "        <li>What are the steps to take to ensure the molecule(s) and prtiens are ready?</li>\n",
+       "        <li>What are steps we can optionally perform to get better or more tailored results?</li>\n",
+       "    </ul>\n",
+       "\n",
+       "    <strong>Objectives:</strong>\n",
+       "    <ul>\n",
+       "        <li>Learn about the \"missing\" information in molecular structure files</li>\n",
+       "        <li>Learn how to use a specific set of tools (among many) to prepare your files</li>\n",
+       "        <li>Understand nuance of the programs we work with to modify our preparation workflow</li>\n",
+       "    </ul>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title Overview\n",
+    "%%html\n",
+    "<style>\n",
+    "div.alert {\n",
+    "    color: #0056b3;\n",
+    "    background-color: #d9edf7;\n",
+    "    border-left: 5px solid #31708f;\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em;\n",
+    "    line-height: 1.5;\n",
+    "}\n",
+    "div.alert ul {\n",
+    "    margin: 0.5em 0;\n",
+    "}\n",
+    "div.alert li {\n",
+    "    margin-bottom: 0.5em;\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <strong>Questions:</strong>\n",
+    "    <ul>\n",
+    "        <li>Why can't we just go from RCSB files to Docking?</li>\n",
+    "        <li>What are the steps to take to ensure the molecule(s) and prtiens are ready?</li>\n",
+    "        <li>What are steps we can optionally perform to get better or more tailored results?</li>\n",
+    "    </ul>\n",
+    "\n",
+    "    <strong>Objectives:</strong>\n",
+    "    <ul>\n",
+    "        <li>Learn about the \"missing\" information in molecular structure files</li>\n",
+    "        <li>Learn how to use a specific set of tools (among many) to prepare your files</li>\n",
+    "        <li>Understand nuance of the programs we work with to modify our preparation workflow</li>\n",
+    "    </ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "iSUEJHDGfxJY"
+   },
+   "source": [
+    "This notebook will walk you through the process for going from RCSB files crystallographic data to docking-ready input files. The structures from the RCSB, and the corresponding files, are incomplete for the purposes of Docking (and molecular mechanics simulations generally). We'll walk through both the programmatic and visual issues with the protein and molecule files, and explicitly show what data are missing.\n",
+    "\n",
+    "For this notebook, you'll install one particular set of tools for this prep workflow, but many are available and some are linked throughout this lesson.\n",
+    "\n",
+    "\n",
+    "# Set Up\n",
+    "\n",
+    "Before going into any details, we'll be installing all the packages we need for this notebook. Specifically for the actual prep workflow we'll install:\n",
+    "* `PDBFixer`\n",
+    "* `MDAnalysis`\n",
+    "* `RDKit`\n",
+    "* `OpenMM` (and `OpenMMForceFields`)\n",
+    "* `OpenBabel`\n",
+    "* `Scrubber` (package: \"`molscrub`\")\n",
+    "\n",
+    "We'll also install a few helper packages for visualization  and analysis. These are not explicitly needed for the workflow, but will aid in seeing what we are doing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "CdTmiOgEGyhR"
+   },
+   "outputs": [],
+   "source": [
+    "# Initial setup to enable Conda installable packages through CoLab\n",
+    "!pip install -q condacolab\n",
+    "import condacolab\n",
+    "\n",
+    "condacolab.install()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Z8us0ezuJyYY"
+   },
+   "outputs": [],
+   "source": [
+    "# Install our main workflow packages, this should take about a minute\n",
+    "%%capture output\n",
+    "!conda install -c conda-forge rdkit pdbfixer openmm openmmforcefields mdanalysis molscrub"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "G-Kx7_XUmwv0"
+   },
+   "outputs": [],
+   "source": [
+    "# Install OpenBabel into the system as well\n",
+    "# OpenBabel is also available through Conda-Forge and PyPI (pip), but we wanted to show that you need not be limited by where a package comes from, just get it.\n",
+    "%%capture output\n",
+    "!apt install openbabel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "35pTzMcBKAZO"
+   },
+   "outputs": [],
+   "source": [
+    "# Install our visual renderer for the workbook.\n",
+    "%%capture output\n",
+    "!pip install py3Dmol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_FgzTMQSIRnp"
+   },
+   "source": [
+    "## Downloading Protein Structure Files\n",
+    "\n",
+    "First and foremost, we need a protein to work with. We're going to look at the [SARS-CoV-2 3CL Protease structure of 7LME from the RCSB](https://www.rcsb.org/structure/7LME).\n",
+    "\n",
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://cdn.rcsb.org/images/structures/7lme_assembly-1.jpeg?raw=true\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+    "</div>\n",
+    "\n",
+    "Image from RCSB\n",
+    "\n",
+    "We'll start by downloading this using the Python built-in `requests` package to make a `GET` REST request for the file. Effectively, this is our Python interpreter asking the RCSB site for a file directly at a specific location, a URL in this case. You can try this in your browser too! If you download or visit the page: https://files.rcsb.org/download/7LME.pdb, you'll get this exact text file; we're just doing it programmatically.\n",
+    "\n",
+    "For our molecule, we know what ligand is bound to the structure from the RCSB page, `Y6J`, and we'll extract that as part of the process.\n",
+    "\n",
+    "Note: You don't have to know the terminology of HTTP methods such as `GET` for this course, but it's helpful to know REST APIs are how most websites serve their information.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "_ij8X3Z9OqVp"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "\n",
+    "pdb_id = \"7LME\"  # The Protein ID we're looking at\n",
+    "\n",
+    "# Start by making a directory for us to work in and stage our intermediate files\n",
+    "protein_directory = \"docking_files\"\n",
+    "protein_filename = f\"{pdb_id}.pdb\"\n",
+    "protein_filepath = os.path.join(protein_directory, protein_filename)\n",
+    "# Actually make the directory, the exist_ok flag lets the command execute even if the folder already exists. It does NOT overwrite existing data.\n",
+    "os.makedirs(protein_directory, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "7ba7-a03nAVY"
+   },
+   "outputs": [],
+   "source": [
+    "# Download the protein file\n",
+    "print(f\"Downloading protein {pdb_id}...\")\n",
+    "protein_url = f\"https://files.rcsb.org/download/{pdb_id}.pdb\"\n",
+    "# Dont break the RCSB!\n",
+    "protein_url = f\"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/main/data/{pdb_id}.pdb\"\n",
+    "# Send the request and save the returned JSON blob as a variable\n",
+    "protein_request = requests.get(protein_url)\n",
+    "protein_request.raise_for_status()  # Check for errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "5EDsODvVna0R"
+   },
+   "outputs": [],
+   "source": [
+    "# Save the actual text of the returned JSON blob as the PDB file we're used to\n",
+    "with open(protein_filepath, \"w\") as f:\n",
+    "    f.write(protein_request.text)\n",
+    "print(f\"Saved protein to {protein_filepath}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eT9cjO4MnvTa"
+   },
+   "source": [
+    "## Visualizing the raw PDB File\n",
+    "\n",
+    "We've downloaded our file from the RCSB, let's take a look at what we have and identify some issues for docking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ktFtsE9HoBTD"
+   },
+   "outputs": [],
+   "source": [
+    "import py3Dmol\n",
+    "\n",
+    "v = py3Dmol.view()\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
+    "v.setStyle({\"chain\": \"A\"}, {\"cartoon\": {\"color\": \"#0e9674\"}})\n",
+    "v.setStyle({\"chain\": \"B\"}, {\"cartoon\": {\"color\": \"#c46225\"}})\n",
+    "v.zoomTo({\"model\": 0})\n",
+    "v.rotate(90, \"z\")\n",
+    "v.rotate(-25, \"y\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "agfLHnkltUf3"
+   },
+   "source": [
+    "The rendered molecule rotation and colors should be approximately  the same as the image from the RCSB's page.\n",
+    "\n",
+    "On its face, it looks good. But let's add a few small changes to how we're doing the rendering to see more."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rZrdekxU2u4M"
+   },
+   "outputs": [],
+   "source": [
+    "v = py3Dmol.view()\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
+    "v.setStyle({\"chain\": \"A\"}, {\"cartoon\": {\"color\": \"#0e9674\"}})\n",
+    "v.setStyle({\"chain\": \"B\"}, {\"cartoon\": {\"color\": \"#c46225\"}})\n",
+    "# Selecting HETATM\n",
+    "v.setStyle({\"hetflag\": True}, {\"stick\": {\"color\": \"spectrum\"}})\n",
+    "# Selecting objects with no bonds, i.e. water\n",
+    "v.setStyle({\"bonds\": 0}, {\"sphere\": {\"radius\": 0.5}})\n",
+    "v.zoomTo({\"model\": 0})\n",
+    "v.rotate(90, \"z\")\n",
+    "v.rotate(-25, \"y\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aWcA3mI32vNQ"
+   },
+   "source": [
+    "You can see from the render that py3Dmol is rendering much more than just the dimer and its chains. There is some of this present inside the RCSB image as well, but here we have much more. Before we delve into exactly why we can't just use this for docking, let's cover what we actually need for a docking run:\n",
+    "\n",
+    "* Atomistic level coordinates of receptor (here: protein)\n",
+    "* Connectivity of receptor (*can* be inferred, not always)\n",
+    "* Polar hydrogen and partial charges for receptor\n",
+    "* Where on the receptor we want to dock\n",
+    "* Atomistic level coordinates of ligand (here: small molecule)\n",
+    "* Partial charge and protonation states for ligand\n",
+    "* Descriptor of how atoms interact with each other\n",
+    "\n",
+    "This may seem like a daunting list to compile from just a PDB file, but the software we're using makes many of these steps automatic for us."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 99
+    },
+    "id": "WFny3Wrmj-gS",
+    "outputId": "03fdbb9f-216c-4f2b-c507-98f9f4e69aa2"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.info { /* Based on Bootstrap Secondary Alert */\n",
+       "    color: #0c5460; /* Darker shade of blue for text */\n",
+       "    background-color: #d1ecf1; /* Light blue background */\n",
+       "    border-left: 5px solid #459db9; /* Bright blue border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.info ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.info li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"info\">\n",
+       "\n",
+       "<strong>Note: Not all docking needs all of these items</strong>\n",
+       "\n",
+       "<p>This list is not fully accurate for shape-based docking; this workshop focuses on force/physics/simulation-based docking.\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title\n",
+    "%%html\n",
+    "<style>\n",
+    "div.info { /* Based on Bootstrap Secondary Alert */\n",
+    "    color: #0c5460; /* Darker shade of blue for text */\n",
+    "    background-color: #d1ecf1; /* Light blue background */\n",
+    "    border-left: 5px solid #459db9; /* Bright blue border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.info ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.info li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"info\">\n",
+    "\n",
+    "<strong>Note: Not all docking needs all of these items</strong>\n",
+    "\n",
+    "<p>This list is not fully accurate for shape-based docking; this workshop focuses on force/physics/simulation-based docking.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_7xLGokmk_eC"
+   },
+   "source": [
+    "## Building Atomistic Receptor Model\n",
+    "\n",
+    "Only looking at the render above, it's not immediately  obvious if we have all the coordinates. One way we can look at this is by checking the PDB file we downloaded. The box below loads the file we pulled down here, but you can use any editor you like to view the file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "MQFpbLQvApQ5"
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import display, HTML\n",
+    "\n",
+    "\n",
+    "def render_text(text_blob):\n",
+    "    # Helper function for displaying text in Jupyter Notebooks in a scrollable object\n",
+    "    html = f\"\"\"\n",
+    "      <div style=\"height:400px; overflow:auto;\">\n",
+    "          <pre>{text_blob}</pre>\n",
+    "      </div>\n",
+    "      \"\"\"\n",
+    "    display(HTML(html))\n",
+    "\n",
+    "\n",
+    "render_text(protein_request.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3TBTDjyZBsyj"
+   },
+   "source": [
+    "Searching for the word \"missing\" shows at `REMARK` 465 and 470 that there are missing residues and atoms respectively. If we were doing shape-based docking, we might be able to get away with not having those residues if they don't contribute to the docking site, but is that a risk we really want to take? And we're not doing shape-based docking anyways, so we need those residues and atoms.\n",
+    "\n",
+    "For instance, let’s look at the tyrosines in our molecule to show the problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "k6KHQ9AOC_MT"
+   },
+   "outputs": [],
+   "source": [
+    "v = py3Dmol.view()\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
+    "v.setStyle()  # Clear all other styles\n",
+    "# Select all tyrosines that are not our problematic one\n",
+    "v.setStyle(\n",
+    "    {\"resn\": \"TYR\", \"not\": {\"resi\": 154}}, {\"stick\": {\"radius\": 0.1, \"color\": \"blue\"}}\n",
+    ")\n",
+    "# Missing atoms tyrosine\n",
+    "v.setStyle({\"resi\": 154}, {\"stick\": {\"radius\": 0.1, \"color\": \"red\"}})\n",
+    "v.zoomTo({\"model\": 0})\n",
+    "v.rotate(90, \"z\")\n",
+    "v.rotate(-25, \"y\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aBfH4Ls_-Wnu"
+   },
+   "source": [
+    "As you can see, those red residues are not fully atomistic tyrosines. That is something we'll have to fix.\n",
+    "\n",
+    "Beyond just missing and incomplete residues, there are atoms in our PDB file which are simply not the receptor (protein). Specifically the crystallographic waters and the bound ligand in the PDB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VhYREiXcuR50"
+   },
+   "outputs": [],
+   "source": [
+    "v = py3Dmol.view()\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
+    "# Select ligand\n",
+    "v.setStyle(\n",
+    "    {\"hetflag\": True, \"not\": {\"resname\": \"HOH\"}}, {\"stick\": {\"color\": \"spectrum\"}}\n",
+    ")\n",
+    "# Select waters\n",
+    "v.setStyle({\"resn\": \"HOH\", \"elem\": \"O\"}, {\"sphere\": {\"radius\": 0.5, \"color\": \"red\"}})\n",
+    "v.setStyle({\"resn\": \"HOH\", \"elem\": \"H\"}, {\"sphere\": {\"radius\": 0.5, \"color\": \"blue\"}})\n",
+    "v.zoomTo({\"model\": 0})\n",
+    "v.rotate(90, \"z\")\n",
+    "v.rotate(-25, \"y\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Nolxz_qy_0tz"
+   },
+   "source": [
+    "The rendering above shows that there are two ligands (stick representation) and many crystallographic waters (red dots). We expect there to be two bound ligands here that are roughly in symmetric locations because this is a dimer structure made of two chains.\n",
+    "\n",
+    "Since we're exploring docking of different molecules in the binding sites, we're going to want to remove the currently present ligand so we can test other ones. We're also going to want to remove the crystallographic waters as they usually (not always) contribute to binding and will slow down our docking procedure. We'll also only be picking one of the binding sites (specifically the pocket in \"Chain A\") to reduce computational time.\n",
+    "\n",
+    "## Cleaning the Receptor PDB Structure\n",
+    "\n",
+    "The good news for most of the issues with the receptor structure is its a regular protein with standard residues. We've studied those and can fill in the missing information reliably.\n",
+    "\n",
+    "For this workshop, we're going to be using a tool from the OpenMM Library called `PDBFixer` which is a tool that you can use to \"fix\" PDB files and prepare them for physics-based calculations. There are many other tools which can do these steps for you as well, but we're keeping within the OpenMM ecosystem of tools as an example of a way to approach a docking pipeline.\n",
+    "\n",
+    "Examples of other tools to fix PDB structures are\n",
+    "[Modeller](https://salilab.org/modeller/),\n",
+    "[Amber's LEaP](https://ambermd.org/tutorials/pengfei/), and\n",
+    "[GalaxyFill (which is used by CHARMM-GUI)](https://seoklab.github.io/GalaxyFill/). Others also exist, so find the one that works for you.\n",
+    "\n",
+    "We could have instructed that everyone should just \"run these commands\" since the protein is regular in its construction, but understanding why the commands are needed is important for novel research and issues which may arise in your own works. We'll see this at the end when we jump a bit ahead to look at the impact some of our choice made."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "3m5I1YrlCSfs"
+   },
+   "outputs": [],
+   "source": [
+    "# Load the PDB into the PDBFixer class\n",
+    "from pdbfixer import PDBFixer\n",
+    "\n",
+    "fixer = PDBFixer(filename=f\"{protein_directory}/{pdb_id}.pdb\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "W98orn1xDrsf"
+   },
+   "source": [
+    "Next we're going to solve the missing residues problem through the `findMissingResidues` method. This doesn't actually do anything to the structure, yet, its just compiling a list of atoms and coordinates on each chain that it *will* add when we call the corresponding command. That way, the user has the option to customize what is \"fixed\" on the protein."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "JU3b0NmiEV-z"
+   },
+   "outputs": [],
+   "source": [
+    "fixer.findMissingResidues()\n",
+    "fixer.missingResidues"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LP-xn3keEfy1"
+   },
+   "source": [
+    "You can see that our list of missing residues matches the one in the `REMARK` section of the base PDB file.\n",
+    "\n",
+    "Next we're going to identify any non-standard residues in our structure as well as provide suggested replacements. We'll also be issuing the command to make the suggested substitutions. You can customize what is substituted by modifying the `nonstandardResidues` attribute, or do mutations with `applyMutations`. Neither are required for this structure, but helpful to have in your pipeline as this can allow you to substitute residues."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "B0pQgiFcFPdA"
+   },
+   "outputs": [],
+   "source": [
+    "fixer.findNonstandardResidues()\n",
+    "print(fixer.nonstandardResidues)\n",
+    "fixer.replaceNonstandardResidues()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LomqlRQsGIm9"
+   },
+   "source": [
+    "Next, we'll strip out all of the crystallographic waters and the ligands from our structure by telling `PDBFixer` to remove the \"heterogen\" atoms. We'll also see a list of things which have been removed from the structure. You may notice that `PDBFixer` notes a Chain 2, 3, and 4 instead of Chain A, B as present in the PDB file. That is because `PDBFixer` distinguishes \"chains\" as atom groupings for bookkeeping purposes, but correctly will reassemble them in the topology at the end."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "yHgA0apSGUF6"
+   },
+   "outputs": [],
+   "source": [
+    "fixer.removeHeterogens(keepWater=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HiQZUSnkHp5R"
+   },
+   "source": [
+    "We took care of the missing residues, but that doesn't account for existing residues with missing atoms. The next step is adding the missing heavy atoms of our protein from the residues already present. This command will also identify missing terminals and add those as well. In theory, we could have done this before removing the water and ligands, but because this command can actually add in the missing terminals (if needed), we recommend removing waters first so there is less chance of steric clashes with the addition of an C/N-terminal from free-standing waters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "o2Z3JMppH1mn"
+   },
+   "outputs": [],
+   "source": [
+    "fixer.findMissingAtoms()\n",
+    "print(fixer.missingAtoms)\n",
+    "print(fixer.missingTerminals)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "X_e5gsnnIAdX"
+   },
+   "source": [
+    "Now we can fix our missing heavy atoms (hydrogens are more complicated) with one command. This will take care of both missing and incomplete residues because we collected them all earlier with `findMissingResidues` and `findMissingAtoms`. This step takes a small amount of time because there is an energy minimization step going on behind the scenes to reduce steric clashes from injecting new atoms into our structure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "3aQjOpMBIGxg"
+   },
+   "outputs": [],
+   "source": [
+    "fixer.addMissingAtoms()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7ln1_Be_KVg5"
+   },
+   "source": [
+    "Let's write out our PDB file and see what it looks like"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "QD7I2UylKUcX"
+   },
+   "outputs": [],
+   "source": [
+    "from openmm.app import PDBFile\n",
+    "\n",
+    "with open(f\"{protein_directory}/{pdb_id}_fix_heavy.pdb\", \"w\") as f:\n",
+    "    # Toplology, Positions, file stream, and keep chain ID's\n",
+    "    PDBFile.writeFile(fixer.topology, fixer.positions, f, True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "sCCkIi_jO_bm"
+   },
+   "outputs": [],
+   "source": [
+    "# Property to get a topology object, works well as a quick summary of structure.\n",
+    "fixer.topology"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qxWh-dxxLCr9"
+   },
+   "outputs": [],
+   "source": [
+    "v = py3Dmol.view()\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}_fix_heavy.pdb\").read())\n",
+    "v.setStyle({\"chain\": \"A\"}, {\"cartoon\": {\"color\": \"#0e9674\"}})\n",
+    "v.setStyle({\"chain\": \"B\"}, {\"cartoon\": {\"color\": \"#c46225\"}})\n",
+    "# Check for ligand\n",
+    "v.setStyle(\n",
+    "    {\"hetflag\": True, \"not\": {\"resname\": \"HOH\"}}, {\"stick\": {\"color\": \"spectrum\"}}\n",
+    ")\n",
+    "# Check for water\n",
+    "v.setStyle({\"resn\": \"HOH\", \"elem\": \"O\"}, {\"sphere\": {\"radius\": 0.5, \"color\": \"red\"}})\n",
+    "v.setStyle({\"resn\": \"HOH\", \"elem\": \"H\"}, {\"sphere\": {\"radius\": 0.5, \"color\": \"blue\"}})\n",
+    "# Look at our problematic tyrosines again to see they are all-atom finally\n",
+    "v.setStyle({\"resi\": 154}, {\"stick\": {\"radius\": 0.2, \"color\": \"red\"}})\n",
+    "v.zoomTo({\"model\": 0})\n",
+    "v.rotate(90, \"z\")\n",
+    "v.rotate(-25, \"y\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VkqXlQOmJkse"
+   },
+   "source": [
+    "What we can see is that all the atoms we wanted are gone, all the atoms we added are present, and we have our protein structure of heavy atoms. We'll now deal with the fact that the hydrogens are all still missing as we need those for our physics-based docking.\n",
+    "\n",
+    "More specifically, we need the correct protonation states for a given pH on our residues. If you're working with a united atom or more generally coarse-grained model, you technically don't need to have atomistic hydrogens. However, we're working with a fully atomistic model, so we'll be including them.\n",
+    "\n",
+    "`PDBFixer` takes in pH information and optionally an atomic Force Field to add its hydrogens. If no force field is provided, it will assume positions that are generally reasonable, but not optimized. It should also be noted that no extensive electrostatic analysis is performed here, assuming default residue pKa's. For this example, we'll be pulling positions from the [Amber ff14SB](https://pubs.acs.org/doi/10.1021/acs.jctc.5b00255) force field natively available to OpenMM."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Qiu22MrmN44_"
+   },
+   "outputs": [],
+   "source": [
+    "# Import the ForceField object to access built-ins (or custom if you have them)\n",
+    "from openmm.app import ForceField\n",
+    "\n",
+    "# Use the Amber ff14SB Force Field. This path is relative to OpenMM's internal\n",
+    "# references, not the local directory.\n",
+    "forcefield = ForceField(\"amber/protein.ff14SB.xml\")\n",
+    "# also accepts a \"pH\" argument, default is pH=7.0\n",
+    "fixer.addMissingHydrogens(forcefield=forcefield)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jrmZyhi8bLst"
+   },
+   "source": [
+    "Note that we didn't specify a pH here, so the default of 7.0 is assumed. The expierment for the 7LME structure was done at a pH of 7.5. Does this matter for our result? \"Maybe.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "1nK1Js3yOohT"
+   },
+   "outputs": [],
+   "source": [
+    "with open(f\"{protein_directory}/{pdb_id}_all_atom.pdb\", \"w\") as f:\n",
+    "    # Toplology, Positions, file stream, and keep chain ID's\n",
+    "    PDBFile.writeFile(fixer.topology, fixer.positions, f, True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "v0CvkE8vOvbB"
+   },
+   "outputs": [],
+   "source": [
+    "v = py3Dmol.view()\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}_all_atom.pdb\").read())\n",
+    "v.setStyle({\"chain\": \"A\"}, {\"cartoon\": {\"color\": \"#0e9674\"}})\n",
+    "v.setStyle({\"chain\": \"B\"}, {\"cartoon\": {\"color\": \"#c46225\"}})\n",
+    "v.zoomTo({\"model\": 0})\n",
+    "v.rotate(90, \"z\")\n",
+    "v.rotate(-25, \"y\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TT_GKvNfG-UB"
+   },
+   "outputs": [],
+   "source": [
+    "fixer.topology"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "N5cSIUVaPqcf"
+   },
+   "source": [
+    "By re-building our protein file with this pipeline, we've also taken care of the connectivity and the partial charges of the hydrogens on our receptor.\n",
+    "\n",
+    "### Additional Considerations for our Receptor Structure\n",
+    "\n",
+    "Because we're doing physics-based docking; we need to take into account the physics we are attempting to understand with respect to not only what we've done to our receptor, but also what methods and algorithms we're going to be subjecting to it.\n",
+    "\n",
+    "Let us first look ahead to figure out what program we're going to run for docking. We'll be using a program called [`gnina`](https://github.com/gnina/gnina) which is based on [smina](https://sourceforge.net/projects/smina/), which itself is based on [AutoDock Vina](https://github.com/ccsb-scripps/AutoDock-Vina), which itself uses a type of [Iterated Local Search](https://pmc.ncbi.nlm.nih.gov/articles/PMC3041641/) optimizer. For our purposes, all of that means we're only going to need the polar hydrogens on our receptor. The rest of the hydrogens can be ignored... or can they?\n",
+    "\n",
+    "Depending on the program(s) you chose, the behavior of your calculations may change even with the same input. `gnina`, the program we're using, assumes any hydrogens present on the input file we're going to generate here are polar hydrogens and uses them for calculations, it won't check first for us with how we're making our files. The instructors looked ahead and found if you leave all the hydrogens on your receptor, you get less accurate results for the reason that they're all treated as polar. Other codes may check this for you and simply remove or disable the non-polar hydrogens."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 158
+    },
+    "id": "BnhqwY97UPpT",
+    "outputId": "76b1a2e0-469e-4d38-cfaf-342d68df8cb3"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.warning { /* Based on Bootstrap Warning */\n",
+       "    color: #856404; /* Darker shade of yellow-brown for text */\n",
+       "    background-color: #fff3cd; /* Light faded yellow background */\n",
+       "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.info ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.info li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"warning\">\n",
+       "\n",
+       "<strong>Important: Understand your methods and software!</strong>\n",
+       "\n",
+       "<p>We're going to show actions you can do to modify your structure as examples.\n",
+       "<p> Most of this remaining section uses ideas and methods which themselves are based in physics and can make intuitive sense, but\n",
+       "  make this particular system less accurate when we dock with Gnina.\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title\n",
+    "\n",
+    "%%html\n",
+    "<style>\n",
+    "div.warning { /* Based on Bootstrap Warning */\n",
+    "    color: #856404; /* Darker shade of yellow-brown for text */\n",
+    "    background-color: #fff3cd; /* Light faded yellow background */\n",
+    "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.info ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.info li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"warning\">\n",
+    "\n",
+    "<strong>Important: Understand your methods and software!</strong>\n",
+    "\n",
+    "<p>We're going to show actions you can do to modify your structure as examples.\n",
+    "<p> Most of this remaining section uses ideas and methods which themselves are based in physics and can make intuitive sense, but\n",
+    "  make this particular system less accurate when we dock with Gnina.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eVbE2g8PV0yV"
+   },
+   "source": [
+    "## Relaxing the Receptor Structure with Hydrogens Present"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 61
+    },
+    "id": "3TPbk1pPV1HR",
+    "outputId": "736e8592-01b5-467c-918d-5e345caf00d7"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.warning { /* Based on Bootstrap Warning */\n",
+       "    color: #856404; /* Darker shade of yellow-brown for text */\n",
+       "    background-color: #fff3cd; /* Light faded yellow background */\n",
+       "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.info ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.info li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"warning\">\n",
+       "\n",
+       "<strong>Reminder: Additional energy minimization makes our current system worse for docking.</strong>\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title\n",
+    "%%html\n",
+    "<style>\n",
+    "div.warning { /* Based on Bootstrap Warning */\n",
+    "    color: #856404; /* Darker shade of yellow-brown for text */\n",
+    "    background-color: #fff3cd; /* Light faded yellow background */\n",
+    "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.info ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.info li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"warning\">\n",
+    "\n",
+    "<strong>Reminder: Additional energy minimization makes our current system worse for docking.</strong>\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FDBPHZBQTm3s"
+   },
+   "source": [
+    "We have added new atoms to our structure based on their predictable location as standard residues, specifically the hydrogens. However, standard residues or not, the atoms we added may still cause large steric and electrostatic clashes that we want to relax before docking.\n",
+    "\n",
+    "There was a short minimization which took place when we ran the `addMissingAtoms` commands, but that was only with the heavy atoms and only on the pairwise interactions the atoms which were added vs atoms which were already present (i.e. nonbonded interactions between unmodified atoms were ignored for speed, something you only know when [looking at the source code](https://github.com/openmm/pdbfixer/blob/master/pdbfixer/pdbfixer.py#L1277-L1279)). This process effectively minimized the impact removing the crystallographic waters and the ligand had- as well as the addition of hydrogens had on the structure of the protein."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 158
+    },
+    "id": "Oypyds6OYYFe",
+    "outputId": "c5ec4fad-8502-415a-af21-6dc4566705a2"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.info { /* Based on Bootstrap Secondary Alert */\n",
+       "    color: #0c5460; /* Darker shade of blue for text */\n",
+       "    background-color: #d1ecf1; /* Light blue background */\n",
+       "    border-left: 5px solid #459db9; /* Bright blue border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.info ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.info li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"info\">\n",
+       "\n",
+       "<strong>Do neglecting those changes we made impact the structure and docking? Maybe!</strong>\n",
+       "\n",
+       "<p>Each system is different and many papers have been written about each of the\n",
+       "  steps we've done and will do and their potential impact.\n",
+       "<p> Take our current protein as a specific example. Consider how the protein structure was found and at what temperature it was generated.\n",
+       "  The 7LME structure we're crystalized by <a href=\"https://www.rcsb.org/experimental/7LME\">room temperature droplets for X-ray diffraction</a>; however, other structures may have been found via Cryo-EM and be generated at different temperatures.\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title\n",
+    "%%html\n",
+    "<style>\n",
+    "div.info { /* Based on Bootstrap Secondary Alert */\n",
+    "    color: #0c5460; /* Darker shade of blue for text */\n",
+    "    background-color: #d1ecf1; /* Light blue background */\n",
+    "    border-left: 5px solid #459db9; /* Bright blue border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.info ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.info li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"info\">\n",
+    "\n",
+    "<strong>Do neglecting those changes we made impact the structure and docking? Maybe!</strong>\n",
+    "\n",
+    "<p>Each system is different and many papers have been written about each of the\n",
+    "  steps we've done and will do and their potential impact.\n",
+    "<p> Take our current protein as a specific example. Consider how the protein structure was found and at what temperature it was generated.\n",
+    "  The 7LME structure we're crystalized by <a href=\"https://www.rcsb.org/experimental/7LME\">room temperature droplets for X-ray diffraction</a>; however, other structures may have been found via Cryo-EM and be generated at different temperatures.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NAUNyY1RYYMj"
+   },
+   "source": [
+    "Let's assume we actually do want a fully relaxed structure. If we were to do another energy minimization now, the binding sites would likely start to collapse due to the removal of the ligand. This would most likely be observed if we were to run an equilibration dynamics simulation to a much more extreme degree. We do wish to have some preservation of the binding site's in our minimization so we can dock new ligands in place.\n",
+    "\n",
+    "An alternate option would be to re-insert the ligand, do an energy minimization, and then run a short dynamics simulation to generate a structure from the equilibrium distribution at the conditions you're interested in. This is often something you'll need to do if you don't have a starting crystal structure! However, molecular mechanics/dynamics are beyond the scope of this course, even if we'll be taking similar initial steps.\n",
+    "\n",
+    "Did the addition of the hydrogens and the removal of the waters matter here? \"Maybe.\" Could we skip this step entirely? \"Maybe.\" It's important to understand the protein and the site you're working with on a case-by-case basis to accurately answer these questions. You can always just try and see what happens! We happen to know the answer is \"yes, we can skip it\" for our current problem, but that's not always the case."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qeIoAyFUfNMU"
+   },
+   "source": [
+    "#### Simple Energy Minimization\n",
+    "\n",
+    "Energy minimizations of structures generally don't perturb the structure all that much when we're looking at before and after coordinates. If you consider the [Lennard-Jones](https://en.wikipedia.org/wiki/Lennard-Jones_potential) + point-charge potential that many classical molecular mechanics codes use for their pairwise potentials, steric clashes (and even electrostatic ones) are dominated by a $1/r^{12}$ scaling energy term at short ranges. Although the interactions are more complicated than this, energy minimization algorithms primarily help minimize that term, so the binding site *might* be minimally perturbed by a simple minimization. Even when we set-up a more complex minimization later, we'll still end with these basic steps.\n",
+    "\n",
+    "We'll perform a simple minimization with OpenMM while also exploring a bit about how OpenMM defines molecular environments for dynamics. Every program will be different, and as we've alluded to, knowing your programs are important for accurate scientific results. To setup this minimization, we'll first define a minimal simulation environment with OpenMM.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "t6KDtkQnhpjJ"
+   },
+   "outputs": [],
+   "source": [
+    "# Create OpenMM system for minimization\n",
+    "system = forcefield.createSystem(fixer.topology)\n",
+    "\n",
+    "# Show our forces as OpenMM understands them\n",
+    "system.getForces()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gYBMP4Wrhtu0"
+   },
+   "source": [
+    "OpenMM defines its `System` object as the collection of `Forces` which act on a set of mass-bearing particles in a molecular \"system.\" That is, neither the positions nor the time evolution of these forces, but instead just the collection of interactions. The concept of bonds, chains, residue names, and all the information in the PDB has been converted into a base 0-indexed list of generic particles in the `System`.\n",
+    "\n",
+    "We can take the molecular `System` in combination with an `Integrator` to say how the `Forces` should propagate to define our `Simulation`. For that, we will need an integrator to satisfy OpenMM, even though its logic is not used for the energy minimization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "XzrLs3EAi_J6"
+   },
+   "outputs": [],
+   "source": [
+    "from openmm import VerletIntegrator\n",
+    "from openmm.app import Simulation\n",
+    "import openmm.unit as unit\n",
+    "\n",
+    "# Use a generic VerletIntegrator\n",
+    "integrator = VerletIntegrator(0.001 * unit.picoseconds)\n",
+    "\n",
+    "# Create simulation for minimization\n",
+    "# Optional, if you have access to a CUDA GPU, comment out the next line and uncomment the one after it\n",
+    "platform = None\n",
+    "# platform = Platform.getPlatformByName('CUDA')\n",
+    "\n",
+    "# Define the OpenMM Simulation object, which serves as a convenince wrapper for the OpenMM Context and Reporter objects\n",
+    "simulation = Simulation(fixer.topology, system, integrator, platform)\n",
+    "# Set the position of our atoms\n",
+    "simulation.context.setPositions(fixer.positions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8NbMONjujKzB"
+   },
+   "source": [
+    "A small peak under the hood: The data `System` have been fed into the `Context` class constructor along with the `Integrator` which the `Simulation` class wraps around. The `System` is then compiled into a platform-specific implementation (CPU, CUDA, OpenCL) and bound to the `Integrator`. The `Integrator` is the class used to step forward in time, the `System` is decoupled, and the `Context` could be used entirely without a `Simulation` object.\n",
+    "\n",
+    "We have now set up a simulation-ready object, so we can now do our minimzation which will update the positions. This step will take a small amount of time.\n",
+    "\n",
+    "OpenMM did most of these steps for us when we ran `addMissingAtoms` earlier, it just had extra logic for only minimizing new atom positions rather than all atom positions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "L_C8iZ3CkmPP"
+   },
+   "outputs": [],
+   "source": [
+    "# Minimize energy\n",
+    "print(\"Minimizing energy...\")\n",
+    "simulation.minimizeEnergy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aYkDM7tfkqH_"
+   },
+   "source": [
+    "Up until now, we've also done similar steps if we wanted to take our molecular system and run dynamics on it. We would need enough atoms to define our system (all-atom here), and then a minimized structure under some physical conditions. Because we are using the leap-frog Verlet Integrator which has no temperature coupling (like a Langevin Integrator), and because we have no pressure coupling (which OpenMM uses a Monte Carlo Barostat `Force` to scale box vectors), we would be running a constant number of particles, volume, energy simulation (NVE) if we were to propagate time. It would be a 1 fs timestep, which may take a while to sample enough configurations to run statistics, but it would run.\n",
+    "\n",
+    "For now, let's leave the world of molecular dynamics and get back to docking by getting our minimized coordinates out of the RAM of the compute hardware to save."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "WmjyS2NzkxOP"
+   },
+   "outputs": [],
+   "source": [
+    "# Get minimized positions. We have to copy the positions of the compiled object back into Python's memory\n",
+    "minimized_positions = simulation.context.getState(getPositions=True).getPositions()\n",
+    "\n",
+    "# Write minimized structure to a PDB file\n",
+    "with open(f\"{protein_directory}/{pdb_id}_fixed.pdb\", \"w\") as output:\n",
+    "    PDBFile.writeFile(fixer.topology, minimized_positions, output)\n",
+    "\n",
+    "print(\n",
+    "    f\"Minimization complete. Minimized structure saved to {protein_directory}/{pdb_id}_fixed_simple.pdb\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "icYnXoCWl0hI"
+   },
+   "source": [
+    "We also may want to actually look at our binding site at some point, so let's define some helper objects to select the residues around the binding site with MDAnalysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "_xdsRn1el9jP"
+   },
+   "outputs": [],
+   "source": [
+    "# Determine residues nearby the ligand with MDAnalysis\n",
+    "import MDAnalysis as mda\n",
+    "\n",
+    "# Load the original PDB\n",
+    "u = mda.Universe(f\"{protein_directory}/{pdb_id}.pdb\")\n",
+    "\n",
+    "# Select atoms using the MDAnalysis selection language\n",
+    "ligand_select = \"segid A and record_type HETATM and not resname HOH\"\n",
+    "ligand = u.select_atoms(ligand_select)\n",
+    "\n",
+    "# Find and residues within a certain distance from the ligand\n",
+    "active_site = u.select_atoms(\n",
+    "    \"around 3.5 group ligand and segid A\", periodic=False, ligand=ligand\n",
+    ")  # Uses generic select_name=object as kwargs\n",
+    "print(active_site.residues.resids)\n",
+    "print(ligand.residues.resids)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "38zdzUtRxR8_"
+   },
+   "source": [
+    "#### Restrained Minimzation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 99
+    },
+    "id": "GQke3jnNwxQc",
+    "outputId": "619d7426-ae9b-49ac-e32e-27c06d298a88"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.warning { /* Based on Bootstrap Warning */\n",
+       "    color: #856404; /* Darker shade of yellow-brown for text */\n",
+       "    background-color: #fff3cd; /* Light faded yellow background */\n",
+       "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.info ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.info li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"warning\">\n",
+       "\n",
+       "<strong>This section is skipped in the online workshop for time and complexity.</strong>\n",
+       "<p> However, this is a powerful tool in OpenMM and for dynamics generally.\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title\n",
+    "%%html\n",
+    "<style>\n",
+    "div.warning { /* Based on Bootstrap Warning */\n",
+    "    color: #856404; /* Darker shade of yellow-brown for text */\n",
+    "    background-color: #fff3cd; /* Light faded yellow background */\n",
+    "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.info ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.info li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"warning\">\n",
+    "\n",
+    "<strong>This section is skipped in the online workshop for time and complexity.</strong>\n",
+    "<p> However, this is a powerful tool in OpenMM and for dynamics generally.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bA8-EeeWfFqT"
+   },
+   "source": [
+    "Sometimes, we may want to run a minimization or dynamics in a way where certain regions may want to be preserved. One way to do that is to restrain the binding site to a certain shape.\n",
+    "\n",
+    "To help preserve our binding site, we're going to select the residues near the original ligand and restrain the heavy atoms with a spherical harmonic restraint around their coordinates. We'll be applying a bit of a simple approach by looking at the residues within a certain distance from the ligand in one chain. Remember: we're not looking for a perfect structure, just one that doesn't have steric clashes which will cause problems for docking. `PDBFixer` can't do this for us, so we either need to measure the distances ourselves and pick out the residues with vector math, or we can use other tools like `MDAnalysis`, [ProLIF](https://prolif.readthedocs.io/en/stable/), and others."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LArGO6gn0lgd"
+   },
+   "source": [
+    "Using list of residues around our binding site, we can visualize the binding site. In this rendering, we're only showing the residues near the ligand and the ligand itself. The colors on the surface are just for visual distinction and do not indicate any electronegativity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "z5OQfeoof-A_"
+   },
+   "outputs": [],
+   "source": [
+    "v = py3Dmol.view()\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
+    "v.setStyle()\n",
+    "v.setStyle(\n",
+    "    {\"resi\": ligand.residues.resids.tolist(), \"chain\": \"A\"},\n",
+    "    {\"stick\": {\"color\": \"spectrum\"}},\n",
+    ")\n",
+    "v.addSurface(\n",
+    "    \"VDW\",\n",
+    "    {\"opacity\": 0.5},\n",
+    "    {\"resi\": active_site.residues.resids.tolist(), \"chain\": \"A\"},\n",
+    ")\n",
+    "v.zoomTo({\"chain\": \"A\"})\n",
+    "v.rotate(90, \"z\")\n",
+    "v.rotate(-25, \"y\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gm0PjLYmmIkt"
+   },
+   "source": [
+    "We've now picked out our ligand and the nearby residues we want to select from. Now we want to perform a small energy minimization procedure with OpenMM while keeping the heavy atoms restrained in spherical harmonic shells to keep the binding site open. To setup this modified minimization, we'll first define a new simulation environment with OpenMM. We could have re-used the system we previously made, but to keep things separate we'll make a new one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "eoC4HPtTm51g"
+   },
+   "outputs": [],
+   "source": [
+    "# Create OpenMM system for minimization\n",
+    "system_restrain = forcefield.createSystem(fixer.topology)\n",
+    "\n",
+    "# Show our forces\n",
+    "system_restrain.getForces()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Erc0gQI-nZ7O"
+   },
+   "source": [
+    "This is so far identical to our original system.\n",
+    "\n",
+    "We're now going to create a new force by defining a `Force` object with OpenMM, specifically the `CustomExternalForce`. OpenMM's `Custom*Force` objects allow us to write potential energy strings which can be added to any `System` and subsequent simulation and behave as a force just like nonbonded, bonded, and other forces. We'll be borrowing from [the OpenMM Cookbook](https://openmm.github.io/openmm-cookbook/latest/notebooks/cookbook/Restraining%20Atom%20Positions.html) for this step, so feel free to look their for additional information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "EXu2QbN4pX0y"
+   },
+   "outputs": [],
+   "source": [
+    "from openmm import CustomExternalForce\n",
+    "import openmm.unit as unit\n",
+    "\n",
+    "# Define the external force for our particles using a string\n",
+    "# This one is a simple spring harmonic force\n",
+    "# Uses built-in function for handling harmonics over periodic distances\n",
+    "restraint = CustomExternalForce(\"k*periodicdistance(x, y, z, x0, y0, z0)^2\")\n",
+    "# Add the force to our system.\n",
+    "# WARNING: If you run this cell again, it will add this force, again, and double up its effect\n",
+    "system_restrain.addForce(restraint)\n",
+    "# Define what the custom per-particle and global parameters are\n",
+    "# This can be done before or after adding the force to the System because\n",
+    "# the Python-side objects have not been converted into hardware-specific/compiled code\n",
+    "restraint.addGlobalParameter(\"k\", 100.0 * unit.kilojoules_per_mole / unit.nanometer**2)\n",
+    "restraint.addPerParticleParameter(\"x0\")\n",
+    "restraint.addPerParticleParameter(\"y0\")\n",
+    "restraint.addPerParticleParameter(\"z0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yYw0bpIjrNIZ"
+   },
+   "source": [
+    "Now let's add the heavy atoms of the residues near the binding site to our `CustomNonbondedForce` (`restraint`) to keep them in place."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zHDO8xzAs13u"
+   },
+   "outputs": [],
+   "source": [
+    "# Cycle through residues with generator. We could also start on chains and then\n",
+    "# break after 1 cycle for tiny optimization, not really needed here.\n",
+    "for residue in fixer.topology.residues():\n",
+    "    # Skip over residues we dont care about\n",
+    "    # Both MDAnalysis and OpenMM are 0-index based, no need to shift by 1\n",
+    "    if residue.index in active_site.residues.resids:\n",
+    "        # Loop over atoms in the residue with generator\n",
+    "        for atom in residue.atoms():\n",
+    "            # Check for heavy atoms\n",
+    "            if atom.element.symbol != \"H\":\n",
+    "                # Add atom to the restraint force\n",
+    "                # We add the index (which topology and system match) as first arg\n",
+    "                # We then add the iterable of the per-particle parameters, which in\n",
+    "                # this case is the coordinate, as the centroid of the harmonic restraint\n",
+    "                restraint.addParticle(atom.index, fixer.positions[atom.index])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RuJv2YctyVUd"
+   },
+   "source": [
+    "We've now added the heavy atoms to our `restraint` `CustomExternalForce` which has also already been added to our `System` object. We can check that the number of atoms added to the restraint is less than the number of atoms in the system by looking at the particle count the restraint is tracking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "E2qkRYQ7vAC8"
+   },
+   "outputs": [],
+   "source": [
+    "restraint.getNumParticles()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rCVUd8T6yvwx"
+   },
+   "source": [
+    "And if we look at our `system`, we can see our new restraint there and ready to be set up for a simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "_z0BN1kgy0lQ"
+   },
+   "outputs": [],
+   "source": [
+    "system_restrain.getForces()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "UTS19Ztjy56p"
+   },
+   "source": [
+    "The rest of the setup for a new minimization is the same as before. We'll need to make a new `Integrator` since our original one is bound to our original simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rzJg2M8gnW3u"
+   },
+   "outputs": [],
+   "source": [
+    "# Use a generic VerletIntegrator\n",
+    "integrator_restrain = VerletIntegrator(0.001 * unit.picoseconds)\n",
+    "\n",
+    "# Create simulation for minimization\n",
+    "# Optional, if you have access to a CUDA GPU, comment out the next line and uncomment the one after it\n",
+    "platform = None\n",
+    "# platform = Platform.getPlatformByName('CUDA')\n",
+    "\n",
+    "# Define the OpenMM Simulation object, which serves as a convenince wrapper for the OpenMM Context and Reporter objects\n",
+    "simulation_restrain = Simulation(\n",
+    "    fixer.topology, system_restrain, integrator_restrain, platform\n",
+    ")\n",
+    "# Set the position of our atoms\n",
+    "simulation_restrain.context.setPositions(fixer.positions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3GyANE0M0gQ7"
+   },
+   "source": [
+    "And just like last time, we run our minimization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "aYyKPinO0wwm"
+   },
+   "outputs": [],
+   "source": [
+    "# Minimize energy\n",
+    "print(\"Minimizing energy...\")\n",
+    "simulation_restrain.minimizeEnergy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Gp0-ZGiA1j0u"
+   },
+   "source": [
+    "And save our final coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "N_OLAqVm1mza"
+   },
+   "outputs": [],
+   "source": [
+    "# Get minimized positions. We have to copy the positions of the compiled object back into Python's memory\n",
+    "min_res_positions = simulation_restrain.context.getState(\n",
+    "    getPositions=True\n",
+    ").getPositions()\n",
+    "\n",
+    "# Write minimized structure to a PDB file\n",
+    "with open(f\"{protein_directory}/{pdb_id}_restrain.pdb\", \"w\") as output:\n",
+    "    PDBFile.writeFile(fixer.topology, min_res_positions, output)\n",
+    "\n",
+    "print(\n",
+    "    f\"Minimization complete. Minimized structure saved to {protein_directory}/{pdb_id}_restrain.pdb\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dWGoujcC4Ft5"
+   },
+   "source": [
+    "## Comparing the minimized structure to the original"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MTQxMQIf4lcL"
+   },
+   "source": [
+    "To see the impact of our efforts, we can visualize our structure, and compare it to the original."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Oc4ZH6-22KSe"
+   },
+   "outputs": [],
+   "source": [
+    "v = py3Dmol.view()\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}_fixed.pdb\").read())\n",
+    "v.setStyle({\"chain\": \"A\"}, {\"cartoon\": {\"color\": \"#0e9674\"}})\n",
+    "v.setStyle({\"chain\": \"B\"}, {\"cartoon\": {\"color\": \"#c46225\"}})\n",
+    "v.zoomTo({\"model\": 0})\n",
+    "v.rotate(90, \"z\")\n",
+    "v.rotate(-25, \"y\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hRxzrol52ILk"
+   },
+   "source": [
+    "On quick visual inspection, it might be hard to see if anything is different. Instead, we will superimpose our final structure superimposed over our original, using MDAnalysis to align them. The entire block below may seem daunting, but that is only because our final structure has a different number of atoms compared to our original structure, we have to be clever about how to pick a set of atoms from each structure to get equal sized sets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Am0ezUW34R-F"
+   },
+   "outputs": [],
+   "source": [
+    "from MDAnalysis.analysis import align\n",
+    "\n",
+    "# Load the final PDB\n",
+    "u_fixed = mda.Universe(f\"{protein_directory}/{pdb_id}_fixed.pdb\")\n",
+    "\n",
+    "# IF the number of CA atoms matched between the structures, this next line\n",
+    "# would be all you need. Instead, we have to do a bit more.\n",
+    "\n",
+    "# align.alignto(u_fixed, u, select=\"name CA\", weights=\"mass\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 99
+    },
+    "id": "0-fbQdEi6VT8",
+    "outputId": "b7be35c8-0e57-4e52-e948-154d8def54ec"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.info { /* Based on Bootstrap Secondary Alert */\n",
+       "    color: #0c5460; /* Darker shade of blue for text */\n",
+       "    background-color: #d1ecf1; /* Light blue background */\n",
+       "    border-left: 5px solid #459db9; /* Bright blue border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.info ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.info li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"info\">\n",
+       "\n",
+       "<strong>Note: This is just one possible choice of alignment!</strong>\n",
+       "\n",
+       "<p>I'm choosing to align to the Alpha Carbons, but you may want to align to something else.\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title\n",
+    "%%html\n",
+    "<style>\n",
+    "div.info { /* Based on Bootstrap Secondary Alert */\n",
+    "    color: #0c5460; /* Darker shade of blue for text */\n",
+    "    background-color: #d1ecf1; /* Light blue background */\n",
+    "    border-left: 5px solid #459db9; /* Bright blue border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.info ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.info li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"info\">\n",
+    "\n",
+    "<strong>Note: This is just one possible choice of alignment!</strong>\n",
+    "\n",
+    "<p>I'm choosing to align to the Alpha Carbons, but you may want to align to something else.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "JwUJ-jfy561M"
+   },
+   "outputs": [],
+   "source": [
+    "# Note: Other options would work besides alpha carbons\n",
+    "fixed_alphas = u_fixed.select_atoms(\"name CA\")\n",
+    "ref_alphas = u.select_atoms(\"name CA\")\n",
+    "\n",
+    "unmatched_fixed_residues = []\n",
+    "ref_res_index = 0\n",
+    "for idx, residue in enumerate(fixed_alphas.residues):\n",
+    "    # Check for exceeding the original structure. Some new residues may not be aligned, thats okay\n",
+    "    if ref_res_index > len(ref_alphas.residues) - 1:\n",
+    "        continue\n",
+    "    # A simple check to see if its the same residue at an index\n",
+    "    fixed_res_name = residue.resname\n",
+    "    ref_res_name = ref_alphas.residues[ref_res_index].resname\n",
+    "    if (\n",
+    "        fixed_res_name != ref_res_name\n",
+    "    ):  # Residues are different, which will only happen because we added the missing ones\n",
+    "        unmatched_fixed_residues.append(idx)\n",
+    "        # Move on the main one to find the next out of place resiude\n",
+    "        continue\n",
+    "    ref_res_index += 1\n",
+    "\n",
+    "# Not an elegant selection string, but works well enough for us\n",
+    "ref_select = \"name CA and segid A\"\n",
+    "fixed_select = (\n",
+    "    \"name CA and segid A and not \"\n",
+    "    + \"(resid \"\n",
+    "    + \" or resid \".join(str(fix) for fix in unmatched_fixed_residues)\n",
+    "    + \")\"\n",
+    ")\n",
+    "selection_dict = {\"mobile\": fixed_select, \"reference\": ref_select}\n",
+    "print(f\"Fixed Structure Selection String: '{fixed_select}'\")\n",
+    "print(f\"Original Structure Selection String: '{ref_select}'\")\n",
+    "\n",
+    "align.alignto(u_fixed, u, select=selection_dict, weights=\"mass\")\n",
+    "\n",
+    "# Now write the aligned structure out.\n",
+    "all_fixed_atoms = u_fixed.select_atoms(\"all\")\n",
+    "all_fixed_atoms.write(f\"{protein_directory}/{pdb_id}_aligned.pdb\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "R2v_NroR6_r8"
+   },
+   "source": [
+    "Our aligned structure is now just another PDB, so lets load the two structures together."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TjfCTTIZSKAp"
+   },
+   "outputs": [],
+   "source": [
+    "# Visualize the alignment\n",
+    "v = py3Dmol.view()\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}_aligned.pdb\").read())\n",
+    "v.setStyle({\"model\": 0}, {\"cartoon\": {\"color\": \"#0e9674\"}})\n",
+    "v.setStyle({\"model\": 1}, {\"cartoon\": {\"color\": \"#c46225\"}})\n",
+    "v.zoomTo({\"model\": 0})\n",
+    "v.rotate(90, \"z\")\n",
+    "v.rotate(-25, \"y\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vNaLxzkx7U61"
+   },
+   "source": [
+    "And we can look at how our binding site has changed (if at all)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2I8S7XZB7FA0"
+   },
+   "outputs": [],
+   "source": [
+    "v = py3Dmol.view()\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}_aligned.pdb\").read())\n",
+    "v.setStyle()\n",
+    "v.addSurface(\n",
+    "    \"VDW\",\n",
+    "    {\"opacity\": 0.75, \"color\": \"#0e9674\"},\n",
+    "    {\"resi\": active_site.residues.resids.tolist(), \"chain\": \"A\", \"model\": 0},\n",
+    ")\n",
+    "v.addSurface(\n",
+    "    \"VDW\",\n",
+    "    {\"opacity\": 0.75, \"color\": \"#c46225\"},\n",
+    "    {\"resi\": active_site.residues.resids.tolist(), \"chain\": \"A\", \"model\": 1},\n",
+    ")\n",
+    "v.zoomTo({\"chain\": \"A\"})\n",
+    "v.rotate(90, \"z\")\n",
+    "v.rotate(-25, \"y\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4fnK3Rjk7r09"
+   },
+   "source": [
+    "We now have the protein in a relaxed structure with all atoms present while performing minimal adjustments to the binding site."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 61
+    },
+    "id": "RjaLOAs-7qL8",
+    "outputId": "2564a82e-1538-4904-bc3f-87b2c8784665"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.warning { /* Based on Bootstrap Warning */\n",
+       "    color: #856404; /* Darker shade of yellow-brown for text */\n",
+       "    background-color: #fff3cd; /* Light faded yellow background */\n",
+       "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.info ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.info li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"warning\">\n",
+       "\n",
+       "<strong>The next visualization requires the Restrained Minimization from above to have been run</strong>\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title\n",
+    "%%html\n",
+    "<style>\n",
+    "div.warning { /* Based on Bootstrap Warning */\n",
+    "    color: #856404; /* Darker shade of yellow-brown for text */\n",
+    "    background-color: #fff3cd; /* Light faded yellow background */\n",
+    "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.info ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.info li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"warning\">\n",
+    "\n",
+    "<strong>The next visualization requires the Restrained Minimization from above to have been run</strong>\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0l5KLWxE9lMw"
+   },
+   "source": [
+    "If you ran the restrained minimization, we can also compare its binding pocket as well. Overlapping three visual surfaces probably isn't very clear, so you may wish to use a more quantitative measure such as RMSD."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "S4xtq_1E7_Cy"
+   },
+   "outputs": [],
+   "source": [
+    "# We'll skip some steps and align our \"fixed\" structure to our \"restrained\" structure\n",
+    "u_res = mda.Universe(f\"{protein_directory}/{pdb_id}_restrain.pdb\")\n",
+    "align.alignto(u_res, u_fixed, select=\"name CA\", weights=\"mass\")\n",
+    "\n",
+    "# Now write the aligned structure out.\n",
+    "all_restrained_atoms = u_res.select_atoms(\"all\")\n",
+    "all_restrained_atoms.write(f\"{protein_directory}/{pdb_id}_restrain_aligned.pdb\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "S-ZUSI5886au"
+   },
+   "outputs": [],
+   "source": [
+    "v = py3Dmol.view()\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}.pdb\").read())\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}_aligned.pdb\").read())\n",
+    "v.addModel(open(f\"{protein_directory}/{pdb_id}_restrain_aligned.pdb\").read())\n",
+    "v.setStyle()\n",
+    "v.addSurface(\n",
+    "    \"VDW\",\n",
+    "    {\"opacity\": 0.75, \"color\": \"#0e9674\"},\n",
+    "    {\"resi\": active_site.residues.resids.tolist(), \"chain\": \"A\", \"model\": 0},\n",
+    ")\n",
+    "v.addSurface(\n",
+    "    \"VDW\",\n",
+    "    {\"opacity\": 0.75, \"color\": \"#c46225\"},\n",
+    "    {\"resi\": active_site.residues.resids.tolist(), \"chain\": \"A\", \"model\": 1},\n",
+    ")\n",
+    "v.addSurface(\n",
+    "    \"VDW\",\n",
+    "    {\"opacity\": 0.75, \"color\": \"#4287f5\"},\n",
+    "    {\"resi\": active_site.residues.resids.tolist(), \"chain\": \"A\", \"model\": 2},\n",
+    ")\n",
+    "v.zoomTo({\"chain\": \"A\"})\n",
+    "v.rotate(90, \"z\")\n",
+    "v.rotate(-25, \"y\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "B4JEGQd7-N0I"
+   },
+   "outputs": [],
+   "source": [
+    "from MDAnalysis.analysis.rms import RMSD\n",
+    "\n",
+    "# Select our residues\n",
+    "residue_select = \"resid \" + \" or resid \".join(\n",
+    "    str(x) for x in active_site.residues.resids\n",
+    ")\n",
+    "residue_select = \"name CA and (\" + residue_select + \")\"\n",
+    "print(residue_select)\n",
+    "\n",
+    "fixed_select_rmsd = u_fixed.select_atoms(residue_select)\n",
+    "restrined_select_rmsd = u_res.select_atoms(residue_select)\n",
+    "ref_select_rmsd = u.select_atoms(residue_select)\n",
+    "\n",
+    "rmsd_fixed = (\n",
+    "    RMSD(fixed_select_rmsd, reference=ref_select_rmsd, weights=\"mass\")\n",
+    "    .run()\n",
+    "    .results.rmsd\n",
+    ")\n",
+    "rmsd_restrined = (\n",
+    "    RMSD(restrined_select_rmsd, reference=ref_select_rmsd, weights=\"mass\")\n",
+    "    .run()\n",
+    "    .results.rmsd\n",
+    ")\n",
+    "print(f\"RMSD of binding site Alpha Carbons after basic minimization: {rmsd_fixed}\")\n",
+    "print(\n",
+    "    f\"RMSD of binding site Alpha Carbons after restrained minimization: {rmsd_restrined}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fds1KWNBTcZA"
+   },
+   "source": [
+    "## Adding Partial Charge Information to the Receptor for Docking\n",
+    "\n",
+    "Molecular docking can sometimes require charge information about the protein in order to correctly handle the physics calculations. Many programs for docking specifically (i.e. the `gnina` program we'll use next, or e.g. Autodock VINA) can use an extended PDB format called PDBQT. Although we technically assigned charges when we did the minimization with the Amber ff14SB force field, those were kept in OpenMM for dynamics simulations. If we want those partial charges in our docking, we need to either take those partial charges from our `System` and write them out to a PDBQT file (for which OpenMM does not have nor should have a writer for), OR, we can use a program like `OpenBabel` to write the file for us from our completed structure.\n",
+    "\n",
+    "This workshop will use docking scoring functions that don't require the partial charges, but we'll show you how to generate them should you choose to need them.\n",
+    "\n",
+    "Technically speaking, MDAnalysis can write to PDBQT file formats, but doesn't have auto-charge generation. We're choosing to show another program which also supports auto-charge generation and is still quite popular today."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "R4gRY0NhXNmQ"
+   },
+   "outputs": [],
+   "source": [
+    "# Invoke OpenBabel's CLI from Python. Can also use subprocess as its safer, but os.system works fine here.\n",
+    "receptor_pdbqt_path = f\"{protein_directory}/{pdb_id}.pdbqt\"\n",
+    "recepetor_fixed_path = f\"{protein_directory}/{pdb_id}_fixed.pdb\"\n",
+    "# Generate the PDBQT file.\n",
+    "# We could have \"--partialcharge <method>\" as a flag if we wanted to compute the partial charges, but this will just assume they are all \"0\"\n",
+    "# The \"-xh\" flag preserves the hydrogens we worked so hard to get.\n",
+    "os.system(f\"obabel -ipdb {recepetor_fixed_path} -opdbqt -O {receptor_pdbqt_path}\")\n",
+    "\n",
+    "# If you get a status code \"2\" here, rerun it. You want status code 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HG6yVycDDXI_"
+   },
+   "source": [
+    "OpenBabel is doing quite alot behind the scenes for us. Because we've specified that we want a PDBQT file, OpenBabel is stripping out all of the non-polar hydrogens from our system. We could have added an [additional flag](https://open-babel.readthedocs.io/en/latest/FileFormats/AutoDock_PDBQT_format.html) to the command in the form of `-xh`, which tells the PDBQT writter to keep all hydrogens (`x` indicates flags for outputs, `h` is hydrogen). We also could have specified a `--partialcharge` method in the command to have OpenBabel place partial charges on our receptor.\n",
+    "\n",
+    "Did we need to do either of those flags though? For our case: No. In fact, for our case, its actually a bad idea. Why though? We have to understand our tools to know why.\n",
+    "\n",
+    "What impact does the `-xh` flag have?\n",
+    "* If we only provide a PDB file to `gnina`, it will automatically strip out any non-polar hydrogens.\n",
+    "* If we give a PDBQT file to `gnina` though, it will use the file **as is**. That means all hydrogens present in the file will be treated as polar hydrogens; which can and do give erroneous results. Not all codes will make this assumption though.\n",
+    "\n",
+    "What impact does the `--partialcharge` flag have?\n",
+    "* We're not using a docking method that need partial charges, so adding the charges doesn't change the result at all (we tested this to make sure). Some actually do use this information and without the flag, it assigns a partial charge of 0 to all atoms, which will give you incorrect results when charges are needed.\n",
+    "* Computing partial charges does take more time, so if you're running this command with some regularity, its just adding empty compute time when not needed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bFsiJwDSGCcm"
+   },
+   "source": [
+    "Congratulations! We've now prepped our receptor protein molecule for docking. We still need to do the ligand, which has less regular data we can draw from (such as adding in missing hydrogens based on standard residues), but the process is still straightforward, and in fewer steps often.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 61
+    },
+    "id": "LIZPRaHiF_-_",
+    "outputId": "3a172a6a-6055-4ee0-f4c6-8d2450e3bb1e"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.info { /* Based on Bootstrap Secondary Alert */\n",
+       "    color: #0c5460; /* Darker shade of blue for text */\n",
+       "    background-color: #d1ecf1; /* Light blue background */\n",
+       "    border-left: 5px solid #459db9; /* Bright blue border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.info ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.info li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"info\">\n",
+       "\n",
+       "<strong>Workshop: Checkpoint for Questions</strong>\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title\n",
+    "%%html\n",
+    "<style>\n",
+    "div.info { /* Based on Bootstrap Secondary Alert */\n",
+    "    color: #0c5460; /* Darker shade of blue for text */\n",
+    "    background-color: #d1ecf1; /* Light blue background */\n",
+    "    border-left: 5px solid #459db9; /* Bright blue border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.info ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.info li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"info\">\n",
+    "\n",
+    "<strong>Workshop: Checkpoint for Questions</strong>\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7wdporBGXN4b"
+   },
+   "source": [
+    "# Building Atomistic Ligand Model\n",
+    "\n",
+    "Let's review what we need to prepare our ligand for docking from our list above:\n",
+    "\n",
+    "* Where on the receptor we want to dock\n",
+    "* Atomistic level coordinates of ligand (here: small molecule)\n",
+    "* Partial charge and protonation states for ligand\n",
+    "* Descriptor of how atoms interact with each other\n",
+    "\n",
+    "Going down the list one at a time, we can work to build our ligand."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Qya8dZfGwdUg"
+   },
+   "source": [
+    "## Where on the Receptor We Want to Dock\n",
+    "\n",
+    "The location we want to dock to can be programmatically determined from the experimentally bound ligand itself. Some docking programs, including the `gnina` program we'll be using, determine the docking location based on an existing ligand and a buffer zone around it. We'll need to make sure its location is well defined, especially because we pulled it's experimental positions out of the binding site earlier before relaxing. In practice, this step will be resolved with the following ones on its own. We could also use a tool like `MDAnalysis` to define our binding region (similar to how we identified nearby residues to the ligand) and provide that for the search grid into our program.\n",
+    "\n",
+    "This process works well when you already know the rough region of the receptor you want to dock to. You'll have to identify active and/or target sites through other means if you don't already have this information; which in itself is a whole field of research beyond the scope here.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VXo-0dpZwfAl"
+   },
+   "source": [
+    "## Atomistic Level Coordinates of Ligand\n",
+    "\n",
+    "Looking at the original PDB file, we can see that our ligand doesn't have hydrogens either. That is not surprising, however, we can't \"fix\" this problem in the same was as we did the protein because a ligand doesn't have the concept of \"standard\" components the same way a protein does. It still follows chemistry though, so we can still fill in the missing information; lucky us!\n",
+    "\n",
+    "The RCSB keeps a record of all the ligands it has in its structures as well. Much in the same way it codes proteins, it does the same for ligands. We'll pull down the \"ideal\" structure for this ligand to make sure we get the correct chemistry for it, and then modify it for our purposes. The \"ideal\" structures are those which have been constructed with optimized bonds, collisions, and alignments for computational analysis; as opposed to the coordinates found in experimental structures. They will be 3D, but you might not always have a ligand which has a 3D structure provided (especially given the information there are $10^{60}$ possible small molecules following Lipinski's rule-of-five and at least 166.4 billion enumerated since 2015; see [The Chemical Space Project](https://pubs.acs.org/doi/10.1021/ar500432k)). For now, let's focus on what we do have.\n",
+    "\n",
+    "We know the ID for this ligand from the PDB file is \"Y6J\" and *could* use that in our code. However, if you're screening many compounds, you may not want to manually look at every PDF file to find the alpha-numeric ID for the ligand(s), so lets extract it programmatically with tools we already have."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "tRy31gUqtONM"
+   },
+   "outputs": [],
+   "source": [
+    "# Reloading the fixed protein in case restrained minimization block wasn't run\n",
+    "import MDAnalysis as mda\n",
+    "\n",
+    "# Load the original PDB\n",
+    "u = mda.Universe(f\"{protein_directory}/{pdb_id}.pdb\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rJEggYkPhTwB"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "# This works well enough for single bound ligand, but is not general for more complicated or non-standard PDB codes\n",
+    "ligands = u.select_atoms(\"not protein and not water\")\n",
+    "ligand_residue_names = ligands.residues.resnames\n",
+    "# This is a dimer, so pull out one name.\n",
+    "ligand_id = np.unique(ligand_residue_names)[0]\n",
+    "print(ligand_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "eGrw95tElNA-"
+   },
+   "outputs": [],
+   "source": [
+    "# Pull the ideal ligand from the RCSB\n",
+    "ligand_directory = \"ligand_structures\"\n",
+    "os.makedirs(ligand_directory, exist_ok=True)\n",
+    "\n",
+    "ideal_ligand_filename = f\"{ligand_id}_ideal.sdf\"\n",
+    "print(f\"Downloading ligand {ligand_id}...\")\n",
+    "ligand_url = f\"https://files.rcsb.org/ligands/download/{ideal_ligand_filename}\"\n",
+    "# dont break the RCSB for the workshop\n",
+    "ligand_url = f\"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/main/data/{ideal_ligand_filename}\"\n",
+    "ligand_request = requests.get(ligand_url)\n",
+    "ligand_request.raise_for_status()  # Check for errors\n",
+    "\n",
+    "ideal_filepath = f\"{ligand_directory}/{ideal_ligand_filename}\"\n",
+    "\n",
+    "with open(ideal_filepath, \"w\") as f:\n",
+    "    f.write(ligand_request.text)\n",
+    "print(f\"Saved ligand to {ideal_filepath}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EmgTv6d6m09r"
+   },
+   "source": [
+    "And we can look at this file much like we did the PDB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Bcr5zy1xm0bY"
+   },
+   "outputs": [],
+   "source": [
+    "# Helper function from above\n",
+    "render_text(ligand_request.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fxEeOi5cm_Zy"
+   },
+   "source": [
+    "The Structured Data File (SDF) format is great for small molecules, including multiple molecules in one file, full coordinates for all atoms, bond type information, formal charge information (although 0 here), and supports other metadata not present in this particular file.\n",
+    "\n",
+    "This ideal structure has plenty of information that the structure in the experimental PDB is missing, however, it also has coordinates which have no relation to how this molecule will be configured in the active site we're investigating. So we'll need to map the information from one to the other. We can start by pulling the coordinates from the PDB file and saving those. Even if we test other ligands that were not experimentally bound, we'll need the originally bound ligand in our specific workflow to define the active site box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "CqFT47FWptS8"
+   },
+   "outputs": [],
+   "source": [
+    "# Split the ligand out into its own PDB file from the experimental one\n",
+    "\n",
+    "# Use only Chain A since this is a dimer and our target site for docking\n",
+    "single_pose_ligand = ligand.select_atoms(\"segid A\")\n",
+    "single_pose_ligand.write(f\"{ligand_directory}/{ligand_id}_fromPDB.pdb\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tQKnlr6Are6N"
+   },
+   "source": [
+    "MDAnalyis [cannot write SDF files](https://userguide.mdanalysis.org/stable/formats/index.html#id10), but we're only really interested in the heavy atom coordinates so the PDB file format is fine for our purposes.\n",
+    "\n",
+    "The tools we've worked with so far in prep are not built to handle bond orders and other types of chemistry we'll need to map the two ligands onto each other. So we'll instead be using RDKit to do that. Specifically, we need to map the bond orders and hydrogens from our ideal molecule onto the coordinates from the experimental pose. RDKit can handle that in a few lines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "RavzgbRMskJ9"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit import Chem\n",
+    "from rdkit.Chem import AllChem\n",
+    "\n",
+    "# Load and remove the hydrogens that we can't map anyways yet.\n",
+    "ideal_mol = Chem.MolFromMolFile(\n",
+    "    f\"{ligand_directory}/{ligand_id}_ideal.sdf\", removeHs=True\n",
+    ")\n",
+    "pose_mol = Chem.MolFromPDBFile(\n",
+    "    f\"{ligand_directory}/{ligand_id}_fromPDB.pdb\", removeHs=True\n",
+    ")\n",
+    "\n",
+    "# Assign bond orders from the template to the pose molecule\n",
+    "corrected_pose = AllChem.AssignBondOrdersFromTemplate(ideal_mol, pose_mol)\n",
+    "\n",
+    "# Add hydrogens back to the corrected pose\n",
+    "corrected_pose_with_H = Chem.AddHs(corrected_pose, addCoords=True)\n",
+    "\n",
+    "# Sanity to check to make sure the molecule is right (check smiles of both)\n",
+    "assert Chem.MolToSmiles(corrected_pose) == Chem.MolToSmiles(ideal_mol)\n",
+    "\n",
+    "# Save the corrected pose to an SDF file\n",
+    "ligand_corrected_pose_file = f\"{ligand_directory}/{ligand_id}_corrected_pose.sdf\"\n",
+    "writer = Chem.SDWriter(ligand_corrected_pose_file)\n",
+    "writer.write(corrected_pose_with_H)\n",
+    "writer.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "GpiMRNYdtuhK"
+   },
+   "outputs": [],
+   "source": [
+    "# Compare the two models\n",
+    "v = py3Dmol.view()\n",
+    "v.addModel(open(f\"{ligand_directory}/{ligand_id}_fromPDB.pdb\").read())\n",
+    "v.addModel(open(f\"{ligand_corrected_pose_file}\").read())\n",
+    "# v.setStyle()\n",
+    "v.setStyle({\"model\": 0}, {\"stick\": {\"color\": \"#0e9674\"}})\n",
+    "v.setStyle({\"model\": 1}, {\"stick\": {\"color\": \"#c46225\"}})\n",
+    "v.zoomTo({\"model\": 0})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6IdSfQaguwBc"
+   },
+   "source": [
+    "You can see in the overlaid rendering here that both the original experimental pose (green) and the structure corrected pose (brown) are present, but the structure corrected one has the added hydrogens.\n",
+    "\n",
+    "We now have a fully atomistic ligand and for some docking programs, this is all we need to do. We've got a bit more to do to have the docking program we want to use, `gnina` behave."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "xegDiRrFzOba"
+   },
+   "source": [
+    "### Partial Charge for the Ligand\n",
+    "\n",
+    "We won't explicitly be needing the partial charges for our small molecule as we won't need them pre-defined for docking here. If you want to make your own partial charges for ligands, you can use an array of tools such as\n",
+    "[Amber's `antechamber`](https://ambermd.org/antechamber/ac.html#antechamber),\n",
+    "[Open Free Energy's charging CLI](https://docs.openfree.energy/en/latest/tutorials/charge_molecules_cli_tutorial.html),\n",
+    "[OpenEye's `molcharge`](https://docs.eyesopen.com/toolkits/cpp/quacpactk/molchargetheory.html),\n",
+    "and OpenBabel (like we'll do here) to name a few.\n",
+    "\n",
+    "We'll be generating a PDBQT file for our ligand just like we did with the receptor due to a quirk in how `gnina` runs its code. If you do *not* provide a PDBQT file, `gnina` will run OpenBabel behind the scenes and strip out all the hydrogens we worked so hard to build up. Not every code does this mind you, but in order to preserve our work, we're going to make a PDBQT file for our ligand so the hydrogens will be preserved.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "30SRmo5N7a1Z"
+   },
+   "outputs": [],
+   "source": [
+    "# Create our PDBQT to keep our hydrogens\n",
+    "ligand_simple_pdbqt_filename = f\"{ligand_directory}/{ligand_id}_obabel.pdbqt\"\n",
+    "os.system(f\"obabel {ligand_corrected_pose_file} -O {ligand_simple_pdbqt_filename} -xh\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "84ki26MC9ZLf"
+   },
+   "source": [
+    "If you want just a single basic resonant structure of your ligand, than you're likely ready to go! However, we may not always want just one structure, especially if we can build tautomers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "oBGUCfnf0P32"
+   },
+   "source": [
+    "### Building Ligand Tautomers and Protomers\n",
+    "\n",
+    "Tautomers and protomers, especially in the biosciences, can drastically change the interactions between a ligand and receptor. One example of this is in drug chemistry where one tautomer may form in compounding, and then decay to another while the drug is on the shelf. If we only explore resonance structures, or only one tautomer of a ligand, then we may miss critical interactions which have real-world impacts later.\n",
+    "\n",
+    "For the purposes of this workshop, I'm referring to \"protomer\" as the moving of a single proton on a small molecule to generate different tautomers, usually as a result of pH. As such, I'll treat them roughly the same and will just use \"tautomer\" for word choice, even if you can get multiple tautomers at a fixed pH.\n",
+    "\n",
+    "Generating tautomers is no easy task, I strongly recommend looking through the literature on this topic to better understand what we'll be doing here. We'll be using `RDKit` and [`Scrubber`](https://github.com/forlilab/molscrub); from the lab which also makes [`meeko`](https://meeko.readthedocs.io/en/release-doc/); to generate our tautomers. You can use these programs separately, or together (`Scrubber` uses `RDKit` under the hood with extra logic). There is also an [excellent blog post by Jeremy Monat](https://bertiewooster.github.io/2024/05/01/Tautomer-Sources-Comparison.html) which compares tautomer generation codes from 2024, one of which we'll be using here.\n",
+    "\n",
+    "Even though tautomers themselves can be complicated, our tool developers have taken great strides to make it as straightforward as possible to generate said tautomers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 131
+    },
+    "id": "btmju_oV-wTd",
+    "outputId": "a928e583-7d08-4399-9890-ec2dc5f1f91e"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.warning { /* Based on Bootstrap Warning */\n",
+       "    color: #856404; /* Darker shade of yellow-brown for text */\n",
+       "    background-color: #fff3cd; /* Light faded yellow background */\n",
+       "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.info ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.info li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"warning\">\n",
+       "\n",
+       "<strong>Meeko doesn't work for this protein system</strong>\n",
+       "\n",
+       "<p>We didn't use Meeko to prepare our protein because it makes infernces based on atomic distances about bonds.\n",
+       "\n",
+       "<p>This dimer structure has interatomic distances which make some atoms bonded that should not be, so we had to take other steps to prepare the receptor.\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title\n",
+    "%%html\n",
+    "<style>\n",
+    "div.warning { /* Based on Bootstrap Warning */\n",
+    "    color: #856404; /* Darker shade of yellow-brown for text */\n",
+    "    background-color: #fff3cd; /* Light faded yellow background */\n",
+    "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.info ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.info li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"warning\">\n",
+    "\n",
+    "<strong>Meeko doesn't work for this protein system</strong>\n",
+    "\n",
+    "<p>We didn't use Meeko to prepare our protein because it makes infernces based on atomic distances about bonds.\n",
+    "\n",
+    "<p>This dimer structure has interatomic distances which make some atoms bonded that should not be, so we had to take other steps to prepare the receptor.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "8-bdg56H44cH"
+   },
+   "outputs": [],
+   "source": [
+    "# Check our molecule from RDKit. Doesn't have rotation, but its neat to see in a Jupyer Notebook for just invoking it\n",
+    "corrected_pose_with_H"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bRMB2GZinpSS"
+   },
+   "source": [
+    "RDKit can help us generate tautomers, however, RDKit also works on the principal that hydrogens are generally implicit (i.e. `removeHs=True`, default). If you leave hydrogens in your structure, [you can get some very odd and incorrect results depending on what you are doing](https://www.rdkit.org/docs/source/rdkit.Chem.rdmolops.html#rdkit.Chem.rdmolops.AddHs). So we'll work with the structure before we added hydrogens."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 99
+    },
+    "id": "AzRt3wzerSly",
+    "outputId": "ec994b30-8143-403a-ad4c-a7fc08d03689"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.info { /* Based on Bootstrap Secondary Alert */\n",
+       "    color: #0c5460; /* Darker shade of blue for text */\n",
+       "    background-color: #d1ecf1; /* Light blue background */\n",
+       "    border-left: 5px solid #459db9; /* Bright blue border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.info ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.info li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"info\">\n",
+       "\n",
+       "<strong>RDKit's Tautomer Enumeration routine generates ALL POSSIBLE tautomers</strong>\n",
+       "\n",
+       "<p>Not all tautomers are stable, or even energetically favored, especially with at certain pH. Without additional logic and code, this is just a set of all possible ones.\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title\n",
+    "%%html\n",
+    "<style>\n",
+    "div.info { /* Based on Bootstrap Secondary Alert */\n",
+    "    color: #0c5460; /* Darker shade of blue for text */\n",
+    "    background-color: #d1ecf1; /* Light blue background */\n",
+    "    border-left: 5px solid #459db9; /* Bright blue border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.info ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.info li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"info\">\n",
+    "\n",
+    "<strong>RDKit's Tautomer Enumeration routine generates ALL POSSIBLE tautomers</strong>\n",
+    "\n",
+    "<p>Not all tautomers are stable, or even energetically favored, especially with at certain pH. Without additional logic and code, this is just a set of all possible ones.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "C5yBSTWDrNMh"
+   },
+   "source": [
+    "Further Reading: [RDKit has a blogpost](https://rdkit.blogspot.com/2020/01/trying-out-new-tautomer.html) with a helpful function to re-order tautomers with the canonical one first. Take a look if you're interested. Note: [\"Canonical\" does not mean most stable, and is likely not the most stable](https://www.rdkit.org/docs/cppapi/classRDKit_1_1MolStandardize_1_1TautomerEnumerator.html#a7e4f2a393b92f09ee1447d2af50918dc)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "IdiqdjPf5hjp"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem.MolStandardize import rdMolStandardize\n",
+    "\n",
+    "# Initialize enumerator\n",
+    "tautomer_enumerator = rdMolStandardize.TautomerEnumerator()\n",
+    "# Provide RDKit Mol object to generate.\n",
+    "# We already made this, but you may start from a SMILE string or other source\n",
+    "# Remember, use the structure with implicit hydrogens!\n",
+    "tautomers = tautomer_enumerator.Enumerate(corrected_pose)\n",
+    "# Take the TautomerEnumerationResults object and iterate over to get a list of structures\n",
+    "tautomers_list = [t for t in tautomers]\n",
+    "\n",
+    "\"\"\"\n",
+    "Note! This may generate duplicate structures,\n",
+    "You may want to cast these Mol objects into SMILES strings, de-duplicate,\n",
+    "then rebuild the Mol objects to map their coordinates back onto the reference structure\n",
+    "\"\"\"\n",
+    "\n",
+    "# Cast to a set to make unique, then back to a list (as some tautomers can be enumerated again for some structures)\n",
+    "smiles_set_tautomers = set(Chem.MolToSmiles(t) for t in tautomers_list)\n",
+    "tautomer_list_unique = list(smiles_set_tautomers)\n",
+    "# We know the Y6J structure does have unique tautomers, this is just a sanity check\n",
+    "assert len(tautomers_list) == len(tautomer_list_unique)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "vTbCvLJ85_Hn"
+   },
+   "outputs": [],
+   "source": [
+    "ligand_tautomers = f\"{ligand_directory}/{ligand_id}_tautomers.sdf\"\n",
+    "writer = Chem.SDWriter(ligand_tautomers)\n",
+    "for t in tautomers_list:\n",
+    "    writer.write(t)\n",
+    "writer.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "kBoaBf6U7tSv"
+   },
+   "source": [
+    "Rendering all these tautomers at once in 3D, or looking through the SDF file isn't going to show many differences, so let's instead just look at the SMILES strings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Yx4zsrq58R0n"
+   },
+   "outputs": [],
+   "source": [
+    "for t in tautomer_list_unique:\n",
+    "    print(t)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aFjmLV0yqTBp"
+   },
+   "source": [
+    "However, rendering their 2D smiles strings can be done with a built-in RDKit module and function. Neat!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "hZcCDj7emckn"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem import Draw\n",
+    "\n",
+    "Draw.MolsToGridImage([Chem.MolFromSmiles(t) for t in tautomer_list_unique])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 125
+    },
+    "id": "mWrk-IGOqtMy",
+    "outputId": "90fcb358-784c-41c8-d863-b8f4e5ee0905"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.warning { /* Based on Bootstrap Warning */\n",
+       "    color: #856404; /* Darker shade of yellow-brown for text */\n",
+       "    background-color: #fff3cd; /* Light faded yellow background */\n",
+       "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.info ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.info li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"warning\">\n",
+       "\n",
+       "<strong>SMILES strings from explicit hydrogen structures breaks RDKit</strong>\n",
+       "\n",
+       "<p>If we made the tautomers with explicit hydrogens, we would have made 24 and RDKit could not have rebuilt the Mol objects from the strings; throwing errors because of too many valence electrons.\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title\n",
+    "%%html\n",
+    "<style>\n",
+    "div.warning { /* Based on Bootstrap Warning */\n",
+    "    color: #856404; /* Darker shade of yellow-brown for text */\n",
+    "    background-color: #fff3cd; /* Light faded yellow background */\n",
+    "    border-left: 5px solid #fad975; /* saturated yellow border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.info ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.info li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"warning\">\n",
+    "\n",
+    "<strong>SMILES strings from explicit hydrogen structures breaks RDKit</strong>\n",
+    "\n",
+    "<p>If we made the tautomers with explicit hydrogens, we would have made 24 and RDKit could not have rebuilt the Mol objects from the strings; throwing errors because of too many valence electrons.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WaDnfUbw-H7D"
+   },
+   "source": [
+    "We've now generated many tautomers we could use for docking. The good news is, many docking codes, including `gnina` will accept multi-ligand input files for us. We could convert the SDF file into a set of PDBQT files for `gnina` like we did with `OpenBabel`, but consider that we've only enumerated *all* tautomers, not the most likely ones for pH. We could do that with `RDKit` and our own logic, or we can use `Scrubber` which has a handy command-line utility we can just call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ieMr_SAX_vDl"
+   },
+   "outputs": [],
+   "source": [
+    "print(f\"{ligand_directory}/{ligand_id}_corrected_pose.sdf\")\n",
+    "print(f\"{ligand_directory}/{ligand_id}.pdbqt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Y31WsDZL_mFW"
+   },
+   "outputs": [],
+   "source": [
+    "!scrub.py ligand_structures/Y6J_corrected_pose.sdf -o ligand_structures/Y6J.sdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zBH6tftqAEO-"
+   },
+   "source": [
+    "Scrubber took a pre-set pH, did the following actions for us (from [their documentation](https://github.com/forlilab/molscrub)) using RDKit under the hood:\n",
+    "* Generate 3D coordinates using RDKit's ETKDGv3 and UFF minimization\n",
+    "* Enumerate tautomers (aiming at low energy states only)\n",
+    "* Enumerate pH corrections\n",
+    "* Convert boats to chairs (6-member rings) and enumerate both chair states\n",
+    "\n",
+    "There are plenty of command line options and a Python API for Scrubber as well.\n",
+    "\n",
+    "And now with our SDF file which has been \"scrubbed,\" we can finally generate our ready-to-feed-into `gnina` PDBQT file that we'll use for docking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "1TmiRxslADpi"
+   },
+   "outputs": [],
+   "source": [
+    "# Create our PDBQT to keep our hydrogens\n",
+    "ligand_pdbqt_filename = f\"{ligand_directory}/{ligand_id}.pdbqt\"\n",
+    "os.system(f\"obabel {ligand_corrected_pose_file} -O {ligand_pdbqt_filename} -xh\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8zdAfY3B0NGL"
+   },
+   "source": [
+    "And now we have 1 ligand ready to go for docking. But what if we want to have multiple ligands, such as the ones we made from the [second notebook of this workshop?](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/02_Cheminfo_crash_course.ipynb)\n",
+    "\n",
+    "## Preparing multiple ligands from SMILES strings\n",
+    "\n",
+    "If you want to upload your own CSV file of SMILES strings, feel free to do so. Or you can pull down a sample output by running the code below. There are other codes which can go about this, but this is one example where we can prep from data we've already worked with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "jw2FL0M_ccoq"
+   },
+   "outputs": [],
+   "source": [
+    "# Run this cell if you want some sample SMILE strings from the\n",
+    "# US20240293380 set for 7LME docking. You can also use your own.\n",
+    "!wget https://github.com/MolSSI-Education/iqb-2025/raw/refs/heads/main/data/US20240293380_examples.csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VAM3CXltd-gU"
+   },
+   "source": [
+    "We'll be using RDKit to pull these SMILES strings back into `Mol` objects (which if we were doing this whole workshop in one notebook we could have skipped), then casting the molecules to SDF, and then back into 3D structures with `Scrubber`. The back and forth between the programs may seem a bit silly because we had the `Mol` objects earlier, but sometimes you will only have SMILE strings to start your research, so we'll work from that basis here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "aWXB5EF3fQjW"
+   },
+   "outputs": [],
+   "source": [
+    "# Load the SMILES strings into RDKit and write back out an SDF file.\n",
+    "# Default delimiter is tab (\\t), so we need to specify \",\"\n",
+    "smiles_supplier = Chem.SmilesMolSupplier(\"US20240293380_examples.csv\", delimiter=\",\")\n",
+    "mols = []  # Could do this in list comprehension, adding a sanity check\n",
+    "for mol in smiles_supplier:\n",
+    "    print(\n",
+    "        Chem.MolToSmiles(mol)\n",
+    "    )  # Sanity check that we got the smiles strings and not metadata\n",
+    "    mols.append(mol)\n",
+    "\n",
+    "# Write out our molecules\n",
+    "ligands_to_dock_dirty = f\"{ligand_directory}/ligands_to_dock_dirty.sdf\"\n",
+    "writer = Chem.SDWriter(ligands_to_dock_dirty)\n",
+    "for m in mols:\n",
+    "    writer.write(m)\n",
+    "writer.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "THd3to70h-71"
+   },
+   "source": [
+    "The file is labeled as \"dirty\" since there is more preparation work to do before these molecules are ready to insert into docking. Because we started with SMILES, we got a 2D structure by default with RDKit. we can see that by just declaring the most recent `mol` object from our list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2x9SqbOCiIZA"
+   },
+   "outputs": [],
+   "source": [
+    "mol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-EtTtZR9iNWy"
+   },
+   "source": [
+    "We can also see that there are some erroneous fields here because we did a very, very simple read of the CSV file with our SMILES strings. We don't need that information here, but you might in the future; make sure you parse your data correctly as needed. (e.g. with the Python built-in `csv` module or manipulate the Pandas `DataFrame` directly). We'll use `Scrubber` to clean up our structures for us all at once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "0-IvNYnwjFSb"
+   },
+   "outputs": [],
+   "source": [
+    "!scrub.py ligand_structures/ligands_to_dock_dirty.sdf -o ligand_structures/ligands_to_dock.sdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EVnXg8m8jf8P"
+   },
+   "source": [
+    "We got some text output, but did that do what we wanted? We could assume we did, or we can make sure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VEu5EJRfjoIO"
+   },
+   "outputs": [],
+   "source": [
+    "# Sanity check we got a structure with hydrogens\n",
+    "# RDKit automatically removes hydrogens by default (needed for most of the kit to work)\n",
+    "# But we're explicitly looking for them here, we can just load them and check\n",
+    "supplier = Chem.SDMolSupplier(f\"{ligand_directory}/ligands_to_dock.sdf\", removeHs=False)\n",
+    "reloaded_ligands = [mol for mol in supplier]\n",
+    "# The last structure will be the same as the last in list comprehension above\n",
+    "reloaded_ligands[-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XZdrl6_6cYIj"
+   },
+   "source": [
+    "Our receptor, experimental ligand, and additional ligands have now been downloaded, separated, cleaned, and modified starting from both a single structure on the RCSB and through BindingDB. We applied our bioinformatics and molecular modeling tools to create computational-ready models that we will now feed into docking."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "include_colab_link": true,
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/04_Cheminfo_crash_course.ipynb
+++ b/04_Cheminfo_crash_course.ipynb
@@ -1,1534 +1,1550 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Hz731IZ6sXmi"
-      },
-      "source": [
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:325px;\">\n",
-        "</div>\n",
-        "\n",
-        "\n",
-        "# Molecular Docking using gnina\n",
-        "\n",
-        "*This tutorial was written by Jessica Nash (Software Scientist) at The Molecular Sciences Software Institue for the [Cheminformatic-Driven Molecular Docking Workshop](https://pdb101.rcsb.org/news/67d9853eaddf75595bd158f7) held as a Crash Course with the Institute for Quantitative Biomedicine (IQB) and the Protein Data Bank (PDB). Special thanks to Pat Walters and David Koes for feedback, suggestions, and proofreading on this notebook.*\n",
-        "\n",
-        "*This notebook is Part 4 of 4 in the notebook series.*\n",
-        "\n",
-        "Other notebooks in this series:\n",
-        "1. [Digital Representation of Molecules](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/01_Cheminfo_crash_course.ipynb)\n",
-        "2. [Exploring Chemical and Biological Data with BindingDB and the RDKit](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/02_Cheminfo_crash_course.ipynb)\n",
-        "3. [Preparing Structures for Docking](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/03_Cheminfo_crash_course.ipynb)\n",
-        "4. **Molecular Docking using gnina** (this notebook)\n",
-        "\n",
-        "In this notebook, we will perform molecular docking of our original bound ligand along with the ligands we prepared in the last notebook.\n",
-        "Molecular docking is a computational method that predicts the preferred orientation of one molecule (the ligand) when bound to another molecule (the receptor, often a protein).\n",
-        "\n",
-        "For docking, we will use a program called [gnina](https://github.com/gnina/gnina). gnina is pronounced `nee-na` (silent g) and is a fork of a software program called smina, which is itself a fork of Autodock Vina.\n",
-        "For those unfamiliar with software development lingo, a \"fork\" is a copy of a project. Forks may be modified and diverge from the original project.\n",
-        "Autodock Vina is the program we used for docking in last year's PDB Crash Course.\n",
-        "\n",
-        "smina was created from AutoDock Vina in order to allow easier set up of docking calculations as well as to allow more customization of the scoring function. smina allows you to set the binding site automatically based on distance from a ligand as well as to define your own scoring functions. gnina builds on that by adding rescoring with convoluational neural networks to improve pose prediction. In this notebook, we will use gnina.\n",
-        "\n",
-        "If you find gnina useful and use it in your own research, please be sure to cite the appropriate papers:\n",
-        "\n",
-        "Citation\n",
-        "========\n",
-        "\n",
-        "**GNINA 1.0: Molecular docking with deep learning** (Primary application citation)  \n",
-        "A McNutt, P Francoeur, R Aggarwal, T Masuda, R Meli, M Ragoza, J Sunseri, DR Koes. *J. Cheminformatics*, 2021  \n",
-        "[link](https://jcheminf.biomedcentral.com/articles/10.1186/s13321-021-00522-2) [PubMed](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8191141/) [ChemRxiv](https://chemrxiv.org/articles/preprint/GNINA_1_0_Molecular_Docking_with_Deep_Learning/13578140)\n",
-        "\n",
-        "**Protein–Ligand Scoring with Convolutional Neural Networks**  (Primary methods citation)  \n",
-        "M Ragoza, J Hochuli, E Idrobo, J Sunseri, DR Koes. *J. Chem. Inf. Model*, 2017  \n",
-        "[link](http://pubs.acs.org/doi/full/10.1021/acs.jcim.6b00740) [PubMed](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5479431/) [arXiv](https://arxiv.org/abs/1612.02751)  \n",
-        "\n",
-        "**Ligand pose optimization with atomic grid-based convolutional neural networks**  \n",
-        "M Ragoza, L Turner, DR Koes. *Machine Learning for Molecules and Materials NIPS 2017 Workshop*, 2017  \n",
-        "[arXiv](https://arxiv.org/abs/1710.07400)  \n",
-        "\n",
-        "**Visualizing convolutional neural network protein-ligand scoring**  \n",
-        "J Hochuli, A Helbling, T Skaist, M Ragoza, DR Koes.  *Journal of Molecular Graphics and Modelling*, 2018  \n",
-        "[link](https://www.sciencedirect.com/science/article/pii/S1093326318301670) [PubMed](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6343664/) [arXiv](https://arxiv.org/abs/1803.02398)\n",
-        "\n",
-        "**Convolutional neural network scoring and minimization in the D3R 2017 community challenge**  \n",
-        "J Sunseri, JE King, PG Francoeur, DR Koes.  *Journal of computer-aided molecular design*, 2018  \n",
-        "[link](https://link.springer.com/article/10.1007/s10822-018-0133-y) [PubMed](https://www.ncbi.nlm.nih.gov/pubmed/29992528)\n",
-        "\n",
-        "**Three-Dimensional Convolutional Neural Networks and a Cross-Docked Data Set for Structure-Based Drug Design**  \n",
-        "PG Francoeur, T Masuda, J Sunseri, A Jia, RB Iovanisci, I Snyder, DR Koes. *J. Chem. Inf. Model*, 2020  \n",
-        "[link](https://pubs.acs.org/doi/abs/10.1021/acs.jcim.0c00411) [PubMed](https://pubmed.ncbi.nlm.nih.gov/32865404/) [Chemrxiv](https://chemrxiv.org/articles/preprint/3D_Convolutional_Neural_Networks_and_a_CrossDocked_Dataset_for_Structure-Based_Drug_Design/11833323/1)\n",
-        "\n",
-        "**Virtual Screening with Gnina 1.0**\n",
-        "J Sunseri, DR Koes D. *Molecules*, 2021\n",
-        "[link](https://www.mdpi.com/1420-3049/26/23/7369) [Preprints](https://www.preprints.org/manuscript/202111.0329/v1)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 31,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 490
-        },
-        "id": "BcDfbcA5seGI",
-        "outputId": "1b8a4a16-cf6d-4f8d-82c3-aaa6d7480775"
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
-            "text/html": [
-              "<style>\n",
-              "div.alert {\n",
-              "    color: #0056b3;\n",
-              "    background-color: #d9edf7;\n",
-              "    border-left: 5px solid #31708f;\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em;\n",
-              "    line-height: 1.5;\n",
-              "}\n",
-              "div.alert ul {\n",
-              "    margin: 0.5em 0;\n",
-              "}\n",
-              "div.alert li {\n",
-              "    margin-bottom: 0.5em;\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"alert alert-block alert-info\">\n",
-              "    <strong>Questions:</strong>\n",
-              "    <ul>\n",
-              "        <li>How can I perform molecular docking using the gnina software?</li>\n",
-              "        <li>What is redocking and how do I perform it?</li>\n",
-              "        <li>What is crossdocking and how do I perform it?</li>\n",
-              "        <li>How are docking results evaluated using scores and Root Mean Square Deviation (RMSD)?</li>\n",
-              "        <li>How do `gnina`'s CNN scores differ from traditional Vina scores in practice?</li>\n",
-              "        <li>How can I dock multiple ligands with gnina?</li>\n",
-              "        <li>How can docking results for multiple compounds be compared?</li>\n",
-              "    </ul>\n",
-              "\n",
-              "    <strong>Objectives:</strong>\n",
-              "    <ul>\n",
-              "        <li>Use `gnina` to perform molecular docking for single and multiple ligands.</li>\n",
-              "        <li>Visualize docked poses within the protein binding site.</li>\n",
-              "        <li>Calculate RMSD to evaluate redocking and cross docking accuracy.</li>\n",
-              "        <li>Interpret the different scoring outputs from `gnina`.</li>\n",
-              "    </ul>\n",
-              "</div>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# @title Overview\n",
-        "%%html\n",
-        "<style>\n",
-        "div.alert {\n",
-        "    color: #0056b3;\n",
-        "    background-color: #d9edf7;\n",
-        "    border-left: 5px solid #31708f;\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em;\n",
-        "    line-height: 1.5;\n",
-        "}\n",
-        "div.alert ul {\n",
-        "    margin: 0.5em 0;\n",
-        "}\n",
-        "div.alert li {\n",
-        "    margin-bottom: 0.5em;\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "    <strong>Questions:</strong>\n",
-        "    <ul>\n",
-        "        <li>How can I perform molecular docking using the gnina software?</li>\n",
-        "        <li>What is redocking and how do I perform it?</li>\n",
-        "        <li>What is crossdocking and how do I perform it?</li>\n",
-        "        <li>How are docking results evaluated using scores and Root Mean Square Deviation (RMSD)?</li>\n",
-        "        <li>How do `gnina`'s CNN scores differ from traditional Vina scores in practice?</li>\n",
-        "        <li>How can I dock multiple ligands with gnina?</li>\n",
-        "        <li>How can docking results for multiple compounds be compared?</li>\n",
-        "    </ul>\n",
-        "\n",
-        "    <strong>Objectives:</strong>\n",
-        "    <ul>\n",
-        "        <li>Use `gnina` to perform molecular docking for single and multiple ligands.</li>\n",
-        "        <li>Visualize docked poses within the protein binding site.</li>\n",
-        "        <li>Calculate RMSD to evaluate redocking and cross docking accuracy.</li>\n",
-        "        <li>Interpret the different scoring outputs from `gnina`.</li>\n",
-        "    </ul>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "AsAJ6XjquK-X"
-      },
-      "source": [
-        "## Set Up\n",
-        "The cells in this section set up the software and files we will need for our calculations.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Km6XsVhTSlxW"
-      },
-      "source": [
-        "\n",
-        "### Install Python Packages  \n",
-        "1. `useful_rdkit_utils` is a Python package written and maintained by Pat Walters that contains useful RDKit functions. We will use it for the functions `mcs_rmsd` (explained later).\n",
-        "2. `py3Dmol` is used for molecular visualization.\n",
-        "3. The RDKit is a popular cheminiformatics package we will use for processing molecules.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Bf5bjLD0uLfv"
-      },
-      "outputs": [],
-      "source": [
-        "%%capture\n",
-        "!pip install useful_rdkit_utils py3Dmol rdkit\n",
-        "!apt install openbabel"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "SdpafOZWSeXd"
-      },
-      "source": [
-        "### Download gnina\n",
-        "\n",
-        "We are downloading the pre-compiled binary of gnina. You may also compile gnina yourself by following the directions on the [gnina GitHub repository](https://github.com/gnina/gnina)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "WnjkCEiA08o_"
-      },
-      "outputs": [],
-      "source": [
-        "# Download gnina\n",
-        "!wget https://github.com/gnina/gnina/releases/download/v1.3/gnina.fix"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Tir5QGznJ-iA"
-      },
-      "outputs": [],
-      "source": [
-        "# Make gnina executable\n",
-        "!mv gnina.fix gnina\n",
-        "!chmod +x gnina"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8XkECD7sSTGH"
-      },
-      "source": [
-        "### Get Lesson Files\n",
-        "\n",
-        "We have stored the files created in the last notebook as a zip file and stored it on GitHub. This cell downloads that file as well as `util.py` which contains a custom utility function for visualizing our ligand and protein.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "vbznC0r_4IdM"
-      },
-      "outputs": [],
-      "source": [
-        "%%capture\n",
-        "!wget https://github.com/MolSSI-Education/iqb-2025/raw/refs/heads/main/data/docking_files.zip\n",
-        "!wget https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/main/util.py"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "bzzSgnUr4Z5d"
-      },
-      "outputs": [],
-      "source": [
-        "!unzip docking_files.zip"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YJ8KQSrcY0nd"
-      },
-      "source": [
-        "## Docking with gnina\n",
-        "\n",
-        "Molecular Docking involves involves two main stages:\n",
-        "\n",
-        "1. Sampling: The algorithm explores many possible positions and orientations (or \"poses\") of the ligand within the receptor's active site. In AutoDock Vina, smina, and gnina, conformations are generated using Monte Carlo Sampling.\n",
-        "2. Scoring: Each generated pose is evaluated using a scoring function which estimates the binding affinity. Poses are then ranked on these scores. For Vina scores, lower energy scores indicating more favorable interactions.\n",
-        "\n",
-        "In addition to the traditional scoring functions avaiable in Vina and smina, gnina adds convolutional neural networks (CNNs) to scoring.  These deep learning models analyze a 3D grid representation of the protein-ligand complex, essentially evaluating a \"picture\" of the interaction based on atomic densities.\n",
-        "\n",
-        "By default, gnina uses results from the CNN for **rescoring**, meaning that poses are initially sampled and scored with the traditional Vina scoring function but re-ranked after sampling using CNN models. You can, however, choose to use the CNN for all scoring, refinement, or not at all (using CNN scoring for refinement or all scoring is more computationally intensive).\n",
-        "\n",
-        "For more details see the paper on [gnina v1.0](https://jcheminf.biomedcentral.com/articles/10.1186/s13321-021-00522-2) and [gnina v1.3](https://jcheminf.biomedcentral.com/articles/10.1186/s13321-025-00973-x)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WYzeWNO5uHxL"
-      },
-      "source": [
-        "## Redocking the Ligand\n",
-        "\n",
-        "Redocking (also called \"cognate docking\") involves redocking a ligand back into the receptor structure from which the bound pose was experimentally determined.\n",
-        "Redocking is typically done to evaluate how well a docking program's sampling algorithm and scoring function and reproduce a known experimental binding pose.\n",
-        "\n",
-        "We will begin our docking journey with gnina by performing a redock of our ligand."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "nDaEbegLZVzr"
-      },
-      "outputs": [],
-      "source": [
-        "from util import visualize_poses\n",
-        "\n",
-        "v = visualize_poses(\"docking_files/protein_structures/7LME_fixed.pdb\",\n",
-        "                             \"docking_files/ligand_structures/Y6J_corrected_pose.sdf\")\n",
-        "v.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gyJOkQp0ZW2Y"
-      },
-      "source": [
-        "You may execute the cell below, and read the following explanation on the input parameters for gnina. gnina works through the command line, so we cannot use in-line comments.\n",
-        "\n",
-        "```\n",
-        "./gnina \\\n",
-        "  # Specify the receptor structure file (-r).\n",
-        "  # This file (7LME.pdbqt) should be prepared for docking (e.g., with hydrogens added).\n",
-        "  -r docking_files/7LME_all_atom.pdbqt \\\n",
-        "  # Specify the ligand structure file (-l) to be docked.\n",
-        "  # This file (Y6J_ideal.pdbqt) contains the 3D coordinates of the ligand.\n",
-        "  -l docking_files/Y6J_ideal.pdbqt \\\n",
-        "  # Define the docking search box automatically (--autobox_ligand).\n",
-        "  # The box will be centered around the coordinates of the ligand in the specified file\n",
-        "  # (Y6J_corrected_pose.sdf), which is the known experimental pose in this redocking example.\n",
-        "  # An optional padding (default 4Å) is added.\n",
-        "  --autobox_ligand docking_files/Y6J_corrected_pose.sdf \\\n",
-        "  # Specify the output file path (-o) where the resulting docked poses will be saved.\n",
-        "  # The output format will be SDF, containing multiple poses ranked by score.\n",
-        "  -o docking_results/Y6J_docked_e12.sdf \\\n",
-        "  # Set the random number generator seed (--seed) to 0.\n",
-        "  # Using a fixed seed makes the docking calculation reproducible.\n",
-        "  --seed 0 \\\n",
-        "  # Set the exhaustiveness level (--exhaustiveness) to 12.\n",
-        "  # This controls the number of Monte Carlo chains for the ligand.\n",
-        "  # The default is 8\n",
-        "  --exhaustiveness 16\n",
-        "  ```\n",
-        "\n",
-        "  Execute the next cell to run gnina.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 32,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 273
-        },
-        "id": "7cAKRSGwYxo6",
-        "outputId": "79380cef-982a-411f-fad2-9a0964cc4b4f"
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
-            "text/html": [
-              "<style>\n",
-              "div.purple-box {\n",
-              "    color: #4b0082; /* Indigo for text */\n",
-              "    background-color: #f3e5f5; /* Light lavender background */\n",
-              "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-              "}\n",
-              "div.purple-box ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.purple-box li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "<div class=\"purple-box\">\n",
-              "   <p> Execute the next cell below to start running\n",
-              "your docking calculation. Then, come back and try these navigation tips for Py3DMol.</p>\n",
-              "    <strong>Py3DMol Visualization Navigation:</strong>\n",
-              "    <table border=\"1\" style=\"border-collapse: collapse; width: 100%;\">\n",
-              "  <thead>\n",
-              "    <tr>\n",
-              "      <th>Movement</th>\n",
-              "      <th>Mouse Input</th>\n",
-              "      <th>Touch Input</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <td>Rotation</td>\n",
-              "      <td>Primary Mouse Button</td>\n",
-              "      <td>Single touch</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <td>Translation</td>\n",
-              "      <td>Middle Mouse Button or Ctrl+Primary</td>\n",
-              "      <td>Triple touch</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <td>Zoom</td>\n",
-              "      <td>Scroll Wheel or Second Mouse Button or Shift+Primary</td>\n",
-              "      <td>Pinch (double touch)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <td>Slab</td>\n",
-              "      <td>Ctrl+Second</td>\n",
-              "      <td>Not Available</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# @title While you Wait: Navigating py3DMol visualizations\n",
-        "%%html\n",
-        "<style>\n",
-        "div.purple-box {\n",
-        "    color: #4b0082; /* Indigo for text */\n",
-        "    background-color: #f3e5f5; /* Light lavender background */\n",
-        "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-        "}\n",
-        "div.purple-box ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.purple-box li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "<div class=\"purple-box\">\n",
-        "   <p> Execute the next cell below to start running\n",
-        "your docking calculation. Then, come back and try these navigation tips for Py3DMol.</p>\n",
-        "    <strong>Py3DMol Visualization Navigation:</strong>\n",
-        "    <table border=\"1\" style=\"border-collapse: collapse; width: 100%;\">\n",
-        "  <thead>\n",
-        "    <tr>\n",
-        "      <th>Movement</th>\n",
-        "      <th>Mouse Input</th>\n",
-        "      <th>Touch Input</th>\n",
-        "    </tr>\n",
-        "  </thead>\n",
-        "  <tbody>\n",
-        "    <tr>\n",
-        "      <td>Rotation</td>\n",
-        "      <td>Primary Mouse Button</td>\n",
-        "      <td>Single touch</td>\n",
-        "    </tr>\n",
-        "    <tr>\n",
-        "      <td>Translation</td>\n",
-        "      <td>Middle Mouse Button or Ctrl+Primary</td>\n",
-        "      <td>Triple touch</td>\n",
-        "    </tr>\n",
-        "    <tr>\n",
-        "      <td>Zoom</td>\n",
-        "      <td>Scroll Wheel or Second Mouse Button or Shift+Primary</td>\n",
-        "      <td>Pinch (double touch)</td>\n",
-        "    </tr>\n",
-        "    <tr>\n",
-        "      <td>Slab</td>\n",
-        "      <td>Ctrl+Second</td>\n",
-        "      <td>Not Available</td>\n",
-        "    </tr>\n",
-        "  </tbody>\n",
-        "</table>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Fw7fjHKQshRM"
-      },
-      "outputs": [],
-      "source": [
-        "# make a folder for our results\n",
-        "!mkdir -p docking_results\n",
-        "\n",
-        "# use gnina\n",
-        "!./gnina \\\n",
-        "  -r docking_files/protein_structures/7LME.pdbqt \\\n",
-        "  -l docking_files/ligand_structures/Y6J_ideal.sdf \\\n",
-        "  --autobox_ligand docking_files/ligand_structures/Y6J_corrected_pose.sdf \\\n",
-        "  -o docking_results/Y6J_docked_7LME.sdf \\\n",
-        "  --seed 0 \\\n",
-        "  --exhaustiveness 16"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "V9rQtIt1BAbi"
-      },
-      "source": [
-        "### Interpreting the output\n",
-        "\n",
-        "When `gnina` finishes a docking run, it prints a summary table for the generated poses. This table is sorted by pose rank, with the poses `gnina` determined to be the best at the top.\n",
-        "\n",
-        "The columns are the following:\n",
-        "\n",
-        "* `mode`: pose rank\n",
-        "* `affinity (kcal/mol)`: the Vina score\n",
-        "* `intra (kcal/mol)`: the ligand's internal strain energy according to the Vina function\n",
-        "* `CNN pose score`: the score from the convolutional neural network predicting pose quality, where higher values closer to 1 indicate higher confidence in the pose's geometric accuracy and are used for ranking.\n",
-        "* `CNN affinity`: The CNN's prediction of binding affinity, expressed in pK units (higher values mean stronger binding, e.g., a predicted score of 9 corresponds to nanomolar (nM) affinity).\n",
-        "\n",
-        "Looking at tscores for the redocked Y6J ligand, the table shows the poses ranked by `CNN pose score` (higher is better), with `mode 1` scoring highest (approx. 0.81). Notably, this differs from the ranking by the Vina `affinity` score (lower is better), where `mode 3` is most favorable (-7.51 kcal/mol) but has a much lower `CNN pose score` (approx. 0.49).\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WY5_D7aD_KyU"
-      },
-      "source": [
-        "### Visualizing the Docked Structures\n",
-        "\n",
-        "In the cell below, we use a function called `visualize_docked_structures`, a custom function defined for this workshop that we obtained above when we retreived `util.py`.\n",
-        "This function allows us to view our generated docked structures along with ligand it its original experimentally determined position."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "NMR8YzT_47me"
-      },
-      "outputs": [],
-      "source": [
-        "v = visualize_poses(\"docking_files/protein_structures/7LME_fixed.pdb\",\n",
-        "                             \"docking_results/Y6J_docked_7LME.sdf\",\n",
-        "                             cognate_file=\"docking_files/ligand_structures/Y6J_corrected_pose.sdf\",\n",
-        "                             animate=False) # Change to True to see an animation of all of the poses\n",
-        "v.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Ky5T3UaU1lDP"
-      },
-      "source": [
-        "### Measuring Root-Mean-Square-Deviation (RMSD)\n",
-        "\n",
-        "After generating docked poses, we next need to quantitatively evaluate how close the known reference structure.\n",
-        "The standard metric used for this comparison is the **Root Mean Square Deviation (RMSD)**.\n",
-        "RMSD measures the average distance between corresponding atoms of two molecular structures.\n",
-        "A lower RMSD value indicates greater similarity between the docked pose and the reference structure.\n",
-        "Mathematically, it's calculated as:\n",
-        "\n",
-        "$$\n",
-        "RMSD = \\sqrt[2]{\\frac{1}{N} \\sum_{i=1}^{N} \\delta_i^2}\n",
-        "$$\n",
-        "\n",
-        "\n",
-        "\n",
-        "where $N$ is the number of corresponding atom pairs being compared, and $\\delta_i$ is the Euclidean distance between the $i$-th pair of atoms\n",
-        "In docking studies, a common threshold for considering a docked pose \"successful\" or accurate is an RMSD below 2 Angstroms compared to the crystal structure.\n",
-        "\n",
-        "In this notebook, we will use the `mcs_rmsd` function from the `useful_rdkit_utils` package, written by Pat Walters (a co-instructor of this workshop!).\n",
-        "This function calculates the RMSD, but with a useful modification: it first identifies the **Maximum Common Substructure (MCS)** between the two input molecules using RDKit's `FindMCS` functionality.\n",
-        "It then calculates the RMSD using only the corresponding atoms belonging to this shared substructure.\n",
-        "This approach is particularly valuable when comparing molecules that are similar but not identical, as it focuses the RMSD calculation on the parts of the molecules that match.\n",
-        "While for redocking the original ligand the MCS will typically be the entire molecule, this function can be used later when we compare the poses of different (but similar) docked ligands to the original crystal ligand.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "EcrJ1i77uQO2"
-      },
-      "outputs": [],
-      "source": [
-        "import useful_rdkit_utils as uru\n",
-        "from rdkit import Chem\n",
-        "\n",
-        "cognate = Chem.MolFromMolFile(\"docking_files/ligand_structures/Y6J_corrected_pose.sdf\")\n",
-        "poses = Chem.SDMolSupplier(\"docking_results/Y6J_docked_7LME.sdf\")\n",
-        "\n",
-        "for i, pose in enumerate(poses):\n",
-        "  n_match, rmsd = uru.mcs_rmsd(cognate, pose)\n",
-        "  print(f\"{n_match}\\t{rmsd:.2f}\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 33,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 152
-        },
-        "id": "9IKXZt1GJD59",
-        "outputId": "b0fa9f6e-96fb-47bb-e031-35fc6389fd84"
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
-            "text/html": [
-              "<style>\n",
-              "div.orange-alert {\n",
-              "    color: #854f00; /* Darker shade of orange for text */\n",
-              "    background-color: #ffe6cc; /* Light orange background */\n",
-              "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.orange-alert ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.orange-alert li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"orange-alert\">\n",
-              "\n",
-              "<strong>How is docking without the CNN rescoring?</strong>\n",
-              "\n",
-              "<p>You can turn off CNN rescoring with gnina by adding <code>--cnn_scoring none</code> to\n",
-              "  your gnina command. Try doing this - make sure to save your results in a new file.\n",
-              "\n",
-              "  How does it affect redocking, particularly the measured RMSD score of the docked structures?\n",
-              "\n",
-              "</div>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# @title Exercise\n",
-        "%%html\n",
-        "<style>\n",
-        "div.orange-alert {\n",
-        "    color: #854f00; /* Darker shade of orange for text */\n",
-        "    background-color: #ffe6cc; /* Light orange background */\n",
-        "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.orange-alert ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.orange-alert li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"orange-alert\">\n",
-        "\n",
-        "<strong>How is docking without the CNN rescoring?</strong>\n",
-        "\n",
-        "<p>You can turn off CNN rescoring with gnina by adding <code>--cnn_scoring none</code> to\n",
-        "  your gnina command. Try doing this - make sure to save your results in a new file.\n",
-        "\n",
-        "  How does it affect redocking, particularly the measured RMSD score of the docked structures?\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ha9UX8Y4nI03"
-      },
-      "outputs": [],
-      "source": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "01yc6AghnOev"
-      },
-      "outputs": [],
-      "source": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0UCtKY_MeMwM"
-      },
-      "source": [
-        "## Cross Docking the Ligand\n",
-        "\n",
-        "We've seen that gnina does a great job fitting the ligand back into its original structure. However, this is an \"easier\" problem than docking a ligand into an unknown structure. When we redock, the binding cavity for the ligand will be perfectly fit for the ligand we are testing.\n",
-        "\n",
-        "When performing cross-docking, you dock the ligand into the structure, but with a different version of the protein structure (a main protease structure from a different PDB ID with a different ligand bound, or with no ligand). If our docking is working well, we should get the same structure for the ligand regardless of the PDB ID we are docking to.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 34,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 315
-        },
-        "id": "GsGJWgeFJ1Do",
-        "outputId": "3ea4c37f-8872-4df8-df5e-d5d4f11addc8"
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
-            "text/html": [
-              "<style>\n",
-              "div.purple-box {\n",
-              "    color: #4b0082; /* Indigo for text */\n",
-              "    background-color: #f3e5f5; /* Light lavender background */\n",
-              "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-              "}\n",
-              "div.purple-box ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.purple-box li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"purple-box\">\n",
-              "    <strong>Cross Docking Structure Prep:</strong>\n",
-              "    <p>\n",
-              "        If you want to perform cross-docking and measure the RMSD of the docked ligands, you will need your two protein structures to be aligned.\n",
-              "        Although two PDB IDs may have the same protein, they may differ in the translation and orientation of the protein.\n",
-              "        If you do not align the structures, the RMSD you measure will primarily be from the translation and rotation of the structure and will not give you an idea of how close the fit is.\n",
-              "    </p>\n",
-              "\n",
-              "    <p>We are going to cross dock with structure <strong>7L11</strong>.\n",
-              "    To prep this file, we loaded into VMD and aligned the protein backbone with the protein backbone of 7LME using\n",
-              "    VMD's Calculate RMSD Tool (use \"Align\" to align your structures!). We have not included this prep in the workshop\n",
-              "    </p>\n",
-              "    <pre>\n",
-              "    </pre>\n",
-              "</div>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# @title Cross Docking Structure Prep\n",
-        "%%html\n",
-        "<style>\n",
-        "div.purple-box {\n",
-        "    color: #4b0082; /* Indigo for text */\n",
-        "    background-color: #f3e5f5; /* Light lavender background */\n",
-        "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-        "}\n",
-        "div.purple-box ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.purple-box li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"purple-box\">\n",
-        "    <strong>Cross Docking Structure Prep:</strong>\n",
-        "    <p>\n",
-        "        If you want to perform cross-docking and measure the RMSD of the docked ligands, you will need your two protein structures to be aligned.\n",
-        "        Although two PDB IDs may have the same protein, they may differ in the translation and orientation of the protein.\n",
-        "        If you do not align the structures, the RMSD you measure will primarily be from the translation and rotation of the structure and will not give you an idea of how close the fit is.\n",
-        "    </p>\n",
-        "\n",
-        "    <p>We are going to cross dock with structure <strong>7L11</strong>.\n",
-        "    To prep this file, we loaded into VMD and aligned the protein backbone with the protein backbone of 7LME using\n",
-        "    VMD's Calculate RMSD Tool (use \"Align\" to align your structures!). We have not included this prep in the workshop\n",
-        "    </p>\n",
-        "    <pre>\n",
-        "    </pre>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "glGrshWkKuai"
-      },
-      "outputs": [],
-      "source": [
-        "v = visualize_poses(\"docking_files/protein_structures/7LME_fixed.pdb\",\n",
-        "                             \"docking_files/ligand_structures/Y6J_corrected_pose.sdf\",\n",
-        "                             cognate_file=\"docking_files/ligand_structures/XF1_corrected_pose.sdf\",\n",
-        "                             animate=False) # Change to True to see an animation of all of the poses\n",
-        "v.show()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "pWZCFCLozV8M"
-      },
-      "outputs": [],
-      "source": [
-        "# use gnina\n",
-        "!./gnina \\\n",
-        "  -r docking_files/protein_structures/7L11.pdbqt \\\n",
-        "  -l docking_files/ligand_structures/Y6J_ideal.sdf \\\n",
-        "  --autobox_ligand docking_files/ligand_structures/XF1_corrected_pose.sdf \\\n",
-        "  -o docking_results/Y6J_docked_7L11.sdf \\\n",
-        "  --seed 0 \\\n",
-        "  --exhaustiveness 16"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "guj5TXQE0nKg"
-      },
-      "outputs": [],
-      "source": [
-        "cognate = Chem.MolFromMolFile(\"docking_files/ligand_structures/Y6J_corrected_pose.sdf\")\n",
-        "poses = Chem.SDMolSupplier(\"docking_results/Y6J_docked_7L11.sdf\")\n",
-        "\n",
-        "for i, pose in enumerate(poses):\n",
-        "  n_match, rmsd = uru.mcs_rmsd(cognate, pose)\n",
-        "  print(f\"{n_match}\\t{rmsd:.2f}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "seIdOWw3Lpim"
-      },
-      "source": [
-        "Our crossdocking scores show very good agreement with our native structure and with redocking."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "-MQcT2ZIOoI_"
-      },
-      "outputs": [],
-      "source": [
-        "v = visualize_poses(\"docking_files/protein_structures/7LME_fixed.pdb\",\n",
-        "                             \"docking_results/Y6J_docked_7L11.sdf\",\n",
-        "                             cognate_file=\"docking_files/ligand_structures/Y6J_corrected_pose.sdf\",\n",
-        "                             animate=False) # Change to True to see an animation of all of the poses\n",
-        "v.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "k1K70FlGuQaS"
-      },
-      "source": [
-        "## Docking our Prepared Ligands\n",
-        "\n",
-        "In this section, we will dock the ligands we prepared in our previous notebook. Luckily, gnina allows docking of multiple ligands by providing an SDF with your ligands of choice."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oUkfIkFSltIC"
-      },
-      "source": [
-        "We can run gnina for multiple ligands by providing this SDF with our ligands of interest to the `-l` argument.\n",
-        "\n",
-        "The command you can use to run gnina with multiple ligands is below:\n",
-        "\n",
-        "```\n",
-        "!./gnina \\\n",
-        "  -r docking_files/protein_structures/7LME.pdbqt \\\n",
-        "  -l docking_files/ligand_structures/ligands_to_dock.sdf \\\n",
-        "  --autobox_ligand docking_files/ligand_structures/Y6J_corrected_pose.sdf \\\n",
-        "  -o docking_results/multiple_ligands_docked.sdf \\\n",
-        "  --seed 0 \\\n",
-        "  --exhaustiveness 16\n",
-        "```\n",
-        "\n",
-        "In the interest of time for this tutorial, we will retrieve precomputed results from running this command. If you later return to this tutorial, feel free to run this calculation yourself by replacing the next cell with the command above!"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": true,
-        "id": "IL_DE5_AIXwT",
-        "jupyter": {
-          "outputs_hidden": true
-        }
-      },
-      "outputs": [],
-      "source": [
-        "!wget https://github.com/MolSSI-Education/iqb-2025/raw/refs/heads/main/data/docking_results.zip\n",
-        "!unzip -o docking_results.zip"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "2WOYZBufEw2E"
-      },
-      "source": [
-        "### Extracting the Scores\n",
-        "\n",
-        "gnina stores information docking poses and the score information in the SDF written for the dock.\n",
-        "To analyze and compare the results from all our docking runs (the redocked `Y6J` and all the `Compound_*` ligands), we need to extract this scoring information from the SDF and put it into a structured table.\n",
-        "\n",
-        "We can use RDKit PandasTools to read the molecular structures (poses) and their associated properties (scores) from the output SDF. The SDF will contain multiple poses for the docked ligands, and each pose record has the calculated scores (like `minimizedAffinity`, `CNNscore`, `CNNaffinity`, `CNN_VS`, etc.) stored as data fields. The `CNN_VS` score is the product of `CNNscore` and `CNNaffinity`. We would typically want ligands that score highly for both (and thus have a high `CNN_VS` score."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "rtHWd6JsDRFz"
-      },
-      "outputs": [],
-      "source": [
-        "# uncomment to see file\n",
-        "#!cat docking_results/multiple_ligands_results.sdf"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "LGaIIRBCAiX8"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem import PandasTools\n",
-        "from rdkit.rdBase import BlockLogs\n",
-        "import pandas as pd\n",
-        "\n",
-        "score_columns = [\n",
-        "    'minimizedAffinity',\n",
-        "    'CNNscore',\n",
-        "    'CNNaffinity',\n",
-        "    'CNN_VS',\n",
-        "    'CNNaffinity_variance'\n",
-        "]\n",
-        "\n",
-        "sdf_paths = [\n",
-        "    \"docking_results/multiple_ligands_docked.sdf\",\n",
-        "    \"docking_results/Y6J_docked_7LME.sdf\"\n",
-        "]\n",
-        "\n",
-        "df_list = []\n",
-        "for filename in sdf_paths:\n",
-        "  with BlockLogs():\n",
-        "    df_list.append(PandasTools.LoadSDF(filename))\n",
-        "\n",
-        "combo_df = pd.concat(df_list)\n",
-        "\n",
-        "# PandasTools reads all SDTags as strings, convert score columns to float\n",
-        "for col in score_columns:\n",
-        "    combo_df[col] = combo_df[col].astype(float)\n",
-        "\n",
-        "combo_df"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "RXyqs_TK5eKH"
-      },
-      "outputs": [],
-      "source": [
-        "top_poses = combo_df.sort_values(by=\"minimizedAffinity\", ascending=True).drop_duplicates(\"ID\")\n",
-        "top_poses"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Mg1n66U3UUg3"
-      },
-      "source": [
-        "Interestingly, the compounds sorted by `minimizedAffinity` (the Vina score) correlates well with the observed `IC50` value from our table."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "t8Wxhbh2TqSn"
-      },
-      "outputs": [],
-      "source": [
-        "ligand_data = pd.read_csv(\"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/main/data/US20240293380_examples.csv\")\n",
-        "ligand_data.sort_values(by=\"IC50 (nM)\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-O7sRVPTFOoT"
-      },
-      "source": [
-        "We can also use our visualization function to visualize the docked ligands to look at how they interact with the binding site."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2xKRmAl7KZt2"
-      },
-      "outputs": [],
-      "source": [
-        "v = visualize_poses(\"docking_files/protein_structures/7LME_fixed.pdb\",\n",
-        "                             \"docking_results/multiple_ligands_docked.sdf\",\n",
-        "                             cognate_file=\"docking_files/ligand_structures/Y6J_corrected_pose.sdf\",\n",
-        "                             animate=True) # Change to True to see an animation of all of the poses\n",
-        "v.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VhMEb6CibvOD"
-      },
-      "source": [
-        "If we would like to visualize poses for only one molecule, we can use the RDKit's PandasTools again to write an SDF for just that compound."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "IxhoYC2KMzwF"
-      },
-      "outputs": [],
-      "source": [
-        "compound_name = \"Compound_12_i0\"\n",
-        "\n",
-        "compound_df = combo_df[combo_df[\"ID\"] == compound_name]\n",
-        "\n",
-        "PandasTools.WriteSDF(\n",
-        "    compound_df,\n",
-        "    f\"docking_results/individual_{compound_name}.sdf\",             # Output file path\n",
-        "    molColName=\"ROMol\", # Name of the column with RDKit molecules\n",
-        "    properties=score_columns     # List of property columns to include\n",
-        ")\n",
-        "\n",
-        "\n",
-        "cognate = Chem.MolFromMolFile(\"docking_files/ligand_structures/Y6J_corrected_pose.sdf\")\n",
-        "poses = Chem.SDMolSupplier(f\"docking_results/individual_{compound_name}.sdf\")\n",
-        "\n",
-        "for i, pose in enumerate(poses):\n",
-        "  n_match, rmsd = uru.mcs_rmsd(cognate, pose)\n",
-        "  print(f\"{n_match}\\t{rmsd:.2f}\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "r9ThxHGXZxPa"
-      },
-      "outputs": [],
-      "source": [
-        "v = visualize_poses(\"docking_files/protein_structures/7LME_fixed.pdb\",\n",
-        "                             f\"docking_results/individual_{compound_name}.sdf\",\n",
-        "                             cognate_file=f\"docking_results/individual_{compound_name}.sdf\",\n",
-        "                             animate=False) # Change to True to see an animation of all of the poses\n",
-        "v.show()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 35,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 402
-        },
-        "id": "uRm7Jby4V6Pq",
-        "outputId": "7b34345e-d644-4ac5-b2f9-713d93383633"
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
-            "text/html": [
-              "<style>\n",
-              "div.purple-box {\n",
-              "    color: #4b0082; /* Indigo for text */\n",
-              "    background-color: #f3e5f5; /* Light lavender background */\n",
-              "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-              "}\n",
-              "div.purple-box ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.purple-box li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"purple-box\">\n",
-              "    <strong>Flexible & Whole Protein Docking with GNINA</strong>\n",
-              "    <ul>\n",
-              "        <li><b>Flexible Docking:</b> <code>gnina</code> allows specific receptor sidechains to be treated as flexible during docking. This is typically enabled using command-line options like <code>--flexdist_ligand</code> (to specify a reference point, often the ligand) and <code>--flexdist</code> (to set a distance threshold around that point for selecting flexible residues).</li>\n",
-              "        <li><b>Whole Protein Docking:</b> When the binding site isn't known beforehand, <code>gnina</code> can perform whole protein docking. This is usually done by setting the search box to encompass the entire receptor, commonly achieved by providing the receptor file itself as the argument to <code>--autobox_ligand</code>. This allows the ligand to explore the entire protein surface for potential binding pockets. <i>Note: Due to the much larger search space, significantly higher <code>--exhaustiveness</code> settings are strongly recommended for whole protein docking.</i></li>\n",
-              "    </ul>\n",
-              "\n",
-              "    However, be careful using these options as they are much more computationally expensive than rigid docking.\n",
-              "</div>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# @title More gnina Docking Options\n",
-        "%%html\n",
-        "<style>\n",
-        "div.purple-box {\n",
-        "    color: #4b0082; /* Indigo for text */\n",
-        "    background-color: #f3e5f5; /* Light lavender background */\n",
-        "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-        "}\n",
-        "div.purple-box ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.purple-box li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"purple-box\">\n",
-        "    <strong>Flexible & Whole Protein Docking with GNINA</strong>\n",
-        "    <ul>\n",
-        "        <li><b>Flexible Docking:</b> <code>gnina</code> allows specific receptor sidechains to be treated as flexible during docking. This is typically enabled using command-line options like <code>--flexdist_ligand</code> (to specify a reference point, often the ligand) and <code>--flexdist</code> (to set a distance threshold around that point for selecting flexible residues).</li>\n",
-        "        <li><b>Whole Protein Docking:</b> When the binding site isn't known beforehand, <code>gnina</code> can perform whole protein docking. This is usually done by setting the search box to encompass the entire receptor, commonly achieved by providing the receptor file itself as the argument to <code>--autobox_ligand</code>. This allows the ligand to explore the entire protein surface for potential binding pockets. <i>Note: Due to the much larger search space, significantly higher <code>--exhaustiveness</code> settings are strongly recommended for whole protein docking.</i></li>\n",
-        "    </ul>\n",
-        "\n",
-        "    However, be careful using these options as they are much more computationally expensive than rigid docking.\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Flexible Docking\n",
-        "\n",
-        "Throughout this tutorial, we've performed docking calculations treating the protein as a rigid receptor. This is a common thing to do and is computationally efficient. However, sometimes the binding site needs to adjust its  shape to accommodate a ligand. This is called \"induced fit\".\n",
-        "\n",
-        "Induced fit is observed for our structure, according to the [reference](https://pubs.acs.org/doi/10.1021/acs.jmedchem.1c00598), particularly Gln 189 and Met49 have flexible sidechains. We have likely observed good docking results because all of our ligands bind to this site in a similar way and the structures we have started from already fit this well.\n",
-        "\n",
-        "In the cell below, we add an argument to highlight residues to show where these residues are relative to our binding site."
-      ],
-      "metadata": {
-        "id": "8azkxhAJ8acU"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "kD0e9a945TBC"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 37,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 359
-        },
-        "id": "P-JeC8EoWPrI",
-        "outputId": "8b28ef90-8103-4730-df91-b217f2551fd9"
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
-            "text/html": [
-              "<style>\n",
-              "div.orange-alert {\n",
-              "    color: #854f00; /* Darker shade of orange for text */\n",
-              "    background-color: #ffe6cc; /* Light orange background */\n",
-              "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "}\n",
-              "div.orange-alert ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.orange-alert li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"orange-alert\">\n",
-              "\n",
-              "<strong>Final Challenge</strong>\n",
-              "\n",
-              "<p>\n",
-              "<i>Challenge 1: Flexible Docking</i>\n",
-              "</p>\n",
-              "\n",
-              "<p>\n",
-              "As stated above, sometimes your docking site may be flexible. `gnina` allows for flexible docking in a few different ways.\n",
-              "You may either use a cut off distance from a target with <code>--flexdist_ligand ARG</code> and <code>--flexdist DISTANCE`</code>,\n",
-              "or you may specify a set of flexible residues using <code>`--flexres`</code>. It is recommended to have as few flexible residues as possible\n",
-              "due to the increased computational cost. To specify the residues highlighted above as flexible, you can add <code>`--flexres A:49,A189`</code> to your\n",
-              "`gnina` command line argument. Here \"A\" refers to chain A.\n",
-              "</p>\n",
-              "\n",
-              "<p>Try redocking or crossdocking using Y6J and flexible docking.</p>\n",
-              "\n",
-              "<p>\n",
-              "    <i>\n",
-              "        Challenge 2: Cross Docking all ligands\n",
-              "    </i>\n",
-              "</p>\n",
-              "<p>\n",
-              "    Try docking all of your ligands to `7L11` using rigid docking. Do you observe the same ordering of ligands?\n",
-              "    </p>\n",
-              "\n",
-              "</div>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# @title Final Exercise\n",
-        "%%html\n",
-        "<style>\n",
-        "div.orange-alert {\n",
-        "    color: #854f00; /* Darker shade of orange for text */\n",
-        "    background-color: #ffe6cc; /* Light orange background */\n",
-        "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.orange-alert ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.orange-alert li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"orange-alert\">\n",
-        "\n",
-        "<strong>Final Challenge</strong>\n",
-        "\n",
-        "<p>\n",
-        "<i>Challenge 1: Flexible Docking</i>\n",
-        "</p>\n",
-        "\n",
-        "<p>\n",
-        "As stated above, sometimes your docking site may be flexible. `gnina` allows for flexible docking in a few different ways.\n",
-        "You may either use a cut off distance from a target with <code>--flexdist_ligand ARG</code> and <code>--flexdist DISTANCE`</code>,\n",
-        "or you may specify a set of flexible residues using <code>`--flexres`</code>. It is recommended to have as few flexible residues as possible\n",
-        "due to the increased computational cost. To specify the residues highlighted above as flexible, you can add <code>`--flexres A:49,A189`</code> to your\n",
-        "`gnina` command line argument. Here \"A\" refers to chain A.\n",
-        "</p>\n",
-        "\n",
-        "<p>Try redocking or crossdocking using Y6J and flexible docking.</p>\n",
-        "\n",
-        "<p>\n",
-        "    <i>\n",
-        "        Challenge 2: Cross Docking all ligands\n",
-        "    </i>\n",
-        "</p>\n",
-        "<p>\n",
-        "    Try docking all of your ligands to `7L11` using rigid docking. Do you observe the same ordering of ligands?\n",
-        "    </p>\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "f-1QUCH9WtkL"
-      },
-      "outputs": [],
-      "source": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "eQ5KkIRlWtz7"
-      },
-      "outputs": [],
-      "source": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "3HNmRoarWt4t"
-      },
-      "outputs": [],
-      "source": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "KJfVTr24WuCH"
-      },
-      "outputs": [],
-      "source": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "icevL2HiWuT8"
-      },
-      "outputs": [],
-      "source": []
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "-RSTDEes_wZB"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 36,
-      "metadata": {
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 428
-        },
-        "id": "-rfPfYovWkL_",
-        "outputId": "1d920b53-c18d-474a-ab03-fd8923e0b61f"
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
-            "text/html": [
-              "<style>\n",
-              "div.green-note {\n",
-              "    color: #155724; /* Dark green for text */\n",
-              "    background-color: #d4edda; /* Light green background */\n",
-              "    border-left: 5px solid #28a745; /* Bright green border */\n",
-              "    padding: 0.5em;\n",
-              "    font-size: 1.25em; /* Consistent with text size */\n",
-              "    line-height: 1.5; /* Ensures readability */\n",
-              "    font-family: Arial, sans-serif; /* Clean and modern font */\n",
-              "}\n",
-              "div.green-note ul {\n",
-              "    margin: 0.5em 0; /* Space around the list */\n",
-              "}\n",
-              "div.green-note li {\n",
-              "    margin-bottom: 0.5em; /* Space between list items */\n",
-              "}\n",
-              "</style>\n",
-              "\n",
-              "<div class=\"green-note\">\n",
-              "    <strong>Key Points:</strong>\n",
-              "    <ul>\n",
-              "        <li><code>gnina</code> is used for molecular docking via the command line, requiring prepared receptor (<code>-r</code>) and ligand (<code>-l</code>) files, defining a search box (e.g., <code>--autobox_ligand</code>), and specifying an output file (<code>-o</code>).</li>\n",
-              "        <li>Docking results are evaluated using scoring functions (<code>minimizedAffinity</code> from Vina, <code>CNNscore</code> and <code>CNNaffinity</code> from the neural network) and Root Mean Square Deviation (RMSD) to measure geometric similarity to a known pose.</li>\n",
-              "        <li><code>gnina</code>'s default <code>CNNscore</code> ranks poses based on predicted geometric accuracy (likelihood of low RMSD) and often differs from rankings based on the Vina affinity score (<code>minimizedAffinity</code>).</li>\n",
-              "        <li>Redocking assesses reproducibility against a known structure, while cross-docking (using a different but related receptor structure) tests robustness, requiring protein alignment for meaningful RMSD comparison.</li>\n",
-              "        <li>Multiple ligands can be docked efficiently by providing a multi-molecule SDF file to <code>gnina</code>, and results can be compiled and analyzed using RDKit and Pandas in Python.</li>\n",
-              "    </ul>\n",
-              "</div>\n"
-            ]
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# @title Key Points\n",
-        "%%html\n",
-        "<style>\n",
-        "div.green-note {\n",
-        "    color: #155724; /* Dark green for text */\n",
-        "    background-color: #d4edda; /* Light green background */\n",
-        "    border-left: 5px solid #28a745; /* Bright green border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Consistent with text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "    font-family: Arial, sans-serif; /* Clean and modern font */\n",
-        "}\n",
-        "div.green-note ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.green-note li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"green-note\">\n",
-        "    <strong>Key Points:</strong>\n",
-        "    <ul>\n",
-        "        <li><code>gnina</code> is used for molecular docking via the command line, requiring prepared receptor (<code>-r</code>) and ligand (<code>-l</code>) files, defining a search box (e.g., <code>--autobox_ligand</code>), and specifying an output file (<code>-o</code>).</li>\n",
-        "        <li>Docking results are evaluated using scoring functions (<code>minimizedAffinity</code> from Vina, <code>CNNscore</code> and <code>CNNaffinity</code> from the neural network) and Root Mean Square Deviation (RMSD) to measure geometric similarity to a known pose.</li>\n",
-        "        <li><code>gnina</code>'s default <code>CNNscore</code> ranks poses based on predicted geometric accuracy (likelihood of low RMSD) and often differs from rankings based on the Vina affinity score (<code>minimizedAffinity</code>).</li>\n",
-        "        <li>Redocking assesses reproducibility against a known structure, while cross-docking (using a different but related receptor structure) tests robustness, requiring protein alignment for meaningful RMSD comparison.</li>\n",
-        "        <li>Multiple ligands can be docked efficiently by providing a multi-molecule SDF file to <code>gnina</code>, and results can be compiled and analyzed using RDKit and Pandas in Python.</li>\n",
-        "    </ul>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "fY45SjZbXHwb"
-      },
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "gpuType": "T4",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.11.11"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Hz731IZ6sXmi"
+   },
+   "source": [
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:325px;\">\n",
+    "</div>\n",
+    "\n",
+    "\n",
+    "# Molecular Docking using gnina\n",
+    "\n",
+    "*This tutorial was written by Jessica Nash (Software Scientist) at The Molecular Sciences Software Institue for the [Cheminformatic-Driven Molecular Docking Workshop](https://pdb101.rcsb.org/news/67d9853eaddf75595bd158f7) held as a Crash Course with the Institute for Quantitative Biomedicine (IQB) and the Protein Data Bank (PDB). Special thanks to Pat Walters and David Koes for feedback, suggestions, and proofreading on this notebook.*\n",
+    "\n",
+    "*This notebook is Part 4 of 4 in the notebook series.*\n",
+    "\n",
+    "Other notebooks in this series:\n",
+    "1. [Digital Representation of Molecules](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/01_Cheminfo_crash_course.ipynb)\n",
+    "2. [Exploring Chemical and Biological Data with BindingDB and the RDKit](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/02_Cheminfo_crash_course.ipynb)\n",
+    "3. [Preparing Structures for Docking](https://colab.research.google.com/github/MolSSI-Education/iqb-2025/blob/main/03_Cheminfo_crash_course.ipynb)\n",
+    "4. **Molecular Docking using gnina** (this notebook)\n",
+    "\n",
+    "In this notebook, we will perform molecular docking of our original bound ligand along with the ligands we prepared in the last notebook.\n",
+    "Molecular docking is a computational method that predicts the preferred orientation of one molecule (the ligand) when bound to another molecule (the receptor, often a protein).\n",
+    "\n",
+    "For docking, we will use a program called [gnina](https://github.com/gnina/gnina). gnina is pronounced `nee-na` (silent g) and is a fork of a software program called smina, which is itself a fork of Autodock Vina.\n",
+    "For those unfamiliar with software development lingo, a \"fork\" is a copy of a project. Forks may be modified and diverge from the original project.\n",
+    "Autodock Vina is the program we used for docking in last year's PDB Crash Course.\n",
+    "\n",
+    "smina was created from AutoDock Vina in order to allow easier set up of docking calculations as well as to allow more customization of the scoring function. smina allows you to set the binding site automatically based on distance from a ligand as well as to define your own scoring functions. gnina builds on that by adding rescoring with convoluational neural networks to improve pose prediction. In this notebook, we will use gnina.\n",
+    "\n",
+    "If you find gnina useful and use it in your own research, please be sure to cite the appropriate papers:\n",
+    "\n",
+    "Citation\n",
+    "========\n",
+    "\n",
+    "**GNINA 1.0: Molecular docking with deep learning** (Primary application citation)  \n",
+    "A McNutt, P Francoeur, R Aggarwal, T Masuda, R Meli, M Ragoza, J Sunseri, DR Koes. *J. Cheminformatics*, 2021  \n",
+    "[link](https://jcheminf.biomedcentral.com/articles/10.1186/s13321-021-00522-2) [PubMed](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8191141/) [ChemRxiv](https://chemrxiv.org/articles/preprint/GNINA_1_0_Molecular_Docking_with_Deep_Learning/13578140)\n",
+    "\n",
+    "**Protein–Ligand Scoring with Convolutional Neural Networks**  (Primary methods citation)  \n",
+    "M Ragoza, J Hochuli, E Idrobo, J Sunseri, DR Koes. *J. Chem. Inf. Model*, 2017  \n",
+    "[link](http://pubs.acs.org/doi/full/10.1021/acs.jcim.6b00740) [PubMed](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5479431/) [arXiv](https://arxiv.org/abs/1612.02751)  \n",
+    "\n",
+    "**Ligand pose optimization with atomic grid-based convolutional neural networks**  \n",
+    "M Ragoza, L Turner, DR Koes. *Machine Learning for Molecules and Materials NIPS 2017 Workshop*, 2017  \n",
+    "[arXiv](https://arxiv.org/abs/1710.07400)  \n",
+    "\n",
+    "**Visualizing convolutional neural network protein-ligand scoring**  \n",
+    "J Hochuli, A Helbling, T Skaist, M Ragoza, DR Koes.  *Journal of Molecular Graphics and Modelling*, 2018  \n",
+    "[link](https://www.sciencedirect.com/science/article/pii/S1093326318301670) [PubMed](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6343664/) [arXiv](https://arxiv.org/abs/1803.02398)\n",
+    "\n",
+    "**Convolutional neural network scoring and minimization in the D3R 2017 community challenge**  \n",
+    "J Sunseri, JE King, PG Francoeur, DR Koes.  *Journal of computer-aided molecular design*, 2018  \n",
+    "[link](https://link.springer.com/article/10.1007/s10822-018-0133-y) [PubMed](https://www.ncbi.nlm.nih.gov/pubmed/29992528)\n",
+    "\n",
+    "**Three-Dimensional Convolutional Neural Networks and a Cross-Docked Data Set for Structure-Based Drug Design**  \n",
+    "PG Francoeur, T Masuda, J Sunseri, A Jia, RB Iovanisci, I Snyder, DR Koes. *J. Chem. Inf. Model*, 2020  \n",
+    "[link](https://pubs.acs.org/doi/abs/10.1021/acs.jcim.0c00411) [PubMed](https://pubmed.ncbi.nlm.nih.gov/32865404/) [Chemrxiv](https://chemrxiv.org/articles/preprint/3D_Convolutional_Neural_Networks_and_a_CrossDocked_Dataset_for_Structure-Based_Drug_Design/11833323/1)\n",
+    "\n",
+    "**Virtual Screening with Gnina 1.0**\n",
+    "J Sunseri, DR Koes D. *Molecules*, 2021\n",
+    "[link](https://www.mdpi.com/1420-3049/26/23/7369) [Preprints](https://www.preprints.org/manuscript/202111.0329/v1)"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 490
+    },
+    "id": "BcDfbcA5seGI",
+    "outputId": "1b8a4a16-cf6d-4f8d-82c3-aaa6d7480775"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.alert {\n",
+       "    color: #0056b3;\n",
+       "    background-color: #d9edf7;\n",
+       "    border-left: 5px solid #31708f;\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em;\n",
+       "    line-height: 1.5;\n",
+       "}\n",
+       "div.alert ul {\n",
+       "    margin: 0.5em 0;\n",
+       "}\n",
+       "div.alert li {\n",
+       "    margin-bottom: 0.5em;\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"alert alert-block alert-info\">\n",
+       "    <strong>Questions:</strong>\n",
+       "    <ul>\n",
+       "        <li>How can I perform molecular docking using the gnina software?</li>\n",
+       "        <li>What is redocking and how do I perform it?</li>\n",
+       "        <li>What is crossdocking and how do I perform it?</li>\n",
+       "        <li>How are docking results evaluated using scores and Root Mean Square Deviation (RMSD)?</li>\n",
+       "        <li>How do `gnina`'s CNN scores differ from traditional Vina scores in practice?</li>\n",
+       "        <li>How can I dock multiple ligands with gnina?</li>\n",
+       "        <li>How can docking results for multiple compounds be compared?</li>\n",
+       "    </ul>\n",
+       "\n",
+       "    <strong>Objectives:</strong>\n",
+       "    <ul>\n",
+       "        <li>Use `gnina` to perform molecular docking for single and multiple ligands.</li>\n",
+       "        <li>Visualize docked poses within the protein binding site.</li>\n",
+       "        <li>Calculate RMSD to evaluate redocking and cross docking accuracy.</li>\n",
+       "        <li>Interpret the different scoring outputs from `gnina`.</li>\n",
+       "    </ul>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title Overview\n",
+    "%%html\n",
+    "<style>\n",
+    "div.alert {\n",
+    "    color: #0056b3;\n",
+    "    background-color: #d9edf7;\n",
+    "    border-left: 5px solid #31708f;\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em;\n",
+    "    line-height: 1.5;\n",
+    "}\n",
+    "div.alert ul {\n",
+    "    margin: 0.5em 0;\n",
+    "}\n",
+    "div.alert li {\n",
+    "    margin-bottom: 0.5em;\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <strong>Questions:</strong>\n",
+    "    <ul>\n",
+    "        <li>How can I perform molecular docking using the gnina software?</li>\n",
+    "        <li>What is redocking and how do I perform it?</li>\n",
+    "        <li>What is crossdocking and how do I perform it?</li>\n",
+    "        <li>How are docking results evaluated using scores and Root Mean Square Deviation (RMSD)?</li>\n",
+    "        <li>How do `gnina`'s CNN scores differ from traditional Vina scores in practice?</li>\n",
+    "        <li>How can I dock multiple ligands with gnina?</li>\n",
+    "        <li>How can docking results for multiple compounds be compared?</li>\n",
+    "    </ul>\n",
+    "\n",
+    "    <strong>Objectives:</strong>\n",
+    "    <ul>\n",
+    "        <li>Use `gnina` to perform molecular docking for single and multiple ligands.</li>\n",
+    "        <li>Visualize docked poses within the protein binding site.</li>\n",
+    "        <li>Calculate RMSD to evaluate redocking and cross docking accuracy.</li>\n",
+    "        <li>Interpret the different scoring outputs from `gnina`.</li>\n",
+    "    </ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AsAJ6XjquK-X"
+   },
+   "source": [
+    "## Set Up\n",
+    "The cells in this section set up the software and files we will need for our calculations.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Km6XsVhTSlxW"
+   },
+   "source": [
+    "\n",
+    "### Install Python Packages  \n",
+    "1. `useful_rdkit_utils` is a Python package written and maintained by Pat Walters that contains useful RDKit functions. We will use it for the functions `mcs_rmsd` (explained later).\n",
+    "2. `py3Dmol` is used for molecular visualization.\n",
+    "3. The RDKit is a popular cheminiformatics package we will use for processing molecules.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Bf5bjLD0uLfv"
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "!pip install useful_rdkit_utils py3Dmol rdkit\n",
+    "!apt install openbabel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "SdpafOZWSeXd"
+   },
+   "source": [
+    "### Download gnina\n",
+    "\n",
+    "We are downloading the pre-compiled binary of gnina. You may also compile gnina yourself by following the directions on the [gnina GitHub repository](https://github.com/gnina/gnina)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "WnjkCEiA08o_"
+   },
+   "outputs": [],
+   "source": [
+    "# Download gnina\n",
+    "!wget https://github.com/gnina/gnina/releases/download/v1.3/gnina.fix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Tir5QGznJ-iA"
+   },
+   "outputs": [],
+   "source": [
+    "# Make gnina executable\n",
+    "!mv gnina.fix gnina\n",
+    "!chmod +x gnina"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8XkECD7sSTGH"
+   },
+   "source": [
+    "### Get Lesson Files\n",
+    "\n",
+    "We have stored the files created in the last notebook as a zip file and stored it on GitHub. This cell downloads that file as well as `util.py` which contains a custom utility function for visualizing our ligand and protein.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "vbznC0r_4IdM"
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "!wget https://github.com/MolSSI-Education/iqb-2025/raw/refs/heads/main/data/docking_files.zip\n",
+    "!wget https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/main/util.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bzzSgnUr4Z5d"
+   },
+   "outputs": [],
+   "source": [
+    "!unzip docking_files.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "YJ8KQSrcY0nd"
+   },
+   "source": [
+    "## Docking with gnina\n",
+    "\n",
+    "Molecular Docking involves involves two main stages:\n",
+    "\n",
+    "1. Sampling: The algorithm explores many possible positions and orientations (or \"poses\") of the ligand within the receptor's active site. In AutoDock Vina, smina, and gnina, conformations are generated using Monte Carlo Sampling.\n",
+    "2. Scoring: Each generated pose is evaluated using a scoring function which estimates the binding affinity. Poses are then ranked on these scores. For Vina scores, lower energy scores indicating more favorable interactions.\n",
+    "\n",
+    "In addition to the traditional scoring functions avaiable in Vina and smina, gnina adds convolutional neural networks (CNNs) to scoring.  These deep learning models analyze a 3D grid representation of the protein-ligand complex, essentially evaluating a \"picture\" of the interaction based on atomic densities.\n",
+    "\n",
+    "By default, gnina uses results from the CNN for **rescoring**, meaning that poses are initially sampled and scored with the traditional Vina scoring function but re-ranked after sampling using CNN models. You can, however, choose to use the CNN for all scoring, refinement, or not at all (using CNN scoring for refinement or all scoring is more computationally intensive).\n",
+    "\n",
+    "For more details see the paper on [gnina v1.0](https://jcheminf.biomedcentral.com/articles/10.1186/s13321-021-00522-2) and [gnina v1.3](https://jcheminf.biomedcentral.com/articles/10.1186/s13321-025-00973-x)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WYzeWNO5uHxL"
+   },
+   "source": [
+    "## Redocking the Ligand\n",
+    "\n",
+    "Redocking (also called \"cognate docking\") involves redocking a ligand back into the receptor structure from which the bound pose was experimentally determined.\n",
+    "Redocking is typically done to evaluate how well a docking program's sampling algorithm and scoring function and reproduce a known experimental binding pose.\n",
+    "\n",
+    "We will begin our docking journey with gnina by performing a redock of our ligand."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "nDaEbegLZVzr"
+   },
+   "outputs": [],
+   "source": [
+    "from util import visualize_poses\n",
+    "\n",
+    "v = visualize_poses(\n",
+    "    \"docking_files/protein_structures/7LME_fixed.pdb\",\n",
+    "    \"docking_files/ligand_structures/Y6J_corrected_pose.sdf\",\n",
+    ")\n",
+    "v.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gyJOkQp0ZW2Y"
+   },
+   "source": [
+    "You may execute the cell below, and read the following explanation on the input parameters for gnina. gnina works through the command line, so we cannot use in-line comments.\n",
+    "\n",
+    "```\n",
+    "./gnina \\\n",
+    "  # Specify the receptor structure file (-r).\n",
+    "  # This file (7LME.pdbqt) should be prepared for docking (e.g., with hydrogens added).\n",
+    "  -r docking_files/7LME_all_atom.pdbqt \\\n",
+    "  # Specify the ligand structure file (-l) to be docked.\n",
+    "  # This file (Y6J_ideal.pdbqt) contains the 3D coordinates of the ligand.\n",
+    "  -l docking_files/Y6J_ideal.pdbqt \\\n",
+    "  # Define the docking search box automatically (--autobox_ligand).\n",
+    "  # The box will be centered around the coordinates of the ligand in the specified file\n",
+    "  # (Y6J_corrected_pose.sdf), which is the known experimental pose in this redocking example.\n",
+    "  # An optional padding (default 4Å) is added.\n",
+    "  --autobox_ligand docking_files/Y6J_corrected_pose.sdf \\\n",
+    "  # Specify the output file path (-o) where the resulting docked poses will be saved.\n",
+    "  # The output format will be SDF, containing multiple poses ranked by score.\n",
+    "  -o docking_results/Y6J_docked_e12.sdf \\\n",
+    "  # Set the random number generator seed (--seed) to 0.\n",
+    "  # Using a fixed seed makes the docking calculation reproducible.\n",
+    "  --seed 0 \\\n",
+    "  # Set the exhaustiveness level (--exhaustiveness) to 12.\n",
+    "  # This controls the number of Monte Carlo chains for the ligand.\n",
+    "  # The default is 8\n",
+    "  --exhaustiveness 16\n",
+    "  ```\n",
+    "\n",
+    "  Execute the next cell to run gnina.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 273
+    },
+    "id": "7cAKRSGwYxo6",
+    "outputId": "79380cef-982a-411f-fad2-9a0964cc4b4f"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.purple-box {\n",
+       "    color: #4b0082; /* Indigo for text */\n",
+       "    background-color: #f3e5f5; /* Light lavender background */\n",
+       "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+       "}\n",
+       "div.purple-box ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.purple-box li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "<div class=\"purple-box\">\n",
+       "   <p> Execute the next cell below to start running\n",
+       "your docking calculation. Then, come back and try these navigation tips for Py3DMol.</p>\n",
+       "    <strong>Py3DMol Visualization Navigation:</strong>\n",
+       "    <table border=\"1\" style=\"border-collapse: collapse; width: 100%;\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th>Movement</th>\n",
+       "      <th>Mouse Input</th>\n",
+       "      <th>Touch Input</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>Rotation</td>\n",
+       "      <td>Primary Mouse Button</td>\n",
+       "      <td>Single touch</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>Translation</td>\n",
+       "      <td>Middle Mouse Button or Ctrl+Primary</td>\n",
+       "      <td>Triple touch</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>Zoom</td>\n",
+       "      <td>Scroll Wheel or Second Mouse Button or Shift+Primary</td>\n",
+       "      <td>Pinch (double touch)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>Slab</td>\n",
+       "      <td>Ctrl+Second</td>\n",
+       "      <td>Not Available</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title While you Wait: Navigating py3DMol visualizations\n",
+    "%%html\n",
+    "<style>\n",
+    "div.purple-box {\n",
+    "    color: #4b0082; /* Indigo for text */\n",
+    "    background-color: #f3e5f5; /* Light lavender background */\n",
+    "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+    "}\n",
+    "div.purple-box ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.purple-box li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "<div class=\"purple-box\">\n",
+    "   <p> Execute the next cell below to start running\n",
+    "your docking calculation. Then, come back and try these navigation tips for Py3DMol.</p>\n",
+    "    <strong>Py3DMol Visualization Navigation:</strong>\n",
+    "    <table border=\"1\" style=\"border-collapse: collapse; width: 100%;\">\n",
+    "  <thead>\n",
+    "    <tr>\n",
+    "      <th>Movement</th>\n",
+    "      <th>Mouse Input</th>\n",
+    "      <th>Touch Input</th>\n",
+    "    </tr>\n",
+    "  </thead>\n",
+    "  <tbody>\n",
+    "    <tr>\n",
+    "      <td>Rotation</td>\n",
+    "      <td>Primary Mouse Button</td>\n",
+    "      <td>Single touch</td>\n",
+    "    </tr>\n",
+    "    <tr>\n",
+    "      <td>Translation</td>\n",
+    "      <td>Middle Mouse Button or Ctrl+Primary</td>\n",
+    "      <td>Triple touch</td>\n",
+    "    </tr>\n",
+    "    <tr>\n",
+    "      <td>Zoom</td>\n",
+    "      <td>Scroll Wheel or Second Mouse Button or Shift+Primary</td>\n",
+    "      <td>Pinch (double touch)</td>\n",
+    "    </tr>\n",
+    "    <tr>\n",
+    "      <td>Slab</td>\n",
+    "      <td>Ctrl+Second</td>\n",
+    "      <td>Not Available</td>\n",
+    "    </tr>\n",
+    "  </tbody>\n",
+    "</table>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Fw7fjHKQshRM"
+   },
+   "outputs": [],
+   "source": [
+    "# make a folder for our results\n",
+    "!mkdir -p docking_results\n",
+    "\n",
+    "# use gnina\n",
+    "!./gnina \\\n",
+    "  -r docking_files/protein_structures/7LME.pdbqt \\\n",
+    "  -l docking_files/ligand_structures/Y6J_ideal.sdf \\\n",
+    "  --autobox_ligand docking_files/ligand_structures/Y6J_corrected_pose.sdf \\\n",
+    "  -o docking_results/Y6J_docked_7LME.sdf \\\n",
+    "  --seed 0 \\\n",
+    "  --exhaustiveness 16"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "V9rQtIt1BAbi"
+   },
+   "source": [
+    "### Interpreting the output\n",
+    "\n",
+    "When `gnina` finishes a docking run, it prints a summary table for the generated poses. This table is sorted by pose rank, with the poses `gnina` determined to be the best at the top.\n",
+    "\n",
+    "The columns are the following:\n",
+    "\n",
+    "* `mode`: pose rank\n",
+    "* `affinity (kcal/mol)`: the Vina score\n",
+    "* `intra (kcal/mol)`: the ligand's internal strain energy according to the Vina function\n",
+    "* `CNN pose score`: the score from the convolutional neural network predicting pose quality, where higher values closer to 1 indicate higher confidence in the pose's geometric accuracy and are used for ranking.\n",
+    "* `CNN affinity`: The CNN's prediction of binding affinity, expressed in pK units (higher values mean stronger binding, e.g., a predicted score of 9 corresponds to nanomolar (nM) affinity).\n",
+    "\n",
+    "Looking at tscores for the redocked Y6J ligand, the table shows the poses ranked by `CNN pose score` (higher is better), with `mode 1` scoring highest (approx. 0.81). Notably, this differs from the ranking by the Vina `affinity` score (lower is better), where `mode 3` is most favorable (-7.51 kcal/mol) but has a much lower `CNN pose score` (approx. 0.49).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WY5_D7aD_KyU"
+   },
+   "source": [
+    "### Visualizing the Docked Structures\n",
+    "\n",
+    "In the cell below, we use a function called `visualize_docked_structures`, a custom function defined for this workshop that we obtained above when we retreived `util.py`.\n",
+    "This function allows us to view our generated docked structures along with ligand it its original experimentally determined position."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NMR8YzT_47me"
+   },
+   "outputs": [],
+   "source": [
+    "v = visualize_poses(\n",
+    "    \"docking_files/protein_structures/7LME_fixed.pdb\",\n",
+    "    \"docking_results/Y6J_docked_7LME.sdf\",\n",
+    "    cognate_file=\"docking_files/ligand_structures/Y6J_corrected_pose.sdf\",\n",
+    "    animate=False,\n",
+    ")  # Change to True to see an animation of all of the poses\n",
+    "v.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Ky5T3UaU1lDP"
+   },
+   "source": [
+    "### Measuring Root-Mean-Square-Deviation (RMSD)\n",
+    "\n",
+    "After generating docked poses, we next need to quantitatively evaluate how close the known reference structure.\n",
+    "The standard metric used for this comparison is the **Root Mean Square Deviation (RMSD)**.\n",
+    "RMSD measures the average distance between corresponding atoms of two molecular structures.\n",
+    "A lower RMSD value indicates greater similarity between the docked pose and the reference structure.\n",
+    "Mathematically, it's calculated as:\n",
+    "\n",
+    "$$\n",
+    "RMSD = \\sqrt[2]{\\frac{1}{N} \\sum_{i=1}^{N} \\delta_i^2}\n",
+    "$$\n",
+    "\n",
+    "\n",
+    "\n",
+    "where $N$ is the number of corresponding atom pairs being compared, and $\\delta_i$ is the Euclidean distance between the $i$-th pair of atoms\n",
+    "In docking studies, a common threshold for considering a docked pose \"successful\" or accurate is an RMSD below 2 Angstroms compared to the crystal structure.\n",
+    "\n",
+    "In this notebook, we will use the `mcs_rmsd` function from the `useful_rdkit_utils` package, written by Pat Walters (a co-instructor of this workshop!).\n",
+    "This function calculates the RMSD, but with a useful modification: it first identifies the **Maximum Common Substructure (MCS)** between the two input molecules using RDKit's `FindMCS` functionality.\n",
+    "It then calculates the RMSD using only the corresponding atoms belonging to this shared substructure.\n",
+    "This approach is particularly valuable when comparing molecules that are similar but not identical, as it focuses the RMSD calculation on the parts of the molecules that match.\n",
+    "While for redocking the original ligand the MCS will typically be the entire molecule, this function can be used later when we compare the poses of different (but similar) docked ligands to the original crystal ligand.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "EcrJ1i77uQO2"
+   },
+   "outputs": [],
+   "source": [
+    "import useful_rdkit_utils as uru\n",
+    "from rdkit import Chem\n",
+    "\n",
+    "cognate = Chem.MolFromMolFile(\"docking_files/ligand_structures/Y6J_corrected_pose.sdf\")\n",
+    "poses = Chem.SDMolSupplier(\"docking_results/Y6J_docked_7LME.sdf\")\n",
+    "\n",
+    "for i, pose in enumerate(poses):\n",
+    "    n_match, rmsd = uru.mcs_rmsd(cognate, pose)\n",
+    "    print(f\"{n_match}\\t{rmsd:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 152
+    },
+    "id": "9IKXZt1GJD59",
+    "outputId": "b0fa9f6e-96fb-47bb-e031-35fc6389fd84"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.orange-alert {\n",
+       "    color: #854f00; /* Darker shade of orange for text */\n",
+       "    background-color: #ffe6cc; /* Light orange background */\n",
+       "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.orange-alert ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.orange-alert li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"orange-alert\">\n",
+       "\n",
+       "<strong>How is docking without the CNN rescoring?</strong>\n",
+       "\n",
+       "<p>You can turn off CNN rescoring with gnina by adding <code>--cnn_scoring none</code> to\n",
+       "  your gnina command. Try doing this - make sure to save your results in a new file.\n",
+       "\n",
+       "  How does it affect redocking, particularly the measured RMSD score of the docked structures?\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title Exercise\n",
+    "%%html\n",
+    "<style>\n",
+    "div.orange-alert {\n",
+    "    color: #854f00; /* Darker shade of orange for text */\n",
+    "    background-color: #ffe6cc; /* Light orange background */\n",
+    "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.orange-alert ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.orange-alert li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"orange-alert\">\n",
+    "\n",
+    "<strong>How is docking without the CNN rescoring?</strong>\n",
+    "\n",
+    "<p>You can turn off CNN rescoring with gnina by adding <code>--cnn_scoring none</code> to\n",
+    "  your gnina command. Try doing this - make sure to save your results in a new file.\n",
+    "\n",
+    "  How does it affect redocking, particularly the measured RMSD score of the docked structures?\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ha9UX8Y4nI03"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "01yc6AghnOev"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0UCtKY_MeMwM"
+   },
+   "source": [
+    "## Cross Docking the Ligand\n",
+    "\n",
+    "We've seen that gnina does a great job fitting the ligand back into its original structure. However, this is an \"easier\" problem than docking a ligand into an unknown structure. When we redock, the binding cavity for the ligand will be perfectly fit for the ligand we are testing.\n",
+    "\n",
+    "When performing cross-docking, you dock the ligand into the structure, but with a different version of the protein structure (a main protease structure from a different PDB ID with a different ligand bound, or with no ligand). If our docking is working well, we should get the same structure for the ligand regardless of the PDB ID we are docking to.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 315
+    },
+    "id": "GsGJWgeFJ1Do",
+    "outputId": "3ea4c37f-8872-4df8-df5e-d5d4f11addc8"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.purple-box {\n",
+       "    color: #4b0082; /* Indigo for text */\n",
+       "    background-color: #f3e5f5; /* Light lavender background */\n",
+       "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+       "}\n",
+       "div.purple-box ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.purple-box li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"purple-box\">\n",
+       "    <strong>Cross Docking Structure Prep:</strong>\n",
+       "    <p>\n",
+       "        If you want to perform cross-docking and measure the RMSD of the docked ligands, you will need your two protein structures to be aligned.\n",
+       "        Although two PDB IDs may have the same protein, they may differ in the translation and orientation of the protein.\n",
+       "        If you do not align the structures, the RMSD you measure will primarily be from the translation and rotation of the structure and will not give you an idea of how close the fit is.\n",
+       "    </p>\n",
+       "\n",
+       "    <p>We are going to cross dock with structure <strong>7L11</strong>.\n",
+       "    To prep this file, we loaded into VMD and aligned the protein backbone with the protein backbone of 7LME using\n",
+       "    VMD's Calculate RMSD Tool (use \"Align\" to align your structures!). We have not included this prep in the workshop\n",
+       "    </p>\n",
+       "    <pre>\n",
+       "    </pre>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title Cross Docking Structure Prep\n",
+    "%%html\n",
+    "<style>\n",
+    "div.purple-box {\n",
+    "    color: #4b0082; /* Indigo for text */\n",
+    "    background-color: #f3e5f5; /* Light lavender background */\n",
+    "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+    "}\n",
+    "div.purple-box ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.purple-box li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"purple-box\">\n",
+    "    <strong>Cross Docking Structure Prep:</strong>\n",
+    "    <p>\n",
+    "        If you want to perform cross-docking and measure the RMSD of the docked ligands, you will need your two protein structures to be aligned.\n",
+    "        Although two PDB IDs may have the same protein, they may differ in the translation and orientation of the protein.\n",
+    "        If you do not align the structures, the RMSD you measure will primarily be from the translation and rotation of the structure and will not give you an idea of how close the fit is.\n",
+    "    </p>\n",
+    "\n",
+    "    <p>We are going to cross dock with structure <strong>7L11</strong>.\n",
+    "    To prep this file, we loaded into VMD and aligned the protein backbone with the protein backbone of 7LME using\n",
+    "    VMD's Calculate RMSD Tool (use \"Align\" to align your structures!). We have not included this prep in the workshop\n",
+    "    </p>\n",
+    "    <pre>\n",
+    "    </pre>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "glGrshWkKuai"
+   },
+   "outputs": [],
+   "source": [
+    "v = visualize_poses(\n",
+    "    \"docking_files/protein_structures/7LME_fixed.pdb\",\n",
+    "    \"docking_files/ligand_structures/Y6J_corrected_pose.sdf\",\n",
+    "    cognate_file=\"docking_files/ligand_structures/XF1_corrected_pose.sdf\",\n",
+    "    animate=False,\n",
+    ")  # Change to True to see an animation of all of the poses\n",
+    "v.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "pWZCFCLozV8M"
+   },
+   "outputs": [],
+   "source": [
+    "# use gnina\n",
+    "!./gnina \\\n",
+    "  -r docking_files/protein_structures/7L11.pdbqt \\\n",
+    "  -l docking_files/ligand_structures/Y6J_ideal.sdf \\\n",
+    "  --autobox_ligand docking_files/ligand_structures/XF1_corrected_pose.sdf \\\n",
+    "  -o docking_results/Y6J_docked_7L11.sdf \\\n",
+    "  --seed 0 \\\n",
+    "  --exhaustiveness 16"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "guj5TXQE0nKg"
+   },
+   "outputs": [],
+   "source": [
+    "cognate = Chem.MolFromMolFile(\"docking_files/ligand_structures/Y6J_corrected_pose.sdf\")\n",
+    "poses = Chem.SDMolSupplier(\"docking_results/Y6J_docked_7L11.sdf\")\n",
+    "\n",
+    "for i, pose in enumerate(poses):\n",
+    "    n_match, rmsd = uru.mcs_rmsd(cognate, pose)\n",
+    "    print(f\"{n_match}\\t{rmsd:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "seIdOWw3Lpim"
+   },
+   "source": [
+    "Our crossdocking scores show very good agreement with our native structure and with redocking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-MQcT2ZIOoI_"
+   },
+   "outputs": [],
+   "source": [
+    "v = visualize_poses(\n",
+    "    \"docking_files/protein_structures/7LME_fixed.pdb\",\n",
+    "    \"docking_results/Y6J_docked_7L11.sdf\",\n",
+    "    cognate_file=\"docking_files/ligand_structures/Y6J_corrected_pose.sdf\",\n",
+    "    animate=False,\n",
+    ")  # Change to True to see an animation of all of the poses\n",
+    "v.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "k1K70FlGuQaS"
+   },
+   "source": [
+    "## Docking our Prepared Ligands\n",
+    "\n",
+    "In this section, we will dock the ligands we prepared in our previous notebook. Luckily, gnina allows docking of multiple ligands by providing an SDF with your ligands of choice."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "oUkfIkFSltIC"
+   },
+   "source": [
+    "We can run gnina for multiple ligands by providing this SDF with our ligands of interest to the `-l` argument.\n",
+    "\n",
+    "The command you can use to run gnina with multiple ligands is below:\n",
+    "\n",
+    "```\n",
+    "!./gnina \\\n",
+    "  -r docking_files/protein_structures/7LME.pdbqt \\\n",
+    "  -l docking_files/ligand_structures/ligands_to_dock.sdf \\\n",
+    "  --autobox_ligand docking_files/ligand_structures/Y6J_corrected_pose.sdf \\\n",
+    "  -o docking_results/multiple_ligands_docked.sdf \\\n",
+    "  --seed 0 \\\n",
+    "  --exhaustiveness 16\n",
+    "```\n",
+    "\n",
+    "In the interest of time for this tutorial, we will retrieve precomputed results from running this command. If you later return to this tutorial, feel free to run this calculation yourself by replacing the next cell with the command above!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "id": "IL_DE5_AIXwT",
+    "jupyter": {
+     "outputs_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!wget https://github.com/MolSSI-Education/iqb-2025/raw/refs/heads/main/data/docking_results.zip\n",
+    "!unzip -o docking_results.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2WOYZBufEw2E"
+   },
+   "source": [
+    "### Extracting the Scores\n",
+    "\n",
+    "gnina stores information docking poses and the score information in the SDF written for the dock.\n",
+    "To analyze and compare the results from all our docking runs (the redocked `Y6J` and all the `Compound_*` ligands), we need to extract this scoring information from the SDF and put it into a structured table.\n",
+    "\n",
+    "We can use RDKit PandasTools to read the molecular structures (poses) and their associated properties (scores) from the output SDF. The SDF will contain multiple poses for the docked ligands, and each pose record has the calculated scores (like `minimizedAffinity`, `CNNscore`, `CNNaffinity`, `CNN_VS`, etc.) stored as data fields. The `CNN_VS` score is the product of `CNNscore` and `CNNaffinity`. We would typically want ligands that score highly for both (and thus have a high `CNN_VS` score."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rtHWd6JsDRFz"
+   },
+   "outputs": [],
+   "source": [
+    "# uncomment to see file\n",
+    "#!cat docking_results/multiple_ligands_results.sdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "LGaIIRBCAiX8"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem import PandasTools\n",
+    "from rdkit.rdBase import BlockLogs\n",
+    "import pandas as pd\n",
+    "\n",
+    "score_columns = [\n",
+    "    \"minimizedAffinity\",\n",
+    "    \"CNNscore\",\n",
+    "    \"CNNaffinity\",\n",
+    "    \"CNN_VS\",\n",
+    "    \"CNNaffinity_variance\",\n",
+    "]\n",
+    "\n",
+    "sdf_paths = [\n",
+    "    \"docking_results/multiple_ligands_docked.sdf\",\n",
+    "    \"docking_results/Y6J_docked_7LME.sdf\",\n",
+    "]\n",
+    "\n",
+    "df_list = []\n",
+    "for filename in sdf_paths:\n",
+    "    with BlockLogs():\n",
+    "        df_list.append(PandasTools.LoadSDF(filename))\n",
+    "\n",
+    "combo_df = pd.concat(df_list)\n",
+    "\n",
+    "# PandasTools reads all SDTags as strings, convert score columns to float\n",
+    "for col in score_columns:\n",
+    "    combo_df[col] = combo_df[col].astype(float)\n",
+    "\n",
+    "combo_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "RXyqs_TK5eKH"
+   },
+   "outputs": [],
+   "source": [
+    "top_poses = combo_df.sort_values(\n",
+    "    by=\"minimizedAffinity\", ascending=True\n",
+    ").drop_duplicates(\"ID\")\n",
+    "top_poses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Mg1n66U3UUg3"
+   },
+   "source": [
+    "Interestingly, the compounds sorted by `minimizedAffinity` (the Vina score) correlates well with the observed `IC50` value from our table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "t8Wxhbh2TqSn"
+   },
+   "outputs": [],
+   "source": [
+    "ligand_data = pd.read_csv(\n",
+    "    \"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/main/data/US20240293380_examples.csv\"\n",
+    ")\n",
+    "ligand_data.sort_values(by=\"IC50 (nM)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-O7sRVPTFOoT"
+   },
+   "source": [
+    "We can also use our visualization function to visualize the docked ligands to look at how they interact with the binding site."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2xKRmAl7KZt2"
+   },
+   "outputs": [],
+   "source": [
+    "v = visualize_poses(\n",
+    "    \"docking_files/protein_structures/7LME_fixed.pdb\",\n",
+    "    \"docking_results/multiple_ligands_docked.sdf\",\n",
+    "    cognate_file=\"docking_files/ligand_structures/Y6J_corrected_pose.sdf\",\n",
+    "    animate=True,\n",
+    ")  # Change to True to see an animation of all of the poses\n",
+    "v.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VhMEb6CibvOD"
+   },
+   "source": [
+    "If we would like to visualize poses for only one molecule, we can use the RDKit's PandasTools again to write an SDF for just that compound."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "IxhoYC2KMzwF"
+   },
+   "outputs": [],
+   "source": [
+    "compound_name = \"Compound_12_i0\"\n",
+    "\n",
+    "compound_df = combo_df[combo_df[\"ID\"] == compound_name]\n",
+    "\n",
+    "PandasTools.WriteSDF(\n",
+    "    compound_df,\n",
+    "    f\"docking_results/individual_{compound_name}.sdf\",  # Output file path\n",
+    "    molColName=\"ROMol\",  # Name of the column with RDKit molecules\n",
+    "    properties=score_columns,  # List of property columns to include\n",
+    ")\n",
+    "\n",
+    "\n",
+    "cognate = Chem.MolFromMolFile(\"docking_files/ligand_structures/Y6J_corrected_pose.sdf\")\n",
+    "poses = Chem.SDMolSupplier(f\"docking_results/individual_{compound_name}.sdf\")\n",
+    "\n",
+    "for i, pose in enumerate(poses):\n",
+    "    n_match, rmsd = uru.mcs_rmsd(cognate, pose)\n",
+    "    print(f\"{n_match}\\t{rmsd:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "r9ThxHGXZxPa"
+   },
+   "outputs": [],
+   "source": [
+    "v = visualize_poses(\n",
+    "    \"docking_files/protein_structures/7LME_fixed.pdb\",\n",
+    "    f\"docking_results/individual_{compound_name}.sdf\",\n",
+    "    cognate_file=f\"docking_results/individual_{compound_name}.sdf\",\n",
+    "    animate=False,\n",
+    ")  # Change to True to see an animation of all of the poses\n",
+    "v.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 402
+    },
+    "id": "uRm7Jby4V6Pq",
+    "outputId": "7b34345e-d644-4ac5-b2f9-713d93383633"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.purple-box {\n",
+       "    color: #4b0082; /* Indigo for text */\n",
+       "    background-color: #f3e5f5; /* Light lavender background */\n",
+       "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+       "}\n",
+       "div.purple-box ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.purple-box li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"purple-box\">\n",
+       "    <strong>Flexible & Whole Protein Docking with GNINA</strong>\n",
+       "    <ul>\n",
+       "        <li><b>Flexible Docking:</b> <code>gnina</code> allows specific receptor sidechains to be treated as flexible during docking. This is typically enabled using command-line options like <code>--flexdist_ligand</code> (to specify a reference point, often the ligand) and <code>--flexdist</code> (to set a distance threshold around that point for selecting flexible residues).</li>\n",
+       "        <li><b>Whole Protein Docking:</b> When the binding site isn't known beforehand, <code>gnina</code> can perform whole protein docking. This is usually done by setting the search box to encompass the entire receptor, commonly achieved by providing the receptor file itself as the argument to <code>--autobox_ligand</code>. This allows the ligand to explore the entire protein surface for potential binding pockets. <i>Note: Due to the much larger search space, significantly higher <code>--exhaustiveness</code> settings are strongly recommended for whole protein docking.</i></li>\n",
+       "    </ul>\n",
+       "\n",
+       "    However, be careful using these options as they are much more computationally expensive than rigid docking.\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title More gnina Docking Options\n",
+    "%%html\n",
+    "<style>\n",
+    "div.purple-box {\n",
+    "    color: #4b0082; /* Indigo for text */\n",
+    "    background-color: #f3e5f5; /* Light lavender background */\n",
+    "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+    "}\n",
+    "div.purple-box ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.purple-box li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"purple-box\">\n",
+    "    <strong>Flexible & Whole Protein Docking with GNINA</strong>\n",
+    "    <ul>\n",
+    "        <li><b>Flexible Docking:</b> <code>gnina</code> allows specific receptor sidechains to be treated as flexible during docking. This is typically enabled using command-line options like <code>--flexdist_ligand</code> (to specify a reference point, often the ligand) and <code>--flexdist</code> (to set a distance threshold around that point for selecting flexible residues).</li>\n",
+    "        <li><b>Whole Protein Docking:</b> When the binding site isn't known beforehand, <code>gnina</code> can perform whole protein docking. This is usually done by setting the search box to encompass the entire receptor, commonly achieved by providing the receptor file itself as the argument to <code>--autobox_ligand</code>. This allows the ligand to explore the entire protein surface for potential binding pockets. <i>Note: Due to the much larger search space, significantly higher <code>--exhaustiveness</code> settings are strongly recommended for whole protein docking.</i></li>\n",
+    "    </ul>\n",
+    "\n",
+    "    However, be careful using these options as they are much more computationally expensive than rigid docking.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8azkxhAJ8acU"
+   },
+   "source": [
+    "## Flexible Docking\n",
+    "\n",
+    "Throughout this tutorial, we've performed docking calculations treating the protein as a rigid receptor. This is a common thing to do and is computationally efficient. However, sometimes the binding site needs to adjust its  shape to accommodate a ligand. This is called \"induced fit\".\n",
+    "\n",
+    "Induced fit is observed for our structure, according to the [reference](https://pubs.acs.org/doi/10.1021/acs.jmedchem.1c00598), particularly Gln 189 and Met49 have flexible sidechains. We have likely observed good docking results because all of our ligands bind to this site in a similar way and the structures we have started from already fit this well.\n",
+    "\n",
+    "In the cell below, we add an argument to highlight residues to show where these residues are relative to our binding site."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "kD0e9a945TBC"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 359
+    },
+    "id": "P-JeC8EoWPrI",
+    "outputId": "8b28ef90-8103-4730-df91-b217f2551fd9"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.orange-alert {\n",
+       "    color: #854f00; /* Darker shade of orange for text */\n",
+       "    background-color: #ffe6cc; /* Light orange background */\n",
+       "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "}\n",
+       "div.orange-alert ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.orange-alert li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"orange-alert\">\n",
+       "\n",
+       "<strong>Final Challenge</strong>\n",
+       "\n",
+       "<p>\n",
+       "<i>Challenge 1: Flexible Docking</i>\n",
+       "</p>\n",
+       "\n",
+       "<p>\n",
+       "As stated above, sometimes your docking site may be flexible. `gnina` allows for flexible docking in a few different ways.\n",
+       "You may either use a cut off distance from a target with <code>--flexdist_ligand ARG</code> and <code>--flexdist DISTANCE`</code>,\n",
+       "or you may specify a set of flexible residues using <code>`--flexres`</code>. It is recommended to have as few flexible residues as possible\n",
+       "due to the increased computational cost. To specify the residues highlighted above as flexible, you can add <code>`--flexres A:49,A189`</code> to your\n",
+       "`gnina` command line argument. Here \"A\" refers to chain A.\n",
+       "</p>\n",
+       "\n",
+       "<p>Try redocking or crossdocking using Y6J and flexible docking.</p>\n",
+       "\n",
+       "<p>\n",
+       "    <i>\n",
+       "        Challenge 2: Cross Docking all ligands\n",
+       "    </i>\n",
+       "</p>\n",
+       "<p>\n",
+       "    Try docking all of your ligands to `7L11` using rigid docking. Do you observe the same ordering of ligands?\n",
+       "    </p>\n",
+       "\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title Final Exercise\n",
+    "%%html\n",
+    "<style>\n",
+    "div.orange-alert {\n",
+    "    color: #854f00; /* Darker shade of orange for text */\n",
+    "    background-color: #ffe6cc; /* Light orange background */\n",
+    "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.orange-alert ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.orange-alert li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"orange-alert\">\n",
+    "\n",
+    "<strong>Final Challenge</strong>\n",
+    "\n",
+    "<p>\n",
+    "<i>Challenge 1: Flexible Docking</i>\n",
+    "</p>\n",
+    "\n",
+    "<p>\n",
+    "As stated above, sometimes your docking site may be flexible. `gnina` allows for flexible docking in a few different ways.\n",
+    "You may either use a cut off distance from a target with <code>--flexdist_ligand ARG</code> and <code>--flexdist DISTANCE`</code>,\n",
+    "or you may specify a set of flexible residues using <code>`--flexres`</code>. It is recommended to have as few flexible residues as possible\n",
+    "due to the increased computational cost. To specify the residues highlighted above as flexible, you can add <code>`--flexres A:49,A189`</code> to your\n",
+    "`gnina` command line argument. Here \"A\" refers to chain A.\n",
+    "</p>\n",
+    "\n",
+    "<p>Try redocking or crossdocking using Y6J and flexible docking.</p>\n",
+    "\n",
+    "<p>\n",
+    "    <i>\n",
+    "        Challenge 2: Cross Docking all ligands\n",
+    "    </i>\n",
+    "</p>\n",
+    "<p>\n",
+    "    Try docking all of your ligands to `7L11` using rigid docking. Do you observe the same ordering of ligands?\n",
+    "    </p>\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "f-1QUCH9WtkL"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "eQ5KkIRlWtz7"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "3HNmRoarWt4t"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "KJfVTr24WuCH"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "icevL2HiWuT8"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-RSTDEes_wZB"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "cellView": "form",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 428
+    },
+    "id": "-rfPfYovWkL_",
+    "outputId": "1d920b53-c18d-474a-ab03-fd8923e0b61f"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "div.green-note {\n",
+       "    color: #155724; /* Dark green for text */\n",
+       "    background-color: #d4edda; /* Light green background */\n",
+       "    border-left: 5px solid #28a745; /* Bright green border */\n",
+       "    padding: 0.5em;\n",
+       "    font-size: 1.25em; /* Consistent with text size */\n",
+       "    line-height: 1.5; /* Ensures readability */\n",
+       "    font-family: Arial, sans-serif; /* Clean and modern font */\n",
+       "}\n",
+       "div.green-note ul {\n",
+       "    margin: 0.5em 0; /* Space around the list */\n",
+       "}\n",
+       "div.green-note li {\n",
+       "    margin-bottom: 0.5em; /* Space between list items */\n",
+       "}\n",
+       "</style>\n",
+       "\n",
+       "<div class=\"green-note\">\n",
+       "    <strong>Key Points:</strong>\n",
+       "    <ul>\n",
+       "        <li><code>gnina</code> is used for molecular docking via the command line, requiring prepared receptor (<code>-r</code>) and ligand (<code>-l</code>) files, defining a search box (e.g., <code>--autobox_ligand</code>), and specifying an output file (<code>-o</code>).</li>\n",
+       "        <li>Docking results are evaluated using scoring functions (<code>minimizedAffinity</code> from Vina, <code>CNNscore</code> and <code>CNNaffinity</code> from the neural network) and Root Mean Square Deviation (RMSD) to measure geometric similarity to a known pose.</li>\n",
+       "        <li><code>gnina</code>'s default <code>CNNscore</code> ranks poses based on predicted geometric accuracy (likelihood of low RMSD) and often differs from rankings based on the Vina affinity score (<code>minimizedAffinity</code>).</li>\n",
+       "        <li>Redocking assesses reproducibility against a known structure, while cross-docking (using a different but related receptor structure) tests robustness, requiring protein alignment for meaningful RMSD comparison.</li>\n",
+       "        <li>Multiple ligands can be docked efficiently by providing a multi-molecule SDF file to <code>gnina</code>, and results can be compiled and analyzed using RDKit and Pandas in Python.</li>\n",
+       "    </ul>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# @title Key Points\n",
+    "%%html\n",
+    "<style>\n",
+    "div.green-note {\n",
+    "    color: #155724; /* Dark green for text */\n",
+    "    background-color: #d4edda; /* Light green background */\n",
+    "    border-left: 5px solid #28a745; /* Bright green border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Consistent with text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "    font-family: Arial, sans-serif; /* Clean and modern font */\n",
+    "}\n",
+    "div.green-note ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.green-note li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"green-note\">\n",
+    "    <strong>Key Points:</strong>\n",
+    "    <ul>\n",
+    "        <li><code>gnina</code> is used for molecular docking via the command line, requiring prepared receptor (<code>-r</code>) and ligand (<code>-l</code>) files, defining a search box (e.g., <code>--autobox_ligand</code>), and specifying an output file (<code>-o</code>).</li>\n",
+    "        <li>Docking results are evaluated using scoring functions (<code>minimizedAffinity</code> from Vina, <code>CNNscore</code> and <code>CNNaffinity</code> from the neural network) and Root Mean Square Deviation (RMSD) to measure geometric similarity to a known pose.</li>\n",
+    "        <li><code>gnina</code>'s default <code>CNNscore</code> ranks poses based on predicted geometric accuracy (likelihood of low RMSD) and often differs from rankings based on the Vina affinity score (<code>minimizedAffinity</code>).</li>\n",
+    "        <li>Redocking assesses reproducibility against a known structure, while cross-docking (using a different but related receptor structure) tests robustness, requiring protein alignment for meaningful RMSD comparison.</li>\n",
+    "        <li>Multiple ligands can be docked efficiently by providing a multi-molecule SDF file to <code>gnina</code>, and results can be compiled and analyzed using RDKit and Pandas in Python.</li>\n",
+    "    </ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "fY45SjZbXHwb"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/Filled_Notebooks/01_Cheminfo_crash_course.ipynb
+++ b/Filled_Notebooks/01_Cheminfo_crash_course.ipynb
@@ -1,917 +1,934 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "7d06a1a8-a729-47c1-973a-3b6afa520f18",
-      "metadata": {
-        "id": "7d06a1a8-a729-47c1-973a-3b6afa520f18"
-      },
-      "source": [
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://raw.githubusercontent.com/MolSSI-Education/molssi-cheminformatics/0895b9e2d810fc260aaff344286a84a1b7d18a51/custom/molssi_main_horizontal.png\" style=\"display: block; margin: 0 auto; max-height:100px;\">\n",
-        "</div>\n",
-        "\n",
-        "# Digital Representation of Molecules\n",
-        "This notebook is based on notebooks 01-04 from the [MolSSI Cheminformatics course](https://github.com/MolSSI-Education/molssi-cheminformatics), which was created by Jessica A. Nash from The Molecular Sciences Software Institute\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "350c2869-274d-4bab-87c9-aa06fbfd9f89",
-      "metadata": {
-        "cellView": "form",
-        "id": "350c2869-274d-4bab-87c9-aa06fbfd9f89"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Overview\n",
-        "%%html\n",
-        "<style>\n",
-        "div.alert {\n",
-        "    color: #0056b3;\n",
-        "    background-color: #d9edf7;\n",
-        "    border-left: 5px solid #31708f;\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em;\n",
-        "    line-height: 1.5;\n",
-        "}\n",
-        "div.alert ul {\n",
-        "    margin: 0.5em 0;\n",
-        "}\n",
-        "div.alert li {\n",
-        "    margin-bottom: 0.5em;\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "    <strong>Questions:</strong>\n",
-        "    <ul>\n",
-        "        <li>How are molecules represented on computers?</li>\n",
-        "        <li>What is a SMILES?</li>\n",
-        "        <li>What are common molecular file formats?</li>\n",
-        "   </ul>\n",
-        "\n",
-        "    <strong>Objectives:</strong>\n",
-        "    <ul>\n",
-        "        <li>Learn the basics of SMILES strings.</li>\n",
-        "        <li>Convert molecules from chemical formula and structures to SMILES strings.</li>\n",
-        "    </ul>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b8eb3cf1-79d9-40f6-a739-92b0ba19539e",
-      "metadata": {
-        "id": "b8eb3cf1-79d9-40f6-a739-92b0ba19539e"
-      },
-      "source": [
-        "## Molecular Representations of Biological Molecules for Computing\n",
-        "\n",
-        "In bioinformatics, if you work with genomics you are accustomed to working with DNA sequences. For example, this is a partial DNA sequence for human dihdydrofolate reductase, an important enzyme in nucelotide metabolism.\n",
-        "\n",
-        "```\n",
-        "GAATTCATGAAAACGTAGCTCGTCCTCAAAAAAAACAGAAGAGGAGTAATCATTTTAAGGGAGAAATATA\n",
-        "TACGAAAGGAACAAGATTTTGAAGCACCCAAGCTGCCACCTACATTAAAACACGGTAGGTGGCTAAACAC\n",
-        "CAGTCTTCAATGCCCTTCCACAGCCTCAGTCTGAAAAATACTGTGCAGGTGACCCAAGTGAGGGGTCACC\n",
-        "CTTGGGCTTTTCCTGTGGCAGTATCTCTGGTTTAAAAACAAACAAACGTACTTATTGCGTTGAAGGACGG\n",
-        "CAACAGGAAGGACTCCATGATTAGTCACATCTATACCATCCTAAGAAACTTTATCCACCCAAACTGTATT\n",
-        "TCAGACTTTATAATCTAAACTACAAAAAGTGTTCACTGGGGAACTGCACAATATGACTGCTTTTAACCGT\n",
-        "```\n",
-        "\n",
-        "The DNA sequence shown here is a simplified representation of a very complex 3D structure that is part of a chromosome, an enormously complex structure. The sequence that represents this gene can be used as a string in coding - computation with strings is orders of magnitude faster than computation with 3D structures. And we can still learn a great deal about this gene simply by exploring the sequence. Likewise we can represent the RNA transcribed from this sequence as a list of characters where T is replaced by U.\n",
-        "\n",
-        "If you study proteins or proteomics, you know that protein function depends on protein structure. Protein structures involve 20 (or more) building blocks so the sequences are more complex, but the principle of representing the protein as a simple string for ease with computing still applies. Here is the sequence of the dihydrofolate reductase protein that is coded in this gene sequence above.\n",
-        "\n",
-        "```\n",
-        "MVGSLNCIVAVSQNMGIGKNGDLPWPPLRNEFRYFQRMTTTSSVEGKQNLVIMGKKTWFSIPEKNRPLKG\n",
-        "RINLVLSRELKEPPQGAHFLSRSLDDALKLTEQPELANKVDMVWIVGGSSVYKEAMNHPGHLKLFVTRIM\n",
-        "QDFESDTFFPEIDLEKYKLLPEYPGVLSDVQEEKGIKYKFEVYEKND\n",
-        "```\n",
-        "\n",
-        "As we move into cheminformatics, we often want to convert small molecule structures, like the aspirin shown here, into strings for computing ease.\n",
-        "\n",
-        "![Aspirin.png](https://drive.google.com/uc?export=view&id=1hcWaacd-pIb09Wi9dceVSQIfkXgWC-vD)\n",
-        "\n",
-        "There are three well-known string conversions for small molecules, SMILES, InChI, and InChI Key. Here are the SMILES, InChI, and InChI Key strings for aspirin.\n",
-        "\n",
-        "SMILES: CC(=O)OC1=CC=CC=C1C(=O)O\n",
-        "\n",
-        "InChI: 1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)\n",
-        "\n",
-        "InChI Key: BSYNRYMUTXBXSQ-UHFFFAOYSA-N\n",
-        "\n",
-        "In this workshop we will use SMILES strings. SMILES syntax is explained below."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1a20ce5f-0392-40be-a64f-006929d49a5a",
-      "metadata": {
-        "id": "1a20ce5f-0392-40be-a64f-006929d49a5a"
-      },
-      "source": [
-        "## Simplified Molecular-Input Line-entry System: SMILES\n",
-        "\n",
-        "SMILES stands for \"Simplified Molecular-Input Line-Entry System\" and is a way to represent molecules as a string of characters.\n",
-        "\n",
-        "Consider the molecule ethanol. The image below shows a representation that we are used to seeing in chemistry:\n",
-        "\n",
-        "![ethanol](https://drive.google.com/uc?export=view&id=1pBnnNujVdkw43xpDOM27nzICgnn7EqJj)\n",
-        "\n",
-        "However, the SMILES representation of this molecule would be \"CCO\".\n",
-        "\n",
-        "You can read more about SMILES at [this tutorial](https://archive.epa.gov/med/med_archive_03/web/html/smiles.html), but rules for atoms and bonds are also repeated below.\n",
-        "\n",
-        "### Atoms\n",
-        "SMILES supports all elements in the periodic table. An atom is represented using its respective atomic symbol. Upper case letters refer to non-aromatic atoms; lower case letters refer to aromatic atoms. If the atomic symbol has more than one letter the second letter must be lower case.\n",
-        "\n",
-        "### Bonds\n",
-        "```\n",
-        "-\tSingle bond\n",
-        "=\tDouble bond\n",
-        "#\tTriple bond\n",
-        "*\tAromatic bond\n",
-        ".\tDisconnected structures\n",
-        "```\n",
-        "Single bonds are the default and therefore need not be entered. For example, 'CC' would mean that there is a non-aromatic carbon attached to another non-aromatic carbon by a single bond, and the computer would identify the structure as the chemical ethane. It is also assumed that the bond between two lower case atom symbols is aromatic. A blank terminates the SMILES string.\n",
-        "\n",
-        "### Branches\n",
-        "\n",
-        "A branch from a chain is specified by placing the SMILES symbol(s) for the branch between parenthesis. Some examples:\n",
-        "\n",
-        "```\n",
-        "\n",
-        "CC(O)C\t2-Propanol\n",
-        "CC(=O)C\t2-Propanone\n",
-        "```\n",
-        "\n",
-        "### Rings\n",
-        "\n",
-        "A ring is specified by placing a number directly after the SMILES symbol where the ring closure occurs. This number acts as a marker, indicating that the atoms with the same number are connected, thus forming a ring. For instance:\n",
-        "\n",
-        "```\n",
-        "C1CCCC1   cyclopentane\n",
-        "n1ccccc1  Pyridine\n",
-        "```\n",
-        "\n",
-        "### SMILES Examples\n",
-        "\n",
-        "![SMILES Example 1](https://drive.google.com/uc?export=view&id=1-MFSoAGwqOPiqIUD06reOkBPx4BTMhGC)\n",
-        "\n",
-        "![SMILES Example 2](https://drive.google.com/uc?export=view&id=18Ub9L98y8cL_lDLF9wl6pLQxCkt8JFqu)\n",
-        "\n",
-        "### Using Online Resources\n",
-        "Most of the time, you will not need to write a SMILES string by hand. You will be able to look up a molecule's SMILES string from a web database like [PubChem](https://pubchem.ncbi.nlm.nih.gov/).\n",
-        "\n",
-        "You can also use tools like this [molecule sketcher from the Protein Data Bank](https://www.rcsb.org/chemical-sketch)\n",
-        "to draw molecules and get their SMILES strings."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "928a5415-2bcb-4ef0-ac8a-1744714d8d3c",
-      "metadata": {
-        "cellView": "form",
-        "id": "928a5415-2bcb-4ef0-ac8a-1744714d8d3c"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Exercise\n",
-        "%%html\n",
-        "<style>\n",
-        "div.orange-alert {\n",
-        "    color: #854f00; /* Darker shade of orange for text */\n",
-        "    background-color: #ffe6cc; /* Light orange background */\n",
-        "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.orange-alert ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.orange-alert li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"orange-alert\">\n",
-        "\n",
-        "<strong>Exercise</strong>\n",
-        "<p>\n",
-        "Based on what you've learned about SMILES strings, answer the following questions:\n",
-        "</p>\n",
-        "    <ul>\n",
-        "        <li> What is the SMILES for ethanol?</li>\n",
-        "        <li> What is the SMILES for water?</li>\n",
-        "        <li> What is the SMILES for benzene?</li>\n",
-        "        <li> What molecule is represented by the SMILES O=C=O?</li>\n",
-        "        <li> What is the SMILES for an amide group?<//li>\n",
-        "        <li> What is the SMILES for a 4 membered carbon chain with an amide group on the second carbon?</li>\n",
-        "    </ul>\n",
-        "</p>\n",
-        "<p>Check your answers from this previous exercise using the PDB molecule sketcher. Notice that you can type in a SMILES string and have the sketcher draw the molecule for you.</p>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6dcdb914-bf20-425d-859c-44c250ca991a",
-      "metadata": {
-        "id": "6dcdb914-bf20-425d-859c-44c250ca991a"
-      },
-      "outputs": [],
-      "source": [
-        "# Fill in your answers here:\n",
-        "# 1. CCO\n",
-        "# 2. O\n",
-        "# 3. c1ccccc1\n",
-        "# 4. Carbon Dioxide\n",
-        "# 5. C(=O)N\n",
-        "# 6. CC(C(=O)N)CC\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "4842145a-676e-4f1f-9b55-8b8296a81301",
-      "metadata": {
-        "id": "4842145a-676e-4f1f-9b55-8b8296a81301"
-      },
-      "source": [
-        "## Molecular File Formats\n",
-        "\n",
-        "Molecules can also be represented using a number of different file formats. As you work more in chemistry, you may see a number of these. Sometimes you will have to pick a file format based on the software you are using or the molecular information you want to save.\n",
-        "\n",
-        "| File Format | Description                                                                 | Features                                                              | Common Uses                              |\n",
-        "|-------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------|------------------------------------------|\n",
-        "| SMILES      | Simplified Molecular Input Line Entry System                                | Line notation for representing molecular structures                   | Database               |\n",
-        "| InChI       | International Chemical Identifier                                           | Textual identifier for chemical substances                            | Databases             |\n",
-        "| MOL/SDF     | MDL MOLfile and Structure-Data File                                         | Contains 2D/3D coordinates, atoms, bonds                              | Structure visualization, cheminformatics |\n",
-        "| PDB         | Protein Data Bank format                                                    | Often used for 3D structures of proteins and nucleic acids,but can also be used for small molecules. Often does not contain molecule information, and cannot store partial charges.                           | Structural biology, bioinformatics       |\n",
-        "| XYZ         | Cartesian coordinates                                                       | Simple text format with atom types and 3D coordinates                 | Computational chemistry, molecular dynamics |     |\n",
-        "| CIF         | Crystallographic Information File                                           | Text file format for representing crystal structure data              | Crystallography                          |\n",
-        "| PQR         | Extended PDB format with partial charges and radii                          | Includes atomic coordinates, partial charges, and radii               | Electrostatics calculations              |\n",
-        "| PDBQT       | PDB format with torsion angles and charges used in AutoDock                 | Includes atomic coordinates, partial charges, torsion angles          | Molecular docking                        |\n",
-        "|MOL2   |Tripos Mol2 format|\tContains atomic coordinates, bonds, molecule types, substructures, and partial charges|\tMolecular modeling, cheminformatics, computational chemistry\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3db21944-72a0-4523-a87d-f702baa98a4b",
-      "metadata": {
-        "cellView": "form",
-        "id": "3db21944-72a0-4523-a87d-f702baa98a4b"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Introduction to RDKit Molecules\n",
-        "%%html\n",
-        "<style>\n",
-        "div.alert {\n",
-        "    color: #0056b3;\n",
-        "    background-color: #d9edf7;\n",
-        "    border-left: 5px solid #31708f;\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em;\n",
-        "    line-height: 1.5;\n",
-        "}\n",
-        "div.alert ul {\n",
-        "    margin: 0.5em 0;\n",
-        "}\n",
-        "div.alert li {\n",
-        "    margin-bottom: 0.5em;\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "    <strong>Questions:</strong>\n",
-        "    <ul>\n",
-        "        <li>What is RDKit?</li>\n",
-        "        <li>What is an RDKit mol object?</li>\n",
-        "        <li>What can I do with RDKit mol objects?</li>\n",
-        "   </ul>\n",
-        "\n",
-        "    <strong>Objectives:</strong>\n",
-        "    <ul>\n",
-        "        <li>Use RDKit to create mol objects in Python.</li>\n",
-        "    </ul>\n",
-        "\n",
-        "<p>\n",
-        "There are Python libraries that are made for working just with chemical data. One commonly\n",
-        "used library in Python for data science (or cheminformatics) is called\n",
-        "[RDKit](https://en.wikipedia.org/wiki/RDKit). RDKit is an open-source cheminformatics\n",
-        "library, primarily developed in C++ and has been under development since the year 2000.\n",
-        "We will be using the Python interface to RDKit, though there are interfaces in other languages.\n",
-        "</p>\n",
-        "\n",
-        "<p>\n",
-        "RDKit provides a molecule object that allows you to manipulate chemical structures. It has\n",
-        "capabilities for reading and writing molecular file formats, calculating molecular properties,\n",
-        "and performing substructure searches. In addition, it offers a wide range of cheminformatics\n",
-        "algorithms such as molecular fingerprint generation, similarity metrics calculation, and\n",
-        "molecular descriptor computation. This notebook introduces RDKit basics, but we will see more\n",
-        "of all of these topics in later notebooks.\n",
-        "</p>\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3949cd4d-3f71-4622-a774-bcf3542a74d8",
-      "metadata": {
-        "cellView": "form",
-        "id": "3949cd4d-3f71-4622-a774-bcf3542a74d8"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Python Skills - Python Objects\n",
-        "%%html\n",
-        "<style>\n",
-        "div.purple-box {\n",
-        "    color: #4b0082; /* Indigo for text */\n",
-        "    background-color: #f3e5f5; /* Light lavender background */\n",
-        "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-        "}\n",
-        "div.purple-box ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.purple-box li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"purple-box\">\n",
-        "    <p>\n",
-        "       Most of this functionality is achieved through the RDKit `mol` object. In Python,\n",
-        "we use the word \"object\" to refer to a variable type with associated data and methods.\n",
-        "One example of an object we have seen in notebooks is a list - we could also call it\n",
-        "a \"list object\". An object has `attributes` (data) and `methods`.\n",
-        "You access information about objects with the syntax\n",
-        "    </p>\n",
-        "<pre>\n",
-        "\n",
-        "object.data\n",
-        "\n",
-        "</pre>\n",
-        "\n",
-        "where data is the attribute name.\n",
-        "\n",
-        "You access object methods with the syntax\n",
-        "\n",
-        "<pre>\n",
-        "\n",
-        "object.method(arguments)\n",
-        "\n",
-        "</pre>\n",
-        "        For example, for a list \"`append` is a method that was covered in the introductory lesson.\n",
-        "<pre>\n",
-        "\n",
-        "my_list = []\n",
-        "my_list.append(1) # \"append\" is a method\n",
-        "\n",
-        "<pre>\n",
-        "</div>\n",
-        "\n",
-        "<p>\n",
-        "In this lesson, we will create and manipulate RDKit `mol` objects. RDKit `mol` objects represent molecules and have\n",
-        "attributes (data) and methods (actions) associated with molecules.\n",
-        "</p>\n",
-        "<p>\n",
-        "We are going to use a part of RDKit called `Chem`. To use `Chem`, we first have to import it.\n",
-        "</p>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "Xovgh3LcqJA2",
-      "metadata": {
-        "id": "Xovgh3LcqJA2"
-      },
-      "outputs": [],
-      "source": [
-        "from google.colab import output\n",
-        "output.clear()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3c5c13a5-b369-4188-8b13-356445deeb5a",
-      "metadata": {
-        "id": "3c5c13a5-b369-4188-8b13-356445deeb5a"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install rdkit\n",
-        "from rdkit import Chem"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d84d6c70-fd6e-41bf-81c6-7145d6f87b0e",
-      "metadata": {
-        "id": "d84d6c70-fd6e-41bf-81c6-7145d6f87b0e"
-      },
-      "source": [
-        "## Creating Molecules with RDKit\n",
-        "\n",
-        "Throughout this tutorial, it will be helpful to have access to the [RDKit documentation](https://www.rdkit.org/docs/index.html).\n",
-        "\n",
-        "To get information about molecules in RDKit, we have to first create objects representing molecules. RDKit has a molecule object that can be used to retrieve information or calculate properties. To create a molecule object, we have to communicate the molecule identity in a way that computers understand.\n",
-        "\n",
-        "We will use SMILES strings to create our objects, though RDKit also has methods for creating molecules from the file formats listed in the previous notebook.\n",
-        "\n",
-        "### Creating molecules using SMILES\n",
-        "\n",
-        "In the last lesson, we learned about molecular representations using SMILES strings. Now we will use SMILES strings to create molecule objects in RDKIT.\n",
-        "\n",
-        "We can create a representation of methane using RDKit by using the `MolFromSmiles` function in `rdkit.Chem`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "b9415ede-7ab5-4a35-89e8-a32d25dfe1b9",
-      "metadata": {
-        "id": "b9415ede-7ab5-4a35-89e8-a32d25dfe1b9"
-      },
-      "outputs": [],
-      "source": [
-        "methane = Chem.MolFromSmiles('C')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "851ae0d6-b0a2-4474-9402-5db4abf49b1c",
-      "metadata": {
-        "id": "851ae0d6-b0a2-4474-9402-5db4abf49b1c"
-      },
-      "outputs": [],
-      "source": [
-        "methane"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6c305149-481a-4e52-83bc-a24ab48f45bf",
-      "metadata": {
-        "cellView": "form",
-        "id": "6c305149-481a-4e52-83bc-a24ab48f45bf"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Check Your Understanding\n",
-        "%%html\n",
-        "<style>\n",
-        "div.orange-alert {\n",
-        "    color: #854f00; /* Darker shade of orange for text */\n",
-        "    background-color: #ffe6cc; /* Light orange background */\n",
-        "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.orange-alert ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.orange-alert li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"orange-alert\">\n",
-        "\n",
-        "<p> Create RDKit molecules for the following molecules. You can look up the SMILES strings on <a href=\"https://pubchem.ncbi.nlm.nih.gov/\">PubChem</a>:\n",
-        "<p>\n",
-        "    <ul>\n",
-        "        <li> Propane\n",
-        "        <li> Ethene\n",
-        "        <li> Cyclohexane\n",
-        "        <li> Benzene </li>\n",
-        "        <li> Acetic Acid\n",
-        "    </ul>\n",
-        "</p>\n",
-        "<p>Create variables for each molecule. The variable names should be the molecule name (all lowercase)</p>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "497025f0-e60a-42d1-a26e-77db46e5c495",
-      "metadata": {
-        "id": "497025f0-e60a-42d1-a26e-77db46e5c495"
-      },
-      "outputs": [],
-      "source": [
-        "# Your answers go here\n",
-        "propane = Chem.MolFromSmiles(\"CCC\")                # TO DO: Insert the SMILES string for propane: CCC\n",
-        "ethene = Chem.MolFromSmiles(\"C=C\")                 # TO DO: Insert the SMILES string for ethene\n",
-        "cyclohexane = Chem.MolFromSmiles(\"C1CCCCC1 \")      # TO DO: Call the method and insert the SMILES string for cyclohexane\n",
-        "benzene = Chem.MolFromSmiles(\"c1ccccc1\")           # TO DO: Call the method and insert the SMILES string for benzene\n",
-        "acetic_acid = Chem.MolFromSmiles(\"CC(=O)O\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f87d25a4-61b2-437a-a5a6-176a2a45a813",
-      "metadata": {
-        "id": "f87d25a4-61b2-437a-a5a6-176a2a45a813"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here just by typing the name of the variable that refers to the RDKit mol object\n",
-        "acetic_acid"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from rdkit.Chem.Draw import IPythonConsole as ipc\n",
-        "from rdkit.Chem import Draw\n",
-        "\n",
-        "# Configuration for displaying in Jupyter notebooks\n",
-        "ipc.ipython_useSVG = True  # Use SVG for higher quality images\n",
-        "ipc.drawOptions.addAtomIndices = True  # Show atom indices\n",
-        "ipc.molSize = 250,250 # Set size of image"
-      ],
-      "metadata": {
-        "id": "4CzZhBBEGpGV"
-      },
-      "id": "4CzZhBBEGpGV",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "474fcdab-a904-4c66-8243-5a59de5ebf90",
-      "metadata": {
-        "id": "474fcdab-a904-4c66-8243-5a59de5ebf90",
-        "cellView": "form"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Working with RDKit Molecules\n",
-        "%%html\n",
-        "<style>\n",
-        "div.purple-box {\n",
-        "    color: #4b0082; /* Indigo for text */\n",
-        "    background-color: #f3e5f5; /* Light lavender background */\n",
-        "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-        "}\n",
-        "div.purple-box ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.purple-box li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"purple-box\">\n",
-        "    <p>\n",
-        "RDKit molecule objects have a number of methods we can use to get more information about the molecule. In the next few cells, we'll look at some methods that can tell us some things about the molecules we've created. The next cell has settings for modifying drawing molecules. It adds labels of atom indices and sets the image size\n",
-        "When working with Python objects in the Jupyter notebook, you can\n",
-        "type a variable or object name to see the methods available on that object.\n",
-        "    </p>\n",
-        "    <p>\n",
-        "In the cell below, type\n",
-        "<pre>\n",
-        "  acetic_acid.\n",
-        "\n",
-        "</pre>\n",
-        "\n",
-        "Notice how there is a dot at the end\n",
-        "\n",
-        "    <pre>\n",
-        "      .\n",
-        "    </pre>\n",
-        "\n",
-        "Then press the `tab` key. A list of possible methods and attributes will come up.\n",
-        "\n",
-        "Look through the methods until you find one that gives you the number of atoms in the molecule.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "e1a331ad-3b4d-44e1-ad51-dc093008dacb",
-      "metadata": {
-        "id": "e1a331ad-3b4d-44e1-ad51-dc093008dacb"
-      },
-      "outputs": [],
-      "source": [
-        "# Pick a method that will tell you the number of atoms acetic acid has.\n",
-        "\n",
-        "x = acetic_acid.GetNumAtoms()                                  # TO DO: enter a . after acetic acid and then scroll down the list to find a method to give you the number of atoms\n",
-        "\n",
-        "print('Acetic acid has', x, 'heavy atoms.')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "56379e5a-44f0-4272-959d-91f652ba4128",
-      "metadata": {
-        "id": "56379e5a-44f0-4272-959d-91f652ba4128"
-      },
-      "source": [
-        "### Finding help\n",
-        "When you start working with RDKit mol objects, it will be an adjustment. This is a new type of variable and it will take time to adjust. One way to find help is to use a simple help command where the object of the help function is the name of the RDKit mol object. In the next cell, we will use help to learn more about the RDKit mol object, acetic_acid, that we just created."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1b7d32b7-f531-4a4f-b05e-4c6c51664d50",
-      "metadata": {
-        "id": "1b7d32b7-f531-4a4f-b05e-4c6c51664d50"
-      },
-      "outputs": [],
-      "source": [
-        "help(acetic_acid)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cc30f661-dc41-4c06-82cc-a4ae762d65e7",
-      "metadata": {
-        "id": "cc30f661-dc41-4c06-82cc-a4ae762d65e7"
-      },
-      "outputs": [],
-      "source": [
-        "# Add an argument to your function to get the total number of atoms in acetic_acid including hydrogens\n",
-        "\n",
-        "x = acetic_acid.GetNumAtoms()                             # This is the method we used in an earlier cell. Note that the parentheses are empty.\n",
-        "\n",
-        "y = acetic_acid.GetNumAtoms(onlyExplicit=False)           # TO DO: To include the hydrogens in the atom count, insert the phrase onlyExplicit = False in the parentheses.\n",
-        "\n",
-        "print(f\"There are {x} heavy atoms in acetic acid and {y} total atoms in acetic acid.\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a47eba18-f0a2-4d59-88c0-b58b1605d9d4",
-      "metadata": {
-        "cellView": "form",
-        "id": "a47eba18-f0a2-4d59-88c0-b58b1605d9d4"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Examining and Visualizing Data\n",
-        "%%html\n",
-        "<style>\n",
-        "div.alert {\n",
-        "    color: #0056b3;\n",
-        "    background-color: #d9edf7;\n",
-        "    border-left: 5px solid #31708f;\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em;\n",
-        "    line-height: 1.5;\n",
-        "}\n",
-        "div.alert ul {\n",
-        "    margin: 0.5em 0;\n",
-        "}\n",
-        "div.alert li {\n",
-        "    margin-bottom: 0.5em;\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "    <strong>Questions:</strong>\n",
-        "    <ul>\n",
-        "        <li>How can I use pandas to work with molecules from rdkit?</li>\n",
-        "        <li>How can I visualize relationships between different parts of my data?</li>\n",
-        "   </ul>\n",
-        "\n",
-        "    <strong>Objectives:</strong>\n",
-        "    <ul>\n",
-        "        <li>Review the pandas dataframe</li>\n",
-        "        <li>Learn to visualize structures in a pandas dataframe</li>\n",
-        "        <li>Learn the <i>apply</i> tool for expanding a pandas dataframe</li>\n",
-        "    </ul>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a4cc10b7-5d18-4853-bfac-a2448f722414",
-      "metadata": {
-        "id": "a4cc10b7-5d18-4853-bfac-a2448f722414"
-      },
-      "source": [
-        "[Pandas](https://pandas.pydata.org/docs/) is a Python library used for data analysis and manipulation. Within the world of data science, it is a ubiquitous and widely used library. If you are learning how to analyze data in Python, it will be almost impossible to avoid pandas.\n",
-        "\n",
-        "The central data structure of pandas is called a DataFrame. Pandas DataFrames work very closely with NumPy arrays and Pandas dataframes are specifically for data which is two dimensional (rows and columns). NumPy arrays, while similar in some ways, can work with higher dimensional data.\n",
-        "\n",
-        "Pandas is very powerful. In this session, we'll be learning how to access information in pandas dataframes and how to do some basic manipulation and analysis. We are going to be looking at a dataset which gives information about the elements in the periodic table."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f2e82ae2-4050-4955-a205-5ed86e42cc2b",
-      "metadata": {
-        "id": "f2e82ae2-4050-4955-a205-5ed86e42cc2b"
-      },
-      "outputs": [],
-      "source": [
-        "import pandas as pd                                     # importing the pandas library\n",
-        "\n",
-        "from rdkit.Chem import PandasTools                      # importing rdkit functions to work with pandas\n",
-        "\n",
-        "PandasTools.RenderImagesInAllDataFrames(images=True)    # to display chemical structures in dataframes"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from urllib.request import urlretrieve                  # importing a method that enables retrieval of a text file from a URL\n",
-        "\n",
-        "url = (\"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/paul/data/nsaids.csv\")\n",
-        "\n",
-        "filename = \"nsaids.csv\"\n",
-        "\n",
-        "urlretrieve(url, filename)"
-      ],
-      "metadata": {
-        "id": "LzrEG54AKY-W"
-      },
-      "id": "LzrEG54AKY-W",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "id": "6ed0f50a-7b42-49dc-acc4-f68c4cedc1a6",
-      "metadata": {
-        "id": "6ed0f50a-7b42-49dc-acc4-f68c4cedc1a6"
-      },
-      "source": [
-        "## Loading a collection of small molecules\n",
-        "\n",
-        "In the next few cells, we'll read a text file that lists the SMILES strings for some nonsteroidal antiinflammatory drugs (NSAIDS) and then use them to start building a pandas dataframe. The SMILES strings for the NSAIDS can be found in [nsaids.txt](https://docs.google.com/document/d/1RQeVIFBMeq4SWTrRNfgZXRvaaRNXVknLxgVZfTbJUDs/edit?usp=drive_link).\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6e09ef49-ad83-4f81-a0da-c90c83f02d3b",
-      "metadata": {
-        "id": "6e09ef49-ad83-4f81-a0da-c90c83f02d3b"
-      },
-      "outputs": [],
-      "source": [
-        "nsaids_file = \"nsaids.csv\"\n",
-        "\n",
-        "nsaids_df = pd.read_csv(nsaids_file)\n",
-        "\n",
-        "nsaids_df"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "26a9b6b3-10ff-4594-b660-5b605ac30e2e",
-      "metadata": {
-        "id": "26a9b6b3-10ff-4594-b660-5b605ac30e2e"
-      },
-      "source": [
-        "### The `.apply` method\n",
-        "\n",
-        "The `.apply` method in pandas is used to apply a function along a row or column of a dataframe.\n",
-        "This is useful when you have a custom function that you need to use on every value in a column, but there is not a NumPy or Pandas function for it.\n",
-        "\n",
-        "For example, we could apply the `len` function to our `Name` column to get the number of letters in the name for each element.\n",
-        "\n",
-        "```python\n",
-        "# Number of letters in name -\n",
-        "df[\"Name\"].apply(len)\n",
-        "```\n",
-        "\n",
-        "We are going to use ```apply``` to add a new column to nsaid_df that contains the rdkit molecule for each of the NSAIDs."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fb693a02-58a2-467d-80fa-723d61f62219",
-      "metadata": {
-        "id": "fb693a02-58a2-467d-80fa-723d61f62219"
-      },
-      "outputs": [],
-      "source": [
-        "nsaids_df[\"Molecule\"] = nsaids_df[\"SMILES\"].apply(Chem.MolFromSmiles)\n",
-        "\n",
-        "nsaids_df.head()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "WqeeyIxPiF-7",
-      "metadata": {
-        "id": "WqeeyIxPiF-7"
-      },
-      "source": [
-        "At this point, nsaid_df contains two columns: the SMILES string and the molecule. We will go one step further and use ```apply``` to add another column to the dataframe that contains a descriptor based on the rdkit molecule. Before we can do that we need to import a new sublibrary from rdkit.Chem called Descriptors. Notice that the new columns will be based on the Molecule column, which contains rdkit mol objects."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "v7lK6asEid7Q",
-      "metadata": {
-        "id": "v7lK6asEid7Q"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem import Descriptors\n",
-        "from rdkit.Chem import Lipinski\n",
-        "nsaids_df[\"Mol Wt\"] = nsaids_df[\"Molecule\"].apply(Descriptors.MolWt)\n",
-        "nsaids_df[\"logP\"] = nsaids_df[\"Molecule\"].apply(Descriptors.MolLogP)\n",
-        "nsaids_df[\"HBD\"] = nsaids_df[\"Molecule\"].apply(Lipinski.NHOHCount)            # Number of hydrogen bond donors\n",
-        "nsaids_df[\"HBA\"] = nsaids_df[\"Molecule\"].apply(Lipinski.NOCount)              # Number of hydrogen bond acceptors\n",
-        "nsaids_df.head()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "nsaids_df.hist(figsize=(8,8), edgecolor='black', grid=False)"
-      ],
-      "metadata": {
-        "id": "WLO4ia4B4lXG"
-      },
-      "id": "WLO4ia4B4lXG",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "dWKNKdDVkJxn",
-      "metadata": {
-        "id": "dWKNKdDVkJxn"
-      },
-      "outputs": [],
-      "source": [
-        "nsaids_df.plot.bar(x='Name', y='Mol Wt', figsize=(10,5))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "LEfWBGaI5-EJ"
-      },
-      "id": "LEfWBGaI5-EJ",
-      "execution_count": null,
-      "outputs": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.2"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7d06a1a8-a729-47c1-973a-3b6afa520f18",
+   "metadata": {
+    "id": "7d06a1a8-a729-47c1-973a-3b6afa520f18"
+   },
+   "source": [
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://raw.githubusercontent.com/MolSSI-Education/molssi-cheminformatics/0895b9e2d810fc260aaff344286a84a1b7d18a51/custom/molssi_main_horizontal.png\" style=\"display: block; margin: 0 auto; max-height:100px;\">\n",
+    "</div>\n",
+    "\n",
+    "# Digital Representation of Molecules\n",
+    "This notebook is based on notebooks 01-04 from the [MolSSI Cheminformatics course](https://github.com/MolSSI-Education/molssi-cheminformatics), which was created by Jessica A. Nash from The Molecular Sciences Software Institute\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "350c2869-274d-4bab-87c9-aa06fbfd9f89",
+   "metadata": {
+    "cellView": "form",
+    "id": "350c2869-274d-4bab-87c9-aa06fbfd9f89"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Overview\n",
+    "%%html\n",
+    "<style>\n",
+    "div.alert {\n",
+    "    color: #0056b3;\n",
+    "    background-color: #d9edf7;\n",
+    "    border-left: 5px solid #31708f;\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em;\n",
+    "    line-height: 1.5;\n",
+    "}\n",
+    "div.alert ul {\n",
+    "    margin: 0.5em 0;\n",
+    "}\n",
+    "div.alert li {\n",
+    "    margin-bottom: 0.5em;\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <strong>Questions:</strong>\n",
+    "    <ul>\n",
+    "        <li>How are molecules represented on computers?</li>\n",
+    "        <li>What is a SMILES?</li>\n",
+    "        <li>What are common molecular file formats?</li>\n",
+    "   </ul>\n",
+    "\n",
+    "    <strong>Objectives:</strong>\n",
+    "    <ul>\n",
+    "        <li>Learn the basics of SMILES strings.</li>\n",
+    "        <li>Convert molecules from chemical formula and structures to SMILES strings.</li>\n",
+    "    </ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8eb3cf1-79d9-40f6-a739-92b0ba19539e",
+   "metadata": {
+    "id": "b8eb3cf1-79d9-40f6-a739-92b0ba19539e"
+   },
+   "source": [
+    "## Molecular Representations of Biological Molecules for Computing\n",
+    "\n",
+    "In bioinformatics, if you work with genomics you are accustomed to working with DNA sequences. For example, this is a partial DNA sequence for human dihdydrofolate reductase, an important enzyme in nucelotide metabolism.\n",
+    "\n",
+    "```\n",
+    "GAATTCATGAAAACGTAGCTCGTCCTCAAAAAAAACAGAAGAGGAGTAATCATTTTAAGGGAGAAATATA\n",
+    "TACGAAAGGAACAAGATTTTGAAGCACCCAAGCTGCCACCTACATTAAAACACGGTAGGTGGCTAAACAC\n",
+    "CAGTCTTCAATGCCCTTCCACAGCCTCAGTCTGAAAAATACTGTGCAGGTGACCCAAGTGAGGGGTCACC\n",
+    "CTTGGGCTTTTCCTGTGGCAGTATCTCTGGTTTAAAAACAAACAAACGTACTTATTGCGTTGAAGGACGG\n",
+    "CAACAGGAAGGACTCCATGATTAGTCACATCTATACCATCCTAAGAAACTTTATCCACCCAAACTGTATT\n",
+    "TCAGACTTTATAATCTAAACTACAAAAAGTGTTCACTGGGGAACTGCACAATATGACTGCTTTTAACCGT\n",
+    "```\n",
+    "\n",
+    "The DNA sequence shown here is a simplified representation of a very complex 3D structure that is part of a chromosome, an enormously complex structure. The sequence that represents this gene can be used as a string in coding - computation with strings is orders of magnitude faster than computation with 3D structures. And we can still learn a great deal about this gene simply by exploring the sequence. Likewise we can represent the RNA transcribed from this sequence as a list of characters where T is replaced by U.\n",
+    "\n",
+    "If you study proteins or proteomics, you know that protein function depends on protein structure. Protein structures involve 20 (or more) building blocks so the sequences are more complex, but the principle of representing the protein as a simple string for ease with computing still applies. Here is the sequence of the dihydrofolate reductase protein that is coded in this gene sequence above.\n",
+    "\n",
+    "```\n",
+    "MVGSLNCIVAVSQNMGIGKNGDLPWPPLRNEFRYFQRMTTTSSVEGKQNLVIMGKKTWFSIPEKNRPLKG\n",
+    "RINLVLSRELKEPPQGAHFLSRSLDDALKLTEQPELANKVDMVWIVGGSSVYKEAMNHPGHLKLFVTRIM\n",
+    "QDFESDTFFPEIDLEKYKLLPEYPGVLSDVQEEKGIKYKFEVYEKND\n",
+    "```\n",
+    "\n",
+    "As we move into cheminformatics, we often want to convert small molecule structures, like the aspirin shown here, into strings for computing ease.\n",
+    "\n",
+    "![Aspirin.png](https://drive.google.com/uc?export=view&id=1hcWaacd-pIb09Wi9dceVSQIfkXgWC-vD)\n",
+    "\n",
+    "There are three well-known string conversions for small molecules, SMILES, InChI, and InChI Key. Here are the SMILES, InChI, and InChI Key strings for aspirin.\n",
+    "\n",
+    "SMILES: CC(=O)OC1=CC=CC=C1C(=O)O\n",
+    "\n",
+    "InChI: 1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)\n",
+    "\n",
+    "InChI Key: BSYNRYMUTXBXSQ-UHFFFAOYSA-N\n",
+    "\n",
+    "In this workshop we will use SMILES strings. SMILES syntax is explained below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a20ce5f-0392-40be-a64f-006929d49a5a",
+   "metadata": {
+    "id": "1a20ce5f-0392-40be-a64f-006929d49a5a"
+   },
+   "source": [
+    "## Simplified Molecular-Input Line-entry System: SMILES\n",
+    "\n",
+    "SMILES stands for \"Simplified Molecular-Input Line-Entry System\" and is a way to represent molecules as a string of characters.\n",
+    "\n",
+    "Consider the molecule ethanol. The image below shows a representation that we are used to seeing in chemistry:\n",
+    "\n",
+    "![ethanol](https://drive.google.com/uc?export=view&id=1pBnnNujVdkw43xpDOM27nzICgnn7EqJj)\n",
+    "\n",
+    "However, the SMILES representation of this molecule would be \"CCO\".\n",
+    "\n",
+    "You can read more about SMILES at [this tutorial](https://archive.epa.gov/med/med_archive_03/web/html/smiles.html), but rules for atoms and bonds are also repeated below.\n",
+    "\n",
+    "### Atoms\n",
+    "SMILES supports all elements in the periodic table. An atom is represented using its respective atomic symbol. Upper case letters refer to non-aromatic atoms; lower case letters refer to aromatic atoms. If the atomic symbol has more than one letter the second letter must be lower case.\n",
+    "\n",
+    "### Bonds\n",
+    "```\n",
+    "-\tSingle bond\n",
+    "=\tDouble bond\n",
+    "#\tTriple bond\n",
+    "*\tAromatic bond\n",
+    ".\tDisconnected structures\n",
+    "```\n",
+    "Single bonds are the default and therefore need not be entered. For example, 'CC' would mean that there is a non-aromatic carbon attached to another non-aromatic carbon by a single bond, and the computer would identify the structure as the chemical ethane. It is also assumed that the bond between two lower case atom symbols is aromatic. A blank terminates the SMILES string.\n",
+    "\n",
+    "### Branches\n",
+    "\n",
+    "A branch from a chain is specified by placing the SMILES symbol(s) for the branch between parenthesis. Some examples:\n",
+    "\n",
+    "```\n",
+    "\n",
+    "CC(O)C\t2-Propanol\n",
+    "CC(=O)C\t2-Propanone\n",
+    "```\n",
+    "\n",
+    "### Rings\n",
+    "\n",
+    "A ring is specified by placing a number directly after the SMILES symbol where the ring closure occurs. This number acts as a marker, indicating that the atoms with the same number are connected, thus forming a ring. For instance:\n",
+    "\n",
+    "```\n",
+    "C1CCCC1   cyclopentane\n",
+    "n1ccccc1  Pyridine\n",
+    "```\n",
+    "\n",
+    "### SMILES Examples\n",
+    "\n",
+    "![SMILES Example 1](https://drive.google.com/uc?export=view&id=1-MFSoAGwqOPiqIUD06reOkBPx4BTMhGC)\n",
+    "\n",
+    "![SMILES Example 2](https://drive.google.com/uc?export=view&id=18Ub9L98y8cL_lDLF9wl6pLQxCkt8JFqu)\n",
+    "\n",
+    "### Using Online Resources\n",
+    "Most of the time, you will not need to write a SMILES string by hand. You will be able to look up a molecule's SMILES string from a web database like [PubChem](https://pubchem.ncbi.nlm.nih.gov/).\n",
+    "\n",
+    "You can also use tools like this [molecule sketcher from the Protein Data Bank](https://www.rcsb.org/chemical-sketch)\n",
+    "to draw molecules and get their SMILES strings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "928a5415-2bcb-4ef0-ac8a-1744714d8d3c",
+   "metadata": {
+    "cellView": "form",
+    "id": "928a5415-2bcb-4ef0-ac8a-1744714d8d3c"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Exercise\n",
+    "%%html\n",
+    "<style>\n",
+    "div.orange-alert {\n",
+    "    color: #854f00; /* Darker shade of orange for text */\n",
+    "    background-color: #ffe6cc; /* Light orange background */\n",
+    "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.orange-alert ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.orange-alert li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"orange-alert\">\n",
+    "\n",
+    "<strong>Exercise</strong>\n",
+    "<p>\n",
+    "Based on what you've learned about SMILES strings, answer the following questions:\n",
+    "</p>\n",
+    "    <ul>\n",
+    "        <li> What is the SMILES for ethanol?</li>\n",
+    "        <li> What is the SMILES for water?</li>\n",
+    "        <li> What is the SMILES for benzene?</li>\n",
+    "        <li> What molecule is represented by the SMILES O=C=O?</li>\n",
+    "        <li> What is the SMILES for an amide group?<//li>\n",
+    "        <li> What is the SMILES for a 4 membered carbon chain with an amide group on the second carbon?</li>\n",
+    "    </ul>\n",
+    "</p>\n",
+    "<p>Check your answers from this previous exercise using the PDB molecule sketcher. Notice that you can type in a SMILES string and have the sketcher draw the molecule for you.</p>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6dcdb914-bf20-425d-859c-44c250ca991a",
+   "metadata": {
+    "id": "6dcdb914-bf20-425d-859c-44c250ca991a"
+   },
+   "outputs": [],
+   "source": [
+    "# Fill in your answers here:\n",
+    "# 1. CCO\n",
+    "# 2. O\n",
+    "# 3. c1ccccc1\n",
+    "# 4. Carbon Dioxide\n",
+    "# 5. C(=O)N\n",
+    "# 6. CC(C(=O)N)CC\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4842145a-676e-4f1f-9b55-8b8296a81301",
+   "metadata": {
+    "id": "4842145a-676e-4f1f-9b55-8b8296a81301"
+   },
+   "source": [
+    "## Molecular File Formats\n",
+    "\n",
+    "Molecules can also be represented using a number of different file formats. As you work more in chemistry, you may see a number of these. Sometimes you will have to pick a file format based on the software you are using or the molecular information you want to save.\n",
+    "\n",
+    "| File Format | Description                                                                 | Features                                                              | Common Uses                              |\n",
+    "|-------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------|------------------------------------------|\n",
+    "| SMILES      | Simplified Molecular Input Line Entry System                                | Line notation for representing molecular structures                   | Database               |\n",
+    "| InChI       | International Chemical Identifier                                           | Textual identifier for chemical substances                            | Databases             |\n",
+    "| MOL/SDF     | MDL MOLfile and Structure-Data File                                         | Contains 2D/3D coordinates, atoms, bonds                              | Structure visualization, cheminformatics |\n",
+    "| PDB         | Protein Data Bank format                                                    | Often used for 3D structures of proteins and nucleic acids,but can also be used for small molecules. Often does not contain molecule information, and cannot store partial charges.                           | Structural biology, bioinformatics       |\n",
+    "| XYZ         | Cartesian coordinates                                                       | Simple text format with atom types and 3D coordinates                 | Computational chemistry, molecular dynamics |     |\n",
+    "| CIF         | Crystallographic Information File                                           | Text file format for representing crystal structure data              | Crystallography                          |\n",
+    "| PQR         | Extended PDB format with partial charges and radii                          | Includes atomic coordinates, partial charges, and radii               | Electrostatics calculations              |\n",
+    "| PDBQT       | PDB format with torsion angles and charges used in AutoDock                 | Includes atomic coordinates, partial charges, torsion angles          | Molecular docking                        |\n",
+    "|MOL2   |Tripos Mol2 format|\tContains atomic coordinates, bonds, molecule types, substructures, and partial charges|\tMolecular modeling, cheminformatics, computational chemistry\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3db21944-72a0-4523-a87d-f702baa98a4b",
+   "metadata": {
+    "cellView": "form",
+    "id": "3db21944-72a0-4523-a87d-f702baa98a4b"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Introduction to RDKit Molecules\n",
+    "%%html\n",
+    "<style>\n",
+    "div.alert {\n",
+    "    color: #0056b3;\n",
+    "    background-color: #d9edf7;\n",
+    "    border-left: 5px solid #31708f;\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em;\n",
+    "    line-height: 1.5;\n",
+    "}\n",
+    "div.alert ul {\n",
+    "    margin: 0.5em 0;\n",
+    "}\n",
+    "div.alert li {\n",
+    "    margin-bottom: 0.5em;\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <strong>Questions:</strong>\n",
+    "    <ul>\n",
+    "        <li>What is RDKit?</li>\n",
+    "        <li>What is an RDKit mol object?</li>\n",
+    "        <li>What can I do with RDKit mol objects?</li>\n",
+    "   </ul>\n",
+    "\n",
+    "    <strong>Objectives:</strong>\n",
+    "    <ul>\n",
+    "        <li>Use RDKit to create mol objects in Python.</li>\n",
+    "    </ul>\n",
+    "\n",
+    "<p>\n",
+    "There are Python libraries that are made for working just with chemical data. One commonly\n",
+    "used library in Python for data science (or cheminformatics) is called\n",
+    "[RDKit](https://en.wikipedia.org/wiki/RDKit). RDKit is an open-source cheminformatics\n",
+    "library, primarily developed in C++ and has been under development since the year 2000.\n",
+    "We will be using the Python interface to RDKit, though there are interfaces in other languages.\n",
+    "</p>\n",
+    "\n",
+    "<p>\n",
+    "RDKit provides a molecule object that allows you to manipulate chemical structures. It has\n",
+    "capabilities for reading and writing molecular file formats, calculating molecular properties,\n",
+    "and performing substructure searches. In addition, it offers a wide range of cheminformatics\n",
+    "algorithms such as molecular fingerprint generation, similarity metrics calculation, and\n",
+    "molecular descriptor computation. This notebook introduces RDKit basics, but we will see more\n",
+    "of all of these topics in later notebooks.\n",
+    "</p>\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3949cd4d-3f71-4622-a774-bcf3542a74d8",
+   "metadata": {
+    "cellView": "form",
+    "id": "3949cd4d-3f71-4622-a774-bcf3542a74d8"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Python Skills - Python Objects\n",
+    "%%html\n",
+    "<style>\n",
+    "div.purple-box {\n",
+    "    color: #4b0082; /* Indigo for text */\n",
+    "    background-color: #f3e5f5; /* Light lavender background */\n",
+    "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+    "}\n",
+    "div.purple-box ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.purple-box li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"purple-box\">\n",
+    "    <p>\n",
+    "       Most of this functionality is achieved through the RDKit `mol` object. In Python,\n",
+    "we use the word \"object\" to refer to a variable type with associated data and methods.\n",
+    "One example of an object we have seen in notebooks is a list - we could also call it\n",
+    "a \"list object\". An object has `attributes` (data) and `methods`.\n",
+    "You access information about objects with the syntax\n",
+    "    </p>\n",
+    "<pre>\n",
+    "\n",
+    "object.data\n",
+    "\n",
+    "</pre>\n",
+    "\n",
+    "where data is the attribute name.\n",
+    "\n",
+    "You access object methods with the syntax\n",
+    "\n",
+    "<pre>\n",
+    "\n",
+    "object.method(arguments)\n",
+    "\n",
+    "</pre>\n",
+    "        For example, for a list \"`append` is a method that was covered in the introductory lesson.\n",
+    "<pre>\n",
+    "\n",
+    "my_list = []\n",
+    "my_list.append(1) # \"append\" is a method\n",
+    "\n",
+    "<pre>\n",
+    "</div>\n",
+    "\n",
+    "<p>\n",
+    "In this lesson, we will create and manipulate RDKit `mol` objects. RDKit `mol` objects represent molecules and have\n",
+    "attributes (data) and methods (actions) associated with molecules.\n",
+    "</p>\n",
+    "<p>\n",
+    "We are going to use a part of RDKit called `Chem`. To use `Chem`, we first have to import it.\n",
+    "</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Xovgh3LcqJA2",
+   "metadata": {
+    "id": "Xovgh3LcqJA2"
+   },
+   "outputs": [],
+   "source": [
+    "from google.colab import output\n",
+    "\n",
+    "output.clear()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c5c13a5-b369-4188-8b13-356445deeb5a",
+   "metadata": {
+    "id": "3c5c13a5-b369-4188-8b13-356445deeb5a"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rdkit\n",
+    "from rdkit import Chem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d84d6c70-fd6e-41bf-81c6-7145d6f87b0e",
+   "metadata": {
+    "id": "d84d6c70-fd6e-41bf-81c6-7145d6f87b0e"
+   },
+   "source": [
+    "## Creating Molecules with RDKit\n",
+    "\n",
+    "Throughout this tutorial, it will be helpful to have access to the [RDKit documentation](https://www.rdkit.org/docs/index.html).\n",
+    "\n",
+    "To get information about molecules in RDKit, we have to first create objects representing molecules. RDKit has a molecule object that can be used to retrieve information or calculate properties. To create a molecule object, we have to communicate the molecule identity in a way that computers understand.\n",
+    "\n",
+    "We will use SMILES strings to create our objects, though RDKit also has methods for creating molecules from the file formats listed in the previous notebook.\n",
+    "\n",
+    "### Creating molecules using SMILES\n",
+    "\n",
+    "In the last lesson, we learned about molecular representations using SMILES strings. Now we will use SMILES strings to create molecule objects in RDKIT.\n",
+    "\n",
+    "We can create a representation of methane using RDKit by using the `MolFromSmiles` function in `rdkit.Chem`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9415ede-7ab5-4a35-89e8-a32d25dfe1b9",
+   "metadata": {
+    "id": "b9415ede-7ab5-4a35-89e8-a32d25dfe1b9"
+   },
+   "outputs": [],
+   "source": [
+    "methane = Chem.MolFromSmiles(\"C\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "851ae0d6-b0a2-4474-9402-5db4abf49b1c",
+   "metadata": {
+    "id": "851ae0d6-b0a2-4474-9402-5db4abf49b1c"
+   },
+   "outputs": [],
+   "source": [
+    "methane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c305149-481a-4e52-83bc-a24ab48f45bf",
+   "metadata": {
+    "cellView": "form",
+    "id": "6c305149-481a-4e52-83bc-a24ab48f45bf"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Check Your Understanding\n",
+    "%%html\n",
+    "<style>\n",
+    "div.orange-alert {\n",
+    "    color: #854f00; /* Darker shade of orange for text */\n",
+    "    background-color: #ffe6cc; /* Light orange background */\n",
+    "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.orange-alert ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.orange-alert li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"orange-alert\">\n",
+    "\n",
+    "<p> Create RDKit molecules for the following molecules. You can look up the SMILES strings on <a href=\"https://pubchem.ncbi.nlm.nih.gov/\">PubChem</a>:\n",
+    "<p>\n",
+    "    <ul>\n",
+    "        <li> Propane\n",
+    "        <li> Ethene\n",
+    "        <li> Cyclohexane\n",
+    "        <li> Benzene </li>\n",
+    "        <li> Acetic Acid\n",
+    "    </ul>\n",
+    "</p>\n",
+    "<p>Create variables for each molecule. The variable names should be the molecule name (all lowercase)</p>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "497025f0-e60a-42d1-a26e-77db46e5c495",
+   "metadata": {
+    "id": "497025f0-e60a-42d1-a26e-77db46e5c495"
+   },
+   "outputs": [],
+   "source": [
+    "# Your answers go here\n",
+    "propane = Chem.MolFromSmiles(\"CCC\")  # TO DO: Insert the SMILES string for propane: CCC\n",
+    "ethene = Chem.MolFromSmiles(\"C=C\")  # TO DO: Insert the SMILES string for ethene\n",
+    "cyclohexane = Chem.MolFromSmiles(\n",
+    "    \"C1CCCCC1 \"\n",
+    ")  # TO DO: Call the method and insert the SMILES string for cyclohexane\n",
+    "benzene = Chem.MolFromSmiles(\n",
+    "    \"c1ccccc1\"\n",
+    ")  # TO DO: Call the method and insert the SMILES string for benzene\n",
+    "acetic_acid = Chem.MolFromSmiles(\"CC(=O)O\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f87d25a4-61b2-437a-a5a6-176a2a45a813",
+   "metadata": {
+    "id": "f87d25a4-61b2-437a-a5a6-176a2a45a813"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here just by typing the name of the variable that refers to the RDKit mol object\n",
+    "acetic_acid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4CzZhBBEGpGV",
+   "metadata": {
+    "id": "4CzZhBBEGpGV"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem.Draw import IPythonConsole as ipc\n",
+    "\n",
+    "# Configuration for displaying in Jupyter notebooks\n",
+    "ipc.ipython_useSVG = True  # Use SVG for higher quality images\n",
+    "ipc.drawOptions.addAtomIndices = True  # Show atom indices\n",
+    "ipc.molSize = 250, 250  # Set size of image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "474fcdab-a904-4c66-8243-5a59de5ebf90",
+   "metadata": {
+    "cellView": "form",
+    "id": "474fcdab-a904-4c66-8243-5a59de5ebf90"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Working with RDKit Molecules\n",
+    "%%html\n",
+    "<style>\n",
+    "div.purple-box {\n",
+    "    color: #4b0082; /* Indigo for text */\n",
+    "    background-color: #f3e5f5; /* Light lavender background */\n",
+    "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+    "}\n",
+    "div.purple-box ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.purple-box li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"purple-box\">\n",
+    "    <p>\n",
+    "RDKit molecule objects have a number of methods we can use to get more information about the molecule. In the next few cells, we'll look at some methods that can tell us some things about the molecules we've created. The next cell has settings for modifying drawing molecules. It adds labels of atom indices and sets the image size\n",
+    "When working with Python objects in the Jupyter notebook, you can\n",
+    "type a variable or object name to see the methods available on that object.\n",
+    "    </p>\n",
+    "    <p>\n",
+    "In the cell below, type\n",
+    "<pre>\n",
+    "  acetic_acid.\n",
+    "\n",
+    "</pre>\n",
+    "\n",
+    "Notice how there is a dot at the end\n",
+    "\n",
+    "    <pre>\n",
+    "      .\n",
+    "    </pre>\n",
+    "\n",
+    "Then press the `tab` key. A list of possible methods and attributes will come up.\n",
+    "\n",
+    "Look through the methods until you find one that gives you the number of atoms in the molecule.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1a331ad-3b4d-44e1-ad51-dc093008dacb",
+   "metadata": {
+    "id": "e1a331ad-3b4d-44e1-ad51-dc093008dacb"
+   },
+   "outputs": [],
+   "source": [
+    "# Pick a method that will tell you the number of atoms acetic acid has.\n",
+    "\n",
+    "x = acetic_acid.GetNumAtoms()  # TO DO: enter a . after acetic acid and then scroll down the list to find a method to give you the number of atoms\n",
+    "\n",
+    "print(\"Acetic acid has\", x, \"heavy atoms.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56379e5a-44f0-4272-959d-91f652ba4128",
+   "metadata": {
+    "id": "56379e5a-44f0-4272-959d-91f652ba4128"
+   },
+   "source": [
+    "### Finding help\n",
+    "When you start working with RDKit mol objects, it will be an adjustment. This is a new type of variable and it will take time to adjust. One way to find help is to use a simple help command where the object of the help function is the name of the RDKit mol object. In the next cell, we will use help to learn more about the RDKit mol object, acetic_acid, that we just created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b7d32b7-f531-4a4f-b05e-4c6c51664d50",
+   "metadata": {
+    "id": "1b7d32b7-f531-4a4f-b05e-4c6c51664d50"
+   },
+   "outputs": [],
+   "source": [
+    "help(acetic_acid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc30f661-dc41-4c06-82cc-a4ae762d65e7",
+   "metadata": {
+    "id": "cc30f661-dc41-4c06-82cc-a4ae762d65e7"
+   },
+   "outputs": [],
+   "source": [
+    "# Add an argument to your function to get the total number of atoms in acetic_acid including hydrogens\n",
+    "\n",
+    "x = (\n",
+    "    acetic_acid.GetNumAtoms()\n",
+    ")  # This is the method we used in an earlier cell. Note that the parentheses are empty.\n",
+    "\n",
+    "y = acetic_acid.GetNumAtoms(\n",
+    "    onlyExplicit=False\n",
+    ")  # TO DO: To include the hydrogens in the atom count, insert the phrase onlyExplicit = False in the parentheses.\n",
+    "\n",
+    "print(f\"There are {x} heavy atoms in acetic acid and {y} total atoms in acetic acid.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a47eba18-f0a2-4d59-88c0-b58b1605d9d4",
+   "metadata": {
+    "cellView": "form",
+    "id": "a47eba18-f0a2-4d59-88c0-b58b1605d9d4"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Examining and Visualizing Data\n",
+    "%%html\n",
+    "<style>\n",
+    "div.alert {\n",
+    "    color: #0056b3;\n",
+    "    background-color: #d9edf7;\n",
+    "    border-left: 5px solid #31708f;\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em;\n",
+    "    line-height: 1.5;\n",
+    "}\n",
+    "div.alert ul {\n",
+    "    margin: 0.5em 0;\n",
+    "}\n",
+    "div.alert li {\n",
+    "    margin-bottom: 0.5em;\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <strong>Questions:</strong>\n",
+    "    <ul>\n",
+    "        <li>How can I use pandas to work with molecules from rdkit?</li>\n",
+    "        <li>How can I visualize relationships between different parts of my data?</li>\n",
+    "   </ul>\n",
+    "\n",
+    "    <strong>Objectives:</strong>\n",
+    "    <ul>\n",
+    "        <li>Review the pandas dataframe</li>\n",
+    "        <li>Learn to visualize structures in a pandas dataframe</li>\n",
+    "        <li>Learn the <i>apply</i> tool for expanding a pandas dataframe</li>\n",
+    "    </ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4cc10b7-5d18-4853-bfac-a2448f722414",
+   "metadata": {
+    "id": "a4cc10b7-5d18-4853-bfac-a2448f722414"
+   },
+   "source": [
+    "[Pandas](https://pandas.pydata.org/docs/) is a Python library used for data analysis and manipulation. Within the world of data science, it is a ubiquitous and widely used library. If you are learning how to analyze data in Python, it will be almost impossible to avoid pandas.\n",
+    "\n",
+    "The central data structure of pandas is called a DataFrame. Pandas DataFrames work very closely with NumPy arrays and Pandas dataframes are specifically for data which is two dimensional (rows and columns). NumPy arrays, while similar in some ways, can work with higher dimensional data.\n",
+    "\n",
+    "Pandas is very powerful. In this session, we'll be learning how to access information in pandas dataframes and how to do some basic manipulation and analysis. We are going to be looking at a dataset which gives information about the elements in the periodic table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2e82ae2-4050-4955-a205-5ed86e42cc2b",
+   "metadata": {
+    "id": "f2e82ae2-4050-4955-a205-5ed86e42cc2b"
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd  # importing the pandas library\n",
+    "\n",
+    "from rdkit.Chem import PandasTools  # importing rdkit functions to work with pandas\n",
+    "\n",
+    "PandasTools.RenderImagesInAllDataFrames(\n",
+    "    images=True\n",
+    ")  # to display chemical structures in dataframes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "LzrEG54AKY-W",
+   "metadata": {
+    "id": "LzrEG54AKY-W"
+   },
+   "outputs": [],
+   "source": [
+    "from urllib.request import (\n",
+    "    urlretrieve,\n",
+    ")  # importing a method that enables retrieval of a text file from a URL\n",
+    "\n",
+    "url = \"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/paul/data/nsaids.csv\"\n",
+    "\n",
+    "filename = \"nsaids.csv\"\n",
+    "\n",
+    "urlretrieve(url, filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ed0f50a-7b42-49dc-acc4-f68c4cedc1a6",
+   "metadata": {
+    "id": "6ed0f50a-7b42-49dc-acc4-f68c4cedc1a6"
+   },
+   "source": [
+    "## Loading a collection of small molecules\n",
+    "\n",
+    "In the next few cells, we'll read a text file that lists the SMILES strings for some nonsteroidal antiinflammatory drugs (NSAIDS) and then use them to start building a pandas dataframe. The SMILES strings for the NSAIDS can be found in [nsaids.txt](https://docs.google.com/document/d/1RQeVIFBMeq4SWTrRNfgZXRvaaRNXVknLxgVZfTbJUDs/edit?usp=drive_link).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e09ef49-ad83-4f81-a0da-c90c83f02d3b",
+   "metadata": {
+    "id": "6e09ef49-ad83-4f81-a0da-c90c83f02d3b"
+   },
+   "outputs": [],
+   "source": [
+    "nsaids_file = \"nsaids.csv\"\n",
+    "\n",
+    "nsaids_df = pd.read_csv(nsaids_file)\n",
+    "\n",
+    "nsaids_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26a9b6b3-10ff-4594-b660-5b605ac30e2e",
+   "metadata": {
+    "id": "26a9b6b3-10ff-4594-b660-5b605ac30e2e"
+   },
+   "source": [
+    "### The `.apply` method\n",
+    "\n",
+    "The `.apply` method in pandas is used to apply a function along a row or column of a dataframe.\n",
+    "This is useful when you have a custom function that you need to use on every value in a column, but there is not a NumPy or Pandas function for it.\n",
+    "\n",
+    "For example, we could apply the `len` function to our `Name` column to get the number of letters in the name for each element.\n",
+    "\n",
+    "```python\n",
+    "# Number of letters in name -\n",
+    "df[\"Name\"].apply(len)\n",
+    "```\n",
+    "\n",
+    "We are going to use ```apply``` to add a new column to nsaid_df that contains the rdkit molecule for each of the NSAIDs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb693a02-58a2-467d-80fa-723d61f62219",
+   "metadata": {
+    "id": "fb693a02-58a2-467d-80fa-723d61f62219"
+   },
+   "outputs": [],
+   "source": [
+    "nsaids_df[\"Molecule\"] = nsaids_df[\"SMILES\"].apply(Chem.MolFromSmiles)\n",
+    "\n",
+    "nsaids_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "WqeeyIxPiF-7",
+   "metadata": {
+    "id": "WqeeyIxPiF-7"
+   },
+   "source": [
+    "At this point, nsaid_df contains two columns: the SMILES string and the molecule. We will go one step further and use ```apply``` to add another column to the dataframe that contains a descriptor based on the rdkit molecule. Before we can do that we need to import a new sublibrary from rdkit.Chem called Descriptors. Notice that the new columns will be based on the Molecule column, which contains rdkit mol objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "v7lK6asEid7Q",
+   "metadata": {
+    "id": "v7lK6asEid7Q"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem import Descriptors\n",
+    "from rdkit.Chem import Lipinski\n",
+    "\n",
+    "nsaids_df[\"Mol Wt\"] = nsaids_df[\"Molecule\"].apply(Descriptors.MolWt)\n",
+    "nsaids_df[\"logP\"] = nsaids_df[\"Molecule\"].apply(Descriptors.MolLogP)\n",
+    "nsaids_df[\"HBD\"] = nsaids_df[\"Molecule\"].apply(\n",
+    "    Lipinski.NHOHCount\n",
+    ")  # Number of hydrogen bond donors\n",
+    "nsaids_df[\"HBA\"] = nsaids_df[\"Molecule\"].apply(\n",
+    "    Lipinski.NOCount\n",
+    ")  # Number of hydrogen bond acceptors\n",
+    "nsaids_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "WLO4ia4B4lXG",
+   "metadata": {
+    "id": "WLO4ia4B4lXG"
+   },
+   "outputs": [],
+   "source": [
+    "nsaids_df.hist(figsize=(8, 8), edgecolor=\"black\", grid=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dWKNKdDVkJxn",
+   "metadata": {
+    "id": "dWKNKdDVkJxn"
+   },
+   "outputs": [],
+   "source": [
+    "nsaids_df.plot.bar(x=\"Name\", y=\"Mol Wt\", figsize=(10, 5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "LEfWBGaI5-EJ",
+   "metadata": {
+    "id": "LEfWBGaI5-EJ"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/prep/A_python_basics.ipynb
+++ b/prep/A_python_basics.ipynb
@@ -1,785 +1,837 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Z441pTAW6Q1z"
-      },
-      "source": [
-        "\n",
-        "\n",
-        "<img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
-        "\n",
-        "# Introduction to Python\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "<h2>Overview</h2>\n",
-        "\n",
-        "Questions:\n",
-        "\n",
-        "* What is the Python programming language, and what is it used for?\n",
-        "\n",
-        "* What is the basic syntax of the Python programming language?\n",
-        "    \n",
-        "* What is a Python list?\n",
-        "    \n",
-        "* What is a Python dictionary?\n",
-        "    \n",
-        "* What is a `for` loop?\n",
-        "\n",
-        "Objectives:\n",
-        "\n",
-        "* Assign values to variables.\n",
-        "\n",
-        "* Use the `print` function to check how the code is working.\n",
-        "    \n",
-        "* Use a `for` loop to perform the same action on all the items in a list.\n",
-        "    \n",
-        "* Use the append function to create new lists in `for` loops.\n",
-        "\n",
-        "</div>\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "q4M4KDTS6Q11"
-      },
-      "source": [
-        "## What is Python and why use it?\n",
-        "\n",
-        "All of the software you use on a regular basis is created through the use of programming languages.\n",
-        "Programming languages allow us to write instructions to a computer.\n",
-        "There are many different programming languages, each with their own strengths, weaknesses, and uses.\n",
-        "Some popular programming languages you might hear about are Javascript (used on the web - any website with interactive content likely uses javascript), Python (scientific programming and many other applications), C++ (high performance applications - much of computational chemistry, self-driving cars, etc), SQL (databases), and many more.\n",
-        "\n",
-        "Python is a computer programming language that has become ubiquitous in scientific programming.\n",
-        "The Python programming language was first introduced in the year 1991, and has grown to be one of the most popular programming languages for both scientists and non-scientists.\n",
-        "According to the [2022 Stack Overflow Developer Survey](https://survey.stackoverflow.co/2022/#most-popular-technologies-language-prof), Python is the fourth most popular programming language.\n",
-        "Compared to other programming languages, Python is considered more intutitive to start learning and is also extremely versatile.\n",
-        "Python can be used to build web applications, interact with databases, and calculate and analyze data.\n",
-        "Python also has many libraries focused on science and machine learning.\n",
-        "\n",
-        "In computational chemistry, we will see that we can use Python to run and analyze our simulations.\n",
-        "We can also use some of Python's many libraries to fit data and predict properties.\n",
-        "\n",
-        "## Getting Started\n",
-        "\n",
-        "Our initial lessons will run python interactively through a Python interpreter.\n",
-        "We will use an environment called a Jupyter notebook.\n",
-        "The Jupyter notebook is an environment in your browser that can be used to write an execute Python code interactively.\n",
-        "You can view a Jupyter notebook using your browser or in some specialized text editors.\n",
-        "\n",
-        "Jupyter notebooks are made up of cells. Cells can either be markdown or code cells.\n",
-        "This cell is a Markdown Cell.\n",
-        "Code cells have executable Python code in them.\n",
-        "To change the type of a cell you can use the drop down option in the top window.\n",
-        "To run code in a cell, click inside of the cell and press `Shift+Enter`.\n",
-        "If the code executes successfully, the next cell will become the active cell.\n",
-        "\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EwBz5gji6Q11"
-      },
-      "source": [
-        "## Assigning variables\n",
-        "\n",
-        "Any Python interpreter can work just like a calculator.\n",
-        "This is not very useful.\n",
-        "Press the Shift Key and the Enter Key (`Shift + Enter`) at the same time to run (also called \"execute\") the code in a cell.\n",
-        "The following cell contains an expression to calculate `3 + 7`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "_e1DP-Li6Q12",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "            # TO DO: Enter 3 + 7 in this cell and hit the play button or shift/return"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "IQb59E2u6Q12"
-      },
-      "source": [
-        "Here, Python has performed a calculation for us. To save this value, or other values, we assign them to a variable for later use.\n",
-        "Variable **assignment** is the technical term for doing this.\n",
-        "If we do not assign an expression to a variable, we will not be able to use its value later.\n",
-        "\n",
-        "The syntax for assigning variables is the following:\n",
-        "\n",
-        "```python\n",
-        "variable_name = varaible_value\n",
-        "```\n",
-        "\n",
-        "Let’s see this in action with a calculation.\n",
-        "Let's define some variables for our calculation.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "0yLHF6xQ6Q13",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "deltaH = -541.5   #kJ/mole\n",
-        "deltaS =  10.4     #kJ/(mole K)\n",
-        "temp = 298      #Kelvin\n",
-        "deltaG = deltaH - temp * deltaS"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Cp2Kbg7N6Q13"
-      },
-      "source": [
-        "Notice several things about this code.\n",
-        "The lines that begin with # are comment lines.\n",
-        "The computer does not do anything with these comments.\n",
-        "They have been used here to remind the user what units each of their values are in.\n",
-        "Comments are also often used to explain what the code is doing or leave information for future people who might use the code.\n",
-        "\n",
-        "When choosing variable names, you should choose informative names so that someone reading your code can tell what they represent. Naming a variable temp or temperature is much more informative than naming that variable t.\n",
-        "\n",
-        "We can now access any of the variables from other cells. Let’s print the value that we calculated.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "rwh5dZHt6Q13",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "print()          # TO DO: enter the name of the variable whose value you want to know"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bEqyDx4W6Q13"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<strong>Check your understanding</strong>\n",
-        "    \n",
-        "Write Python code to calculate the pressure of 1 mol of nitrogen gas in a sealed container with volume 10 L at 273.15 K using the Ideal Gas Law. Use R=0.0821 L·atm/mol·K for your gas constant.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ac6oW9UJ6Q14"
-      },
-      "outputs": [],
-      "source": [
-        "                    # TO DO: Declare variables for all the known values for this problem\n",
-        "\n",
-        "P =                 # TO DO: Use the ideal gas law to solve this problem\n",
-        "print(P)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "4JQ7fz776Q14"
-      },
-      "outputs": [],
-      "source": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3cwZnFar6Q14"
-      },
-      "source": [
-        "## Using Functions\n",
-        "\n",
-        "When we use `print`, we are using a `function`.\n",
-        "Functions are reusable pieces of code that perform certain tasks.\n",
-        "Examples include printing, opening files, performing a calculations, and many others.\n",
-        "Functions have a name that is followed by parenthesis containing the function inputs separated by commas (also called *arguments*).\n",
-        "\n",
-        "```python\n",
-        "function_name(argument1, argument2)\n",
-        "```\n",
-        "\n",
-        "In the previous code block, we introduced the `print` function. Often, we will use the print function just to make sure our code is working correctly.\n",
-        "\n",
-        "Note that if you do not specify a new name for a variable, then it doesn’t automatically change the value of the variable. For example if we typed"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "e3JOtxYk6Q15",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "print(deltaG)\n",
-        "deltaG * 1000\n",
-        "print(deltaG)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3fOYQXvk6Q15"
-      },
-      "source": [
-        "Nothing happened to the value of deltaG. If we wanted to change the value of deltaG we would have to re-save the variable using the same name to overwrite the existing value."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "xjWwm0-I6Q15",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "print(deltaG)\n",
-        "deltaG = deltaG * 1000\n",
-        "print(deltaG)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rvzkK-s16Q15"
-      },
-      "source": [
-        "There are situations where it is reasonable to overwrite a variable with a new value, but you should always think carefully about this. Usually it is a better practice to give the variable a new name and leave the existing variable as is."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "NEdXe7IV6Q15",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "deltaG = deltaH - temp * deltaS         # This will reset the value of deltaG to reflect units of kilojoules\n",
-        "deltaG_joules = deltaG * 1000\n",
-        "print(deltaG)\n",
-        "print()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "U4IEpMO76Q15"
-      },
-      "source": [
-        "## Data Types\n",
-        "\n",
-        "Each variable is some particular type of data.\n",
-        "The most common types of data are strings (str),\n",
-        "integers (int), and floating point numbers (float).\n",
-        "You can identify the data type of any variable with the function `type(variable_name)`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "dxzyV0Ei6Q16",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "type()          # TO DO: Enter the variable whose value you want to know in the parentheses"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oLlD2SeW6Q16"
-      },
-      "source": [
-        "You can change the data type of a variable like this. This is called casting."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "zAQ48wXN6Q16",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "deltaG_string = str(deltaG)\n",
-        "type()           # # TO DO: Enter the variable whose type you want to know in the parentheses"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5wb7zLds6Q16"
-      },
-      "source": [
-        "We could have created a variable as a string originally by surrounding the value in quotes `\"\"`. It doesn't matter if you use single or double quotes, the first quote just has to match the closing quote."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "DKlZnioW6Q16",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "string_variable = \"This is a string\"\n",
-        "print(type(string_variable))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Obx4E1yr6Q16"
-      },
-      "source": [
-        "## Lists\n",
-        "\n",
-        "Another common data structure in python is the list. Lists can be used to group several values or variables together, and are declared using square brackets `[ ]`.\n",
-        "List values are separated by commas.\n",
-        "Python has several built in functions which can be used on lists.\n",
-        "The built-in function `len` can be used to determine the length of a list.\n",
-        "This code block also demonstrates how to print multiple variables."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "5FUptHHh6Q16",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "# This is a list\n",
-        "\n",
-        "energy_kcal = [-13.4, -2.7, 5.4, 42.1]\n",
-        "\n",
-        "\n",
-        "# I can determine its length\n",
-        "energy_length = len()                     # TO DO: Enter the list variable whose length you want to know in the parentheses\n",
-        "\n",
-        "# print the list length\n",
-        "\n",
-        "print('The length of this list is', energy_length)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wLfRsTv26Q16"
-      },
-      "source": [
-        "If I want to operate on a particular element of the list, you use the list name and then put in brackets which element of the list you want. In python counting starts at zero. So the first element of the list is list[0]."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "GuL4Wrc06Q17",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "# Print the first element of the list\n",
-        "print(energy_kcal[])                  # TO DO: Enter the number for the first element in the list"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "MNzJlt3j6Q17"
-      },
-      "source": [
-        "You can use an element of a list as a variable in a calculation."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "-CnmuFrV6Q17",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "# Convert the second list element to kilojoules.\n",
-        "energy_kilojoules = energy_kcal[1] * 4.184\n",
-        "print()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5uGB4iwf6Q17"
-      },
-      "source": [
-        "### Slices\n",
-        "\n",
-        "Sometimes you will want to make a new list that is a subset of an existing list. For example, we might want to make a new list that is just the first few elements of our previous list. This is called a slice. The general syntax is\n",
-        "\n",
-        "```python\n",
-        "new_list = list_name[start:end]\n",
-        "```\n",
-        "\n",
-        "When taking a slice, it is very important to remember how counting works in python. Remember that counting starts at zero so the first element of a list is `list_name[0]`. When you specify the last element for the slice, it goes *up to but not including* that element of the list. So a slice like\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "vPeEme_t6Q17",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "short_list = energy_kcal[0:2]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "W9TzLj2n6Q17"
-      },
-      "source": [
-        "includes energy_kcal[0] and energy_kcal[1] but not energy_kcal[2].\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "8iudc3W46Q17",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "print(short_list)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EN3gzR0Q6Q18"
-      },
-      "source": [
-        "If you do not include a start index, the slice automatically starts at list_name[0]. If you do not include an end index, the slice automatically goes to the end of the list.\n",
-        "\n",
-        "\n",
-        "<div class=\"exercise admonition\">\n",
-        "<p class=\"admonition-title\">Check Your Understanding</p>\n",
-        "\n",
-        "What does the following code block print?\n",
-        "```python\n",
-        "slice1 = energy_kcal[1:]\n",
-        "slice2 = energy_kcal[:3]\n",
-        "print('slice1 is', slice1)\n",
-        "print('slice2 is', slice2)\n",
-        "```\n",
-        "\n",
-        "<div class=\"solution admonition dropdown\">\n",
-        "<p class=\"admonition-title\">Solution</p>\n",
-        "\n",
-        "The code prints\n",
-        "\n",
-        "```output\n",
-        "slice1 is [-2.7, 5.4, 42.1]\n",
-        "slice2 is [-13.4, -2.7, 5.4]\n",
-        "```\n",
-        "\n",
-        "</div>\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "A4cQRftf6Q18"
-      },
-      "source": [
-        "## Repeating an operation many times: for loops\n",
-        "\n",
-        "Often, you will want to do something to every element of a list. The structure to do this is called a for loop. The general structure of a for loop is\n",
-        "\n",
-        "```python\n",
-        "for variable in list:\n",
-        "    do things using variable\n",
-        "\n",
-        "```\n",
-        "\n",
-        "There are two very important pieces of syntax for the for loop. Notice the colon : after the word list. You will always have a colon at the end of a for statement. If you forget the colon, you will get an error when you try to run your code.\n",
-        "\n",
-        "The second thing to notice is that the lines of code under the for loop (the things you want to do several times) are indented. Indentation is very important in python. There is nothing like an end or exit statement that tells you that you are finished with the loop. The indentation shows you what statements are in the loop. Each indentation is 4 spaces by convention in Python 3. However, if you are using an editor which understands Python, it will do the correct indentation for you when you press the tab key on your keyboard. In fact, the Jupyter notebook will notice that you used a colon (`:`) in the previous line, and will indent for you (so you will not need to press tab).\n",
-        "\n",
-        "Let’s use a loop to change all of our energies in kcal to kJ.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "0vZUvpoJ6Q18",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "for number in energy_kcal:\n",
-        "    kJ = number * 4.184\n",
-        "    print()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jY6muhcv6Q18"
-      },
-      "source": [
-        "Now it seems like we are really getting somewhere with our program! But it would be even better if instead of just printing the values, it saved them in a new list. To do this, we are going to use the append function. The append function adds a new item to the end of an existing list. The general form of the append function is\n",
-        "\n",
-        "```python\n",
-        "list_name.append(new_thing)\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Sj8oxoGW6Q18",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "for number in energy_kcal:\n",
-        "    kJ = number * 4.184\n",
-        "    energy_kJ.append(kJ)\n",
-        "\n",
-        "print(energy_kJ)\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "zoOiQhhL6Q18"
-      },
-      "source": [
-        "This is an example of an error message. An error message is what occurs if there is something wrong with your code.\n",
-        "In Python, when you read error messagees, you should try to read the last line of the error message first.\n",
-        "It will have a message about what went wrong in the program execution.\n",
-        "\n",
-        "This code doesn’t work because on the first iteration of our loop, the list energy_kJ doesn’t exist. To make it work, we have to start the list outside of the loop. The list can be blank when we start it, but we have to start it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "lwtrAAp56Q2B",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "energy_kJ =                           # TO DO: When you declare a list variable, it must have square brackets, even for an empty list\n",
-        "for number in energy_kcal:\n",
-        "    kJ = number * 4.184\n",
-        "    energy_kJ.append(kJ)\n",
-        "\n",
-        "print(energy_kJ)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7Jca6K4H6Q2B"
-      },
-      "source": [
-        "## Making choices: logic statements\n",
-        "\n",
-        "Within your code, you may need to evaluate a variable and then do something if the variable has a particular value. This type of logic is handled by an if statement. In the following example, we only append the negative numbers to a new list."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "JVkY9icZ6Q2C",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "negative_energy_kJ =\n",
-        "\n",
-        "for number in energy_kJ:\n",
-        "    if number < 0:\n",
-        "        negative_energy_kJ.append(number)\n",
-        "\n",
-        "print(negative_energy_kJ)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FOFy7HFw6Q2C"
-      },
-      "source": [
-        "Other logic operations include\n",
-        "\n",
-        "* equal to `==`\n",
-        "* not equal to `!=`\n",
-        "* greater than `>`\n",
-        "* less than `<`\n",
-        "* greater than or equal to `>=`\n",
-        "* less than or equal to `<=`\n",
-        "\n",
-        "You can also use and, or, and not to check more than one condition.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "VIG-Xhhy6Q2C",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "negative_numbers = []\n",
-        "for number in energy_kJ:\n",
-        "    if number < 0 or number == 0:\n",
-        "        negative_numbers.append(number)\n",
-        "\n",
-        "print(negative_numbers)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "shYOnOjN6Q2C"
-      },
-      "source": [
-        "To define what happens if the `if` statement is not met, you can use the `else` keyword."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "1nCZFepn6Q2C",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "negative_numbers = []\n",
-        "positive_numbers = []\n",
-        "for number in energy_kJ:\n",
-        "    if number < 0 or number == 0:\n",
-        "        negative_numbers.append(number)\n",
-        "    else:\n",
-        "        positive_numbers.append(number)\n",
-        "\n",
-        "print(\"Negative numbers:\", negative_numbers)\n",
-        "print(\"Positive Numbers: \", positive_numbers)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TbKB6K6U6Q2C",
-        "tags": []
-      },
-      "source": [
-        "## Formatted Strings\n",
-        "\n",
-        "Throughout the lesson we will sometimes use a special kind of string called a \"formatted string\". A formatted string is a string that has a variable in it.\n",
-        "To make a formatted string, you start your string with an `f`, and put variable names in curly braces."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "zj1Y6sZ86Q2C"
-      },
-      "outputs": [],
-      "source": [
-        "my_string = f\"The positive numbers are {positive_numbers}.\"\n",
-        "print(my_string)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "AkpawsHC6Q2D"
-      },
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.2"
-    },
-    "vscode": {
-      "interpreter": {
-        "hash": "16d4a7bb199d969b1271ebe46f77414b0d9cd01b3c3983c2b2742fc6cd4503d3"
-      }
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Z441pTAW6Q1z"
+   },
+   "source": [
+    "\n",
+    "\n",
+    "<img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+    "\n",
+    "# Introduction to Python\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2>Overview</h2>\n",
+    "\n",
+    "Questions:\n",
+    "\n",
+    "* What is the Python programming language, and what is it used for?\n",
+    "\n",
+    "* What is the basic syntax of the Python programming language?\n",
+    "    \n",
+    "* What is a Python list?\n",
+    "    \n",
+    "* What is a Python dictionary?\n",
+    "    \n",
+    "* What is a `for` loop?\n",
+    "\n",
+    "Objectives:\n",
+    "\n",
+    "* Assign values to variables.\n",
+    "\n",
+    "* Use the `print` function to check how the code is working.\n",
+    "    \n",
+    "* Use a `for` loop to perform the same action on all the items in a list.\n",
+    "    \n",
+    "* Use the append function to create new lists in `for` loops.\n",
+    "\n",
+    "</div>\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "q4M4KDTS6Q11"
+   },
+   "source": [
+    "## What is Python and why use it?\n",
+    "\n",
+    "All of the software you use on a regular basis is created through the use of programming languages.\n",
+    "Programming languages allow us to write instructions to a computer.\n",
+    "There are many different programming languages, each with their own strengths, weaknesses, and uses.\n",
+    "Some popular programming languages you might hear about are Javascript (used on the web - any website with interactive content likely uses javascript), Python (scientific programming and many other applications), C++ (high performance applications - much of computational chemistry, self-driving cars, etc), SQL (databases), and many more.\n",
+    "\n",
+    "Python is a computer programming language that has become ubiquitous in scientific programming.\n",
+    "The Python programming language was first introduced in the year 1991, and has grown to be one of the most popular programming languages for both scientists and non-scientists.\n",
+    "According to the [2022 Stack Overflow Developer Survey](https://survey.stackoverflow.co/2022/#most-popular-technologies-language-prof), Python is the fourth most popular programming language.\n",
+    "Compared to other programming languages, Python is considered more intutitive to start learning and is also extremely versatile.\n",
+    "Python can be used to build web applications, interact with databases, and calculate and analyze data.\n",
+    "Python also has many libraries focused on science and machine learning.\n",
+    "\n",
+    "In computational chemistry, we will see that we can use Python to run and analyze our simulations.\n",
+    "We can also use some of Python's many libraries to fit data and predict properties.\n",
+    "\n",
+    "## Getting Started\n",
+    "\n",
+    "Our initial lessons will run python interactively through a Python interpreter.\n",
+    "We will use an environment called a Jupyter notebook.\n",
+    "The Jupyter notebook is an environment in your browser that can be used to write an execute Python code interactively.\n",
+    "You can view a Jupyter notebook using your browser or in some specialized text editors.\n",
+    "\n",
+    "Jupyter notebooks are made up of cells. Cells can either be markdown or code cells.\n",
+    "This cell is a Markdown Cell.\n",
+    "Code cells have executable Python code in them.\n",
+    "To change the type of a cell you can use the drop down option in the top window.\n",
+    "To run code in a cell, click inside of the cell and press `Shift+Enter`.\n",
+    "If the code executes successfully, the next cell will become the active cell.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EwBz5gji6Q11"
+   },
+   "source": [
+    "## Assigning variables\n",
+    "\n",
+    "Any Python interpreter can work just like a calculator.\n",
+    "This is not very useful.\n",
+    "Press the Shift Key and the Enter Key (`Shift + Enter`) at the same time to run (also called \"execute\") the code in a cell.\n",
+    "The following cell contains an expression to calculate `3 + 7`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "_e1DP-Li6Q12",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# TO DO: Enter 3 + 7 in this cell and hit the play button or shift/return"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "IQb59E2u6Q12"
+   },
+   "source": [
+    "Here, Python has performed a calculation for us. To save this value, or other values, we assign them to a variable for later use.\n",
+    "Variable **assignment** is the technical term for doing this.\n",
+    "If we do not assign an expression to a variable, we will not be able to use its value later.\n",
+    "\n",
+    "The syntax for assigning variables is the following:\n",
+    "\n",
+    "```python\n",
+    "variable_name = varaible_value\n",
+    "```\n",
+    "\n",
+    "Let’s see this in action with a calculation.\n",
+    "Let's define some variables for our calculation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "0yLHF6xQ6Q13",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "deltaH = -541.5  # kJ/mole\n",
+    "deltaS = 10.4  # kJ/(mole K)\n",
+    "temp = 298  # Kelvin\n",
+    "deltaG = deltaH - temp * deltaS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Cp2Kbg7N6Q13"
+   },
+   "source": [
+    "Notice several things about this code.\n",
+    "The lines that begin with # are comment lines.\n",
+    "The computer does not do anything with these comments.\n",
+    "They have been used here to remind the user what units each of their values are in.\n",
+    "Comments are also often used to explain what the code is doing or leave information for future people who might use the code.\n",
+    "\n",
+    "When choosing variable names, you should choose informative names so that someone reading your code can tell what they represent. Naming a variable temp or temperature is much more informative than naming that variable t.\n",
+    "\n",
+    "We can now access any of the variables from other cells. Let’s print the value that we calculated.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "id": "rwh5dZHt6Q13",
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print()  # TO DO: enter the name of the variable whose value you want to know"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bEqyDx4W6Q13"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<strong>Check your understanding</strong>\n",
+    "    \n",
+    "Write Python code to calculate the pressure of 1 mol of nitrogen gas in a sealed container with volume 10 L at 273.15 K using the Ideal Gas Law. Use R=0.0821 L·atm/mol·K for your gas constant.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "id": "ac6oW9UJ6Q14"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ellipsis\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TO DO: Declare variables for all the known values for this problem\n",
+    "\n",
+    "P = ...  # TO DO: Use the ideal gas law to solve this problem\n",
+    "print(P)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3cwZnFar6Q14"
+   },
+   "source": [
+    "## Using Functions\n",
+    "\n",
+    "When we use `print`, we are using a `function`.\n",
+    "Functions are reusable pieces of code that perform certain tasks.\n",
+    "Examples include printing, opening files, performing a calculations, and many others.\n",
+    "Functions have a name that is followed by parenthesis containing the function inputs separated by commas (also called *arguments*).\n",
+    "\n",
+    "```python\n",
+    "function_name(argument1, argument2)\n",
+    "```\n",
+    "\n",
+    "In the previous code block, we introduced the `print` function. Often, we will use the print function just to make sure our code is working correctly.\n",
+    "\n",
+    "Note that if you do not specify a new name for a variable, then it doesn’t automatically change the value of the variable. For example if we typed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "id": "e3JOtxYk6Q15",
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-3640.7000000000003\n",
+      "-3640.7000000000003\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(deltaG)\n",
+    "deltaG * 1000\n",
+    "print(deltaG)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3fOYQXvk6Q15"
+   },
+   "source": [
+    "Nothing happened to the value of deltaG. If we wanted to change the value of deltaG we would have to re-save the variable using the same name to overwrite the existing value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "xjWwm0-I6Q15",
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-3640.7000000000003\n",
+      "-3640700.0000000005\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(deltaG)\n",
+    "deltaG = deltaG * 1000\n",
+    "print(deltaG)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rvzkK-s16Q15"
+   },
+   "source": [
+    "There are situations where it is reasonable to overwrite a variable with a new value, but you should always think carefully about this. Usually it is a better practice to give the variable a new name and leave the existing variable as is."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "NEdXe7IV6Q15",
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-3640.7000000000003\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "deltaG = (\n",
+    "    deltaH - temp * deltaS\n",
+    ")  # This will reset the value of deltaG to reflect units of kilojoules\n",
+    "deltaG_joules = deltaG * 1000\n",
+    "print(deltaG)\n",
+    "print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "U4IEpMO76Q15"
+   },
+   "source": [
+    "## Data Types\n",
+    "\n",
+    "Each variable is some particular type of data.\n",
+    "The most common types of data are strings (str),\n",
+    "integers (int), and floating point numbers (float).\n",
+    "You can identify the data type of any variable with the function `type(variable_name)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "dxzyV0Ei6Q16",
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ellipsis"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(...)  # TO DO: Enter the variable whose value you want to know in the parentheses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "oLlD2SeW6Q16"
+   },
+   "source": [
+    "You can change the data type of a variable like this. This is called casting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "id": "zAQ48wXN6Q16",
+    "tags": []
+   },
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "type() takes 1 or 3 arguments",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[9]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m deltaG_string = \u001b[38;5;28mstr\u001b[39m(deltaG)\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[38;5;28;43mtype\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m           \u001b[38;5;66;03m# # TO DO: Enter the variable whose type you want to know in the parentheses\u001b[39;00m\n",
+      "\u001b[31mTypeError\u001b[39m: type() takes 1 or 3 arguments"
+     ]
+    }
+   ],
+   "source": [
+    "deltaG_string = str(deltaG)\n",
+    "type()  # # TO DO: Enter the variable whose type you want to know in the parentheses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5wb7zLds6Q16"
+   },
+   "source": [
+    "We could have created a variable as a string originally by surrounding the value in quotes `\"\"`. It doesn't matter if you use single or double quotes, the first quote just has to match the closing quote."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "DKlZnioW6Q16",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "string_variable = \"This is a string\"\n",
+    "print(type(string_variable))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Obx4E1yr6Q16"
+   },
+   "source": [
+    "## Lists\n",
+    "\n",
+    "Another common data structure in python is the list. Lists can be used to group several values or variables together, and are declared using square brackets `[ ]`.\n",
+    "List values are separated by commas.\n",
+    "Python has several built in functions which can be used on lists.\n",
+    "The built-in function `len` can be used to determine the length of a list.\n",
+    "This code block also demonstrates how to print multiple variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "5FUptHHh6Q16",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# This is a list\n",
+    "\n",
+    "energy_kcal = [-13.4, -2.7, 5.4, 42.1]\n",
+    "\n",
+    "\n",
+    "# I can determine its length\n",
+    "energy_length = (\n",
+    "    len()\n",
+    ")  # TO DO: Enter the list variable whose length you want to know in the parentheses\n",
+    "\n",
+    "# print the list length\n",
+    "\n",
+    "print(\"The length of this list is\", energy_length)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wLfRsTv26Q16"
+   },
+   "source": [
+    "If I want to operate on a particular element of the list, you use the list name and then put in brackets which element of the list you want. In python counting starts at zero. So the first element of the list is list[0]."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "GuL4Wrc06Q17",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Print the first element of the list\n",
+    "print(energy_kcal[...])  # TO DO: Enter the number for the first element in the list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MNzJlt3j6Q17"
+   },
+   "source": [
+    "You can use an element of a list as a variable in a calculation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-CnmuFrV6Q17",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Convert the second list element to kilojoules.\n",
+    "energy_kilojoules = energy_kcal[1] * 4.184\n",
+    "print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5uGB4iwf6Q17"
+   },
+   "source": [
+    "### Slices\n",
+    "\n",
+    "Sometimes you will want to make a new list that is a subset of an existing list. For example, we might want to make a new list that is just the first few elements of our previous list. This is called a slice. The general syntax is\n",
+    "\n",
+    "```python\n",
+    "new_list = list_name[start:end]\n",
+    "```\n",
+    "\n",
+    "When taking a slice, it is very important to remember how counting works in python. Remember that counting starts at zero so the first element of a list is `list_name[0]`. When you specify the last element for the slice, it goes *up to but not including* that element of the list. So a slice like\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "vPeEme_t6Q17",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "short_list = energy_kcal[0:2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "W9TzLj2n6Q17"
+   },
+   "source": [
+    "includes energy_kcal[0] and energy_kcal[1] but not energy_kcal[2].\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "8iudc3W46Q17",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(short_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EN3gzR0Q6Q18"
+   },
+   "source": [
+    "If you do not include a start index, the slice automatically starts at list_name[0]. If you do not include an end index, the slice automatically goes to the end of the list.\n",
+    "\n",
+    "\n",
+    "<div class=\"exercise admonition\">\n",
+    "<p class=\"admonition-title\">Check Your Understanding</p>\n",
+    "\n",
+    "What does the following code block print?\n",
+    "```python\n",
+    "slice1 = energy_kcal[1:]\n",
+    "slice2 = energy_kcal[:3]\n",
+    "print('slice1 is', slice1)\n",
+    "print('slice2 is', slice2)\n",
+    "```\n",
+    "\n",
+    "<div class=\"solution admonition dropdown\">\n",
+    "<p class=\"admonition-title\">Solution</p>\n",
+    "\n",
+    "The code prints\n",
+    "\n",
+    "```output\n",
+    "slice1 is [-2.7, 5.4, 42.1]\n",
+    "slice2 is [-13.4, -2.7, 5.4]\n",
+    "```\n",
+    "\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "A4cQRftf6Q18"
+   },
+   "source": [
+    "## Repeating an operation many times: for loops\n",
+    "\n",
+    "Often, you will want to do something to every element of a list. The structure to do this is called a for loop. The general structure of a for loop is\n",
+    "\n",
+    "```python\n",
+    "for variable in list:\n",
+    "    do things using variable\n",
+    "\n",
+    "```\n",
+    "\n",
+    "There are two very important pieces of syntax for the for loop. Notice the colon : after the word list. You will always have a colon at the end of a for statement. If you forget the colon, you will get an error when you try to run your code.\n",
+    "\n",
+    "The second thing to notice is that the lines of code under the for loop (the things you want to do several times) are indented. Indentation is very important in python. There is nothing like an end or exit statement that tells you that you are finished with the loop. The indentation shows you what statements are in the loop. Each indentation is 4 spaces by convention in Python 3. However, if you are using an editor which understands Python, it will do the correct indentation for you when you press the tab key on your keyboard. In fact, the Jupyter notebook will notice that you used a colon (`:`) in the previous line, and will indent for you (so you will not need to press tab).\n",
+    "\n",
+    "Let’s use a loop to change all of our energies in kcal to kJ.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "0vZUvpoJ6Q18",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for number in energy_kcal:\n",
+    "    kJ = number * 4.184\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jY6muhcv6Q18"
+   },
+   "source": [
+    "Now it seems like we are really getting somewhere with our program! But it would be even better if instead of just printing the values, it saved them in a new list. To do this, we are going to use the append function. The append function adds a new item to the end of an existing list. The general form of the append function is\n",
+    "\n",
+    "```python\n",
+    "list_name.append(new_thing)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Sj8oxoGW6Q18",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for number in energy_kcal:\n",
+    "    kJ = number * 4.184\n",
+    "    energy_kJ.append(kJ)  # noqa:F821\n",
+    "\n",
+    "print(energy_kJ)  # noqa:F821"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zoOiQhhL6Q18"
+   },
+   "source": [
+    "This is an example of an error message. An error message is what occurs if there is something wrong with your code.\n",
+    "In Python, when you read error messagees, you should try to read the last line of the error message first.\n",
+    "It will have a message about what went wrong in the program execution.\n",
+    "\n",
+    "This code doesn’t work because on the first iteration of our loop, the list energy_kJ doesn’t exist. To make it work, we have to start the list outside of the loop. The list can be blank when we start it, but we have to start it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "lwtrAAp56Q2B",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "energy_kJ = ...  # TO DO: When you declare a list variable, it must have square brackets, even for an empty list\n",
+    "for number in energy_kcal:\n",
+    "    kJ = number * 4.184\n",
+    "    energy_kJ.append(kJ)\n",
+    "\n",
+    "print(energy_kJ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7Jca6K4H6Q2B"
+   },
+   "source": [
+    "## Making choices: logic statements\n",
+    "\n",
+    "Within your code, you may need to evaluate a variable and then do something if the variable has a particular value. This type of logic is handled by an if statement. In the following example, we only append the negative numbers to a new list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "JVkY9icZ6Q2C",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "negative_energy_kJ = ...\n",
+    "\n",
+    "for number in energy_kJ:\n",
+    "    if number < 0:\n",
+    "        negative_energy_kJ.append(number)\n",
+    "\n",
+    "print(negative_energy_kJ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FOFy7HFw6Q2C"
+   },
+   "source": [
+    "Other logic operations include\n",
+    "\n",
+    "* equal to `==`\n",
+    "* not equal to `!=`\n",
+    "* greater than `>`\n",
+    "* less than `<`\n",
+    "* greater than or equal to `>=`\n",
+    "* less than or equal to `<=`\n",
+    "\n",
+    "You can also use and, or, and not to check more than one condition.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VIG-Xhhy6Q2C",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "negative_numbers = []\n",
+    "for number in energy_kJ:\n",
+    "    if number < 0 or number == 0:\n",
+    "        negative_numbers.append(number)\n",
+    "\n",
+    "print(negative_numbers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "shYOnOjN6Q2C"
+   },
+   "source": [
+    "To define what happens if the `if` statement is not met, you can use the `else` keyword."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "1nCZFepn6Q2C",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "negative_numbers = []\n",
+    "positive_numbers = []\n",
+    "for number in energy_kJ:\n",
+    "    if number < 0 or number == 0:\n",
+    "        negative_numbers.append(number)\n",
+    "    else:\n",
+    "        positive_numbers.append(number)\n",
+    "\n",
+    "print(\"Negative numbers:\", negative_numbers)\n",
+    "print(\"Positive Numbers: \", positive_numbers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TbKB6K6U6Q2C",
+    "tags": []
+   },
+   "source": [
+    "## Formatted Strings\n",
+    "\n",
+    "Throughout the lesson we will sometimes use a special kind of string called a \"formatted string\". A formatted string is a string that has a variable in it.\n",
+    "To make a formatted string, you start your string with an `f`, and put variable names in curly braces."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zj1Y6sZ86Q2C"
+   },
+   "outputs": [],
+   "source": [
+    "my_string = f\"The positive numbers are {positive_numbers}.\"\n",
+    "print(my_string)"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.1"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "16d4a7bb199d969b1271ebe46f77414b0d9cd01b3c3983c2b2742fc6cd4503d3"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/prep/A_python_basics.ipynb
+++ b/prep/A_python_basics.ipynb
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "id": "_e1DP-Li6Q12",
     "tags": []
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "id": "0yLHF6xQ6Q13",
     "tags": []
@@ -161,20 +161,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "id": "rwh5dZHt6Q13",
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print()  # TO DO: enter the name of the variable whose value you want to know"
    ]
@@ -195,19 +187,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "id": "ac6oW9UJ6Q14"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ellipsis\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# TO DO: Declare variables for all the known values for this problem\n",
     "\n",
@@ -239,21 +223,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "id": "e3JOtxYk6Q15",
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-3640.7000000000003\n",
-      "-3640.7000000000003\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(deltaG)\n",
     "deltaG * 1000\n",
@@ -271,21 +246,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "id": "xjWwm0-I6Q15",
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-3640.7000000000003\n",
-      "-3640700.0000000005\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(deltaG)\n",
     "deltaG = deltaG * 1000\n",
@@ -303,21 +269,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "id": "NEdXe7IV6Q15",
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-3640.7000000000003\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "deltaG = (\n",
     "    deltaH - temp * deltaS\n",
@@ -343,23 +300,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "id": "dxzyV0Ei6Q16",
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ellipsis"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "type(...)  # TO DO: Enter the variable whose value you want to know in the parentheses"
    ]
@@ -375,24 +321,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "id": "zAQ48wXN6Q16",
     "tags": []
    },
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "type() takes 1 or 3 arguments",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[9]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m deltaG_string = \u001b[38;5;28mstr\u001b[39m(deltaG)\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[38;5;28;43mtype\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m           \u001b[38;5;66;03m# # TO DO: Enter the variable whose type you want to know in the parentheses\u001b[39;00m\n",
-      "\u001b[31mTypeError\u001b[39m: type() takes 1 or 3 arguments"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "deltaG_string = str(deltaG)\n",
     "type()  # # TO DO: Enter the variable whose type you want to know in the parentheses"

--- a/prep/C_rdkit_intro.ipynb
+++ b/prep/C_rdkit_intro.ipynb
@@ -1,970 +1,999 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "d9020474",
-      "metadata": {
-        "id": "d9020474"
-      },
-      "source": [
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
-        "</div>\n",
-        "\n",
-        "\n",
-        "# Introduction to RDKit Molecules\n",
-        "\n",
-        "<strong>Author(s):</strong> Jessica A. Nash, The Molecular Sciences Software Institute\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "<h2>Overview</h2>\n",
-        "\n",
-        "<strong>Questions:</strong>\n",
-        "\n",
-        "* What is RDKit?\n",
-        "\n",
-        "* What is an RDKit molecule object?\n",
-        "\n",
-        "* What can I do with RDKit molecules?\n",
-        "\n",
-        "<strong>Objectives:</strong>\n",
-        "\n",
-        "* Use RDKit to create molecules in Python\n",
-        "\n",
-        "</div>\n",
-        "\n",
-        "There are Python libraries that are made for working just with chemical data. One commonly used library in Python for data science (or cheminformatics) is called [RDKit](https://en.wikipedia.org/wiki/RDKit). RDKit is an open-source cheminformatics library, primarily developed in C++ and has been under development since the year 2000. We will be using the Python interface to RDKit, though there are interfaces in other languages.\n",
-        "\n",
-        "RDKit provides a molecule object that allows you to manipulate chemical structures. It has capabilities for reading and writing molecular file formats, calculating molecular properties, and performing substructure searches. In addition, it offers a wide range of cheminformatics algorithms such as molecular fingerprint generation, similarity metrics calculation, and molecular descriptor computation. This notebook introduces RDKit basics, but we will see more of all of these topics in later notebooks.\n",
-        "\n",
-        "<div class=\"alert alert-block alert-success\">\n",
-        "<strong>Python Skills: Python Objects</strong>\n",
-        "\n",
-        "Most of this functionality is achieved through the RDKit `mol` object. In Python, we use the word \"object\" to refer to a variable type with associated data and methods.\n",
-        "One example of an object we have seen in notebooks is a list - we could also call it a \"list object\". An object has `attributes` (data) and `methods`.\n",
-        "You access information about objects with the syntax\n",
-        "```python\n",
-        "object.data\n",
-        "```\n",
-        "where data is the attribute name.\n",
-        "\n",
-        "You access object methods with the syntax\n",
-        "```python\n",
-        "object.method(arguments)\n",
-        "```\n",
-        "\n",
-        "For example, for a list \"`append` is a method that was covered in the introductory lesson.\n",
-        "\n",
-        "```\n",
-        "my_list = []\n",
-        "my_list.append(1) # \"append\" is a method that can be called for a list\n",
-        "```\n",
-        "</div>    \n",
-        "\n",
-        "In this lesson, we will create and manipulate RDKit `mol` objects. RDKit `mol` objects represent molecules and have\n",
-        "attributes (data) and methods (actions) associated with molecules.\n",
-        "\n",
-        "We are going to use a part of RDKit called `Chem`. To use `Chem`, we first have to import it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "eFjTn5wMHixe",
-      "metadata": {
-        "id": "eFjTn5wMHixe"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install rdkit"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "afc9bc63",
-      "metadata": {
-        "id": "afc9bc63",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit import Chem"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d5b835ad",
-      "metadata": {
-        "id": "d5b835ad"
-      },
-      "source": [
-        "## Creating Molecules with RDKit\n",
-        "\n",
-        "Throughout this tutorial, it will be helpful to have access to the [RDKit documentation](https://www.rdkit.org/docs/index.html).\n",
-        "\n",
-        "To get information about molecules in RDKit, we have to first create objects representing molecules. RDKit has a molecule object that can be used to retrieve information or calculate properties. To create a molecule object, we have to communicate the molecule identity in a way that computers understand.\n",
-        "\n",
-        "We will use SMILES strings to create our objects, though RDKit also has methods for creating molecules from the file formats listed in the previous notebook.\n",
-        "\n",
-        "### Creating molecules using SMILES\n",
-        "\n",
-        "In the last lesson, we learned about molecular representations using SMILES strings. Now we will use SMILES strings to create molecule objects in RDKIT.\n",
-        "\n",
-        "We can create a representation of methane using RDKit by using the `MolFromSmiles` function in `rdkit.Chem`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "40b29a7c",
-      "metadata": {
-        "id": "40b29a7c",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "methane = Chem.MolFromSmiles(\"\")           # TO DO: Enter a capital C between the quote marks in the parentheses"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "da5b102b-e997-47b4-8a0d-7cc5befc1b7e",
-      "metadata": {
-        "id": "da5b102b-e997-47b4-8a0d-7cc5befc1b7e"
-      },
-      "source": [
-        "The `methane` variable is now an RDKit \"molecule object\".\n",
-        "\n",
-        "In a Jupyter environment, putting a variable that is an RDKit molecule as the only or last thing in a cell,\n",
-        "will result in a picture of the molecule as an output."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "99734c44",
-      "metadata": {
-        "id": "99734c44",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "methane"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fae858d1-503d-4dc9-a220-f713ed075847",
-      "metadata": {
-        "id": "fae858d1-503d-4dc9-a220-f713ed075847"
-      },
-      "outputs": [],
-      "source": [
-        "ethane = Chem.MolFromSmiles(\"\")          # TO DO: Enter a capital CC between the quote marks in the parentheses\n",
-        "ethane"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e98c39d3",
-      "metadata": {
-        "id": "e98c39d3"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Check Your Understanding</h3>\n",
-        "<p> Create RDKit molecules for the following molecules. You can look up the SMILES strings on <a href=\"https://pubchem.ncbi.nlm.nih.gov/\">PubChem</a>:\n",
-        "<p>\n",
-        "    <ul>\n",
-        "        <li> Propane\n",
-        "        <li> Ethene\n",
-        "        <li> Cyclohexane\n",
-        "        <li> Benzene </li>\n",
-        "        <li> Acetic Acid\n",
-        "    </ul>\n",
-        "</p>\n",
-        "<p>Create variables for each molecule. The variable names should be the molecule name (all lowercase)</p>\n",
-        "</div>\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "bbae7a92-6647-4361-b5ed-f45363f4d249",
-      "metadata": {
-        "id": "bbae7a92-6647-4361-b5ed-f45363f4d249",
-        "tags": []
-      },
-      "outputs": [],
-      "source": [
-        "# Your answers go here\n",
-        "propane = Chem.MolFromSmiles(\"\")            # TO DO: Enter the SMILES string for propane between the quote marks in the parentheses\n",
-        "ethene = Chem.MolFromSmiles(\"\")             # TO DO: Enter the SMILES string for ethene between the quote marks in the parentheses\n",
-        "cyclohexane = Chem.MolFromSmiles(\"\")        # TO DO: Enter the SMILES string for cyclohexane between the quote marks in the parentheses\n",
-        "benzene = Chem.MolFromSmiles('')            # TO DO: Enter the SMILES string for benzene between the quote marks in the parentheses\n",
-        "acetic_acid = Chem.MolFromSmiles(\"\")        # TO DO: Enter the SMILES string for acetic acid between the quote marks in the parentheses"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "395bc20c-bef9-4941-a2f8-fca830baae2b",
-      "metadata": {
-        "id": "395bc20c-bef9-4941-a2f8-fca830baae2b"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
-        "propane"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "e22a13a2-305e-458b-9caa-ba636b836e1e",
-      "metadata": {
-        "id": "e22a13a2-305e-458b-9caa-ba636b836e1e"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
-        "ethene"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "2fc9b578-6889-43d9-85c0-0f07111053b3",
-      "metadata": {
-        "id": "2fc9b578-6889-43d9-85c0-0f07111053b3"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
-        "cyclohexane"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "0942cfe3-0ca2-4145-baaf-c7dff83fed24",
-      "metadata": {
-        "id": "0942cfe3-0ca2-4145-baaf-c7dff83fed24"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
-        "benzene"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "670f07a8-c1ac-41bc-b4d9-62ac7bf342fd",
-      "metadata": {
-        "id": "670f07a8-c1ac-41bc-b4d9-62ac7bf342fd"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
-        "acetic_acid"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ee8b5f19-d326-4c5c-a563-ef06e7890b9f",
-      "metadata": {
-        "id": "ee8b5f19-d326-4c5c-a563-ef06e7890b9f"
-      },
-      "source": [
-        "## Working with RDKit Molecules\n",
-        "\n",
-        "RDKit molecule objects have a number of methods we can use to get more information about the molecule.\n",
-        "In the next few cells, we'll look at some methods that can tell us some things about the molecules we've created.\n",
-        "The next cell has settings for modifying drawing molecules. It adds labels of atom indices and sets the image size."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "761d0c31-0e04-453a-9be7-cb93cb9386a5",
-      "metadata": {
-        "id": "761d0c31-0e04-453a-9be7-cb93cb9386a5"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem.Draw import IPythonConsole as ipc\n",
-        "from rdkit.Chem import Draw\n",
-        "\n",
-        "# Configuration for displaying in Jupyter notebooks\n",
-        "ipc.ipython_useSVG = True  # Use SVG for higher quality images\n",
-        "ipc.drawOptions.addAtomIndices = True  # Show atom indices\n",
-        "ipc.molSize = 250,250 # Set size of image"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "07cfae6b-3159-44df-8acf-67c35a68b99d",
-      "metadata": {
-        "id": "07cfae6b-3159-44df-8acf-67c35a68b99d"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-success\">\n",
-        "<strong>Jupyter Skills: The Tab Key</strong>\n",
-        "\n",
-        "When working with Python objects in the Jupyter notebook, you can type a variable or object name to see the methods available on that object.\n",
-        "\n",
-        "In the cell below, type `acetic_acid.` (notice how there is a dot (`.`) at the end), then press the `tab` key.\n",
-        "A list of possible methods and attributes will come up.\n",
-        "\n",
-        "Look through the methods until you find one that gives you the number of atoms in the molecule.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "91d1dd84-e932-4f2d-a170-dc9a15ab5447",
-      "metadata": {
-        "id": "91d1dd84-e932-4f2d-a170-dc9a15ab5447"
-      },
-      "outputs": [],
-      "source": [
-        "# Pick a method that will tell you the number of atoms acetic acid has.\n",
-        "\n",
-        "x = acetic_acid                # TO DO: Type a period after acetic_acid and look for a function that will give you the number of atoms in the molecule\n",
-        "\n",
-        "print('Acetic acid has', x, 'heavy atoms.')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c69990f5-4a31-4fa5-9787-546faab4b071",
-      "metadata": {
-        "id": "c69990f5-4a31-4fa5-9787-546faab4b071"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-success\">\n",
-        "<strong>Python Skills: Getting Help</strong>\n",
-        "\n",
-        "Is this the number of atoms you expected for a benzene molecule?\n",
-        "\n",
-        "We can use the `help` function on the method you found in the previous step to find a method argument to figure out a method argument to get the number of atoms we expect.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "eb159c7b-fb4f-4024-85e6-22f5d90d51ff",
-      "metadata": {
-        "id": "eb159c7b-fb4f-4024-85e6-22f5d90d51ff"
-      },
-      "outputs": [],
-      "source": [
-        "help(acetic_acid)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "66d59a12-0dd4-4e7a-adbc-e874c4f036ec",
-      "metadata": {
-        "id": "66d59a12-0dd4-4e7a-adbc-e874c4f036ec"
-      },
-      "outputs": [],
-      "source": [
-        "# Add an argument to your function to get the number of atoms that gives you\n",
-        "# the total number of atoms in acetic_acid including hydrogens\n",
-        "\n",
-        "x = acetic_acid.GetNumAtoms()\n",
-        "y = acetic_acid.GetNumAtoms()          # TO DO: Insert the expression      onlyExplicit = False      inside the parentheses so that it will include hydrogens.\n",
-        "\n",
-        "print(f\"There are {x} heavy atoms in acetic acid and {y} total atoms in acetic acid.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "71567da6-cd35-4265-9c16-813c3d008456",
-      "metadata": {
-        "id": "71567da6-cd35-4265-9c16-813c3d008456"
-      },
-      "source": [
-        "Each molecule is made up of RDKit atom objects and RDKit bond objects.\n",
-        "If we want to get the atoms for a particular molecule, we can use the `GetAtoms` method."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d1f14353-5f81-4c43-a7ea-8d8a5c5cfe8f",
-      "metadata": {
-        "id": "d1f14353-5f81-4c43-a7ea-8d8a5c5cfe8f"
-      },
-      "outputs": [],
-      "source": [
-        "acetic_acid_atoms = acetic_acid.GetAtoms()\n",
-        "print(acetic_acid_atoms)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "5c674690-c889-4e43-8d39-99ec703c3534",
-      "metadata": {
-        "id": "5c674690-c889-4e43-8d39-99ec703c3534"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-success\">\n",
-        "<strong>Python Skills: Iterators</strong>\n",
-        "\n",
-        "When we look at the results of the `GetAtoms` method, it tells us that we have a `GetAtomsIterator`.\n",
-        "In Python, an iterator is an object that contains values that can be looped through and indexed in.\n",
-        "\n",
-        "Although we haven't used this terminology before, a Python list is an example of an iterator.\n",
-        "\n",
-        "</div>\n",
-        "\n",
-        "Like a list, we can also call `len` on the iterator.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fc8318c2-0adf-48ae-b41a-c4cf99f129d8",
-      "metadata": {
-        "id": "fc8318c2-0adf-48ae-b41a-c4cf99f129d8"
-      },
-      "outputs": [],
-      "source": [
-        "len(acetic_acid_atoms)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "578df920-172d-4d23-a42b-7cb9a27a4903",
-      "metadata": {
-        "id": "578df920-172d-4d23-a42b-7cb9a27a4903"
-      },
-      "source": [
-        "Because `acetic_acid_atoms` is an iterator, we can use indexing to get a particular atom.\n",
-        "Atoms in RDKit molecules are represented by Atom objects."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9af16d3f-b730-4f5d-8763-75470ef5995b",
-      "metadata": {
-        "id": "9af16d3f-b730-4f5d-8763-75470ef5995b"
-      },
-      "outputs": [],
-      "source": [
-        "atom = acetic_acid_atoms[0]\n",
-        "atom"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "15254adb-2bff-4b0c-8a59-4001cf55b5bd",
-      "metadata": {
-        "id": "15254adb-2bff-4b0c-8a59-4001cf55b5bd"
-      },
-      "source": [
-        "When we examine one atom, we see there that there are many methods associated with the atom.\n",
-        "For example, we can print the atom element or atom hybridization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "c438feec-6021-4403-948c-924cd5a9afa1",
-      "metadata": {
-        "id": "c438feec-6021-4403-948c-924cd5a9afa1"
-      },
-      "outputs": [],
-      "source": [
-        "print(atom)             # TO DO: Type a . after atom and look for a method that will print out the symbol for the atom\n",
-        "print(atom)             # TO DO: Type a . after atom and look for a method that will tell you the hydridization of the atom"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "36750053-e4d8-4ce1-a8ff-4b71f5c33a0d",
-      "metadata": {
-        "id": "36750053-e4d8-4ce1-a8ff-4b71f5c33a0d"
-      },
-      "source": [
-        "We can use a for loop to give information about each atom."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f93df84c-f808-493a-a7d1-07e75841cdbb",
-      "metadata": {
-        "id": "f93df84c-f808-493a-a7d1-07e75841cdbb"
-      },
-      "outputs": [],
-      "source": [
-        "for atom in acetic_acid_atoms:                                                      # We can do this because acetic_acid_atoms is an iterator\n",
-        "    print(f\"Atom {atom.GetSymbol()} has hybridization {atom.GetHybridization()}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "3a32c170-b190-4def-a24e-721f2bf9c50e",
-      "metadata": {
-        "id": "3a32c170-b190-4def-a24e-721f2bf9c50e"
-      },
-      "source": [
-        "Bonds are also objects in RDKit, and we can iterate over them the same way we can iterate over atoms."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "64a6fb8f-bfc2-45a6-8659-641a6c47f574",
-      "metadata": {
-        "id": "64a6fb8f-bfc2-45a6-8659-641a6c47f574"
-      },
-      "outputs": [],
-      "source": [
-        "acetic_acid_bonds = acetic_acid.GetBonds()\n",
-        "bond = acetic_acid_bonds[0]"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "7af42942-0bf1-49c0-9478-ad162495c92e",
-      "metadata": {
-        "id": "7af42942-0bf1-49c0-9478-ad162495c92e"
-      },
-      "outputs": [],
-      "source": [
-        "bond.GetBondType()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1288c516-437e-4651-ba08-79592621793e",
-      "metadata": {
-        "id": "1288c516-437e-4651-ba08-79592621793e"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Challenge</h3>\n",
-        "\n",
-        "Use a `for` loop to print information about each bond.\n",
-        "For each bond, you should print the starting atom symbol, the ending atom symbol,\n",
-        "and the bond type.\n",
-        "\n",
-        "Your output should look like the following:\n",
-        "\n",
-        "```\n",
-        "Bond between C and C is a SINGLE bond.\n",
-        "Bond between C and O is a DOUBLE bond.\n",
-        "Bond between C and O is a SINGLE bond.\n",
-        "```\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "71c91dce-e046-46ea-a74f-069f9aba99f6",
-      "metadata": {
-        "id": "71c91dce-e046-46ea-a74f-069f9aba99f6"
-      },
-      "outputs": [],
-      "source": [
-        "for bond in acetic_acid_bonds:\n",
-        "    start_atom = bond.GetBeginAtom()\n",
-        "    end_atom = bond.GetEndAtom()\n",
-        "    bond_type = bond.GetBondType()\n",
-        "    print(f\"Bond between {start_atom.GetSymbol()} and {end_atom.GetSymbol()} is a {bond_type} bond.\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c076e9e2-1b3d-4979-bfb5-aa4e643b813b",
-      "metadata": {
-        "id": "c076e9e2-1b3d-4979-bfb5-aa4e643b813b"
-      },
-      "source": [
-        "## Editing Atoms with RDKit\n",
-        "\n",
-        "In addition to seeing information about atoms and bonds in our molecule, we can also use RDKit to change our molecule structure.\n",
-        "Let's consider benzene for our example. We will change one of the carbons in the benzene ring to a nitrogen to make pyridine.\n",
-        "\n",
-        "We are going to create a copy of our benzene molecule using another function from RDKit called `RWMol`. `RWMol` makes our molecule readable and writeable (or \"editable\")."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "382e0906-f3cb-4413-9bee-b1a2f2f1f718",
-      "metadata": {
-        "id": "382e0906-f3cb-4413-9bee-b1a2f2f1f718"
-      },
-      "outputs": [],
-      "source": [
-        "pyridine = Chem.RWMol()             # TO DO: we will create pyridine from benzene, an RDKit mol object we already created in this noteobook\n",
-        "pyridine                            # but you can see it's still benzene, not pyridine"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d0bd6d4f-0d4d-4536-9bf0-79e596fa01c8",
-      "metadata": {
-        "id": "d0bd6d4f-0d4d-4536-9bf0-79e596fa01c8"
-      },
-      "source": [
-        "One way we can change molecules in RDKit is to set the atomic number of a particular atom to another number.\n",
-        "To change one of the carbons in our ring to nitrogen, we can select one of the atoms and then set its atomic number to that of nitrogen (7)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6f852ffe-d424-413f-8ce3-0d6e82b3324c",
-      "metadata": {
-        "id": "6f852ffe-d424-413f-8ce3-0d6e82b3324c"
-      },
-      "outputs": [],
-      "source": [
-        "atom = pyridine.GetAtomWithIdx()     # TO DO: Get atom with index 0 (labeled 0 above)\n",
-        "atom.SetAtomicNum()                  # TO DO: Set the atomic number to 7\n",
-        "pyridine"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "63eb53d6-af12-4b67-bede-1faaf9f760a6",
-      "metadata": {
-        "id": "63eb53d6-af12-4b67-bede-1faaf9f760a6"
-      },
-      "outputs": [],
-      "source": [
-        "Chem.MolToSmiles(pyridine)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "607cba74-d60d-43a2-befa-11b74777580c",
-      "metadata": {
-        "id": "607cba74-d60d-43a2-befa-11b74777580c"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Challenge</h3>\n",
-        "\n",
-        "Change another atom in the pyridine ring to create [pyrimidine](https://en.wikipedia.org/wiki/Pyrimidine).\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d31fdcc6-6fdd-4fc2-b820-2bc17fcd3048",
-      "metadata": {
-        "id": "d31fdcc6-6fdd-4fc2-b820-2bc17fcd3048"
-      },
-      "outputs": [],
-      "source": [
-        "pyrimidine = Chem.RWMol()               # TO DO: Create pyrimidine by starting with pyridine\n",
-        "atom = pyrimidine.GetAtomWithIdx()      # TO DO: Get atom with index 2 (labeled 2 above)\n",
-        "atom.SetAtomicNum()                     # TO DO: Set the atomic number to 7\n",
-        "pyrimidine"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a62f8686-83aa-4dc8-841e-2eb4e931b375",
-      "metadata": {
-        "id": "a62f8686-83aa-4dc8-841e-2eb4e931b375"
-      },
-      "outputs": [],
-      "source": []
-    },
-    {
-      "cell_type": "markdown",
-      "id": "021f75c5-a9d2-4767-935c-8a46d4f22812",
-      "metadata": {
-        "id": "021f75c5-a9d2-4767-935c-8a46d4f22812"
-      },
-      "source": [
-        "## Combining two molecules\n",
-        "\n",
-        "We can also create and combine molecules using RDKit. This approach might be necessary when we want to add a more complex functional group. In the example below we create a carboxyl group and add it to benzene to make benzoic acid.\n",
-        "\n",
-        "First we create the molecule for our functional group."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1ca7648c-8857-405c-a747-8c41ee5db922",
-      "metadata": {
-        "id": "1ca7648c-8857-405c-a747-8c41ee5db922"
-      },
-      "outputs": [],
-      "source": [
-        "carboxyl = Chem.MolFromSmiles('C(=O)O')\n",
-        "carboxyl"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "3f81da17-5b67-486c-821e-74cba04c053d",
-      "metadata": {
-        "id": "3f81da17-5b67-486c-821e-74cba04c053d"
-      },
-      "source": [
-        "Next, we combine the two molecules together using the `CombineMols` function."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "13dd67a7-afd2-4698-92e5-455bbdeca12a",
-      "metadata": {
-        "id": "13dd67a7-afd2-4698-92e5-455bbdeca12a"
-      },
-      "outputs": [],
-      "source": [
-        "combined = Chem.CombineMols(benzene, carboxyl)\n",
-        "combined"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ec93dc59-4468-446e-a03f-b2715597c45c",
-      "metadata": {
-        "id": "ec93dc59-4468-446e-a03f-b2715597c45c"
-      },
-      "source": [
-        "After the combining, we have to make our combined molecules editable so that we can change the bonds and atoms."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "5459cbf8-5773-43a5-b947-03fcd8da515d",
-      "metadata": {
-        "id": "5459cbf8-5773-43a5-b947-03fcd8da515d"
-      },
-      "outputs": [],
-      "source": [
-        "editable_mol = Chem.RWMol(combined)\n",
-        "editable_mol"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ddbcf42c-2c42-437d-aca1-88fd8ba4475a",
-      "metadata": {
-        "id": "ddbcf42c-2c42-437d-aca1-88fd8ba4475a"
-      },
-      "source": [
-        "Finally, we can use `AddBonds` to add a bond between the carbon on our carboxyl group (6) to an atom on benzene. We could have picked any carbon, but the example below uses index 5."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "7e6035b7-3594-4e20-8347-254d9f951bcf",
-      "metadata": {
-        "id": "7e6035b7-3594-4e20-8347-254d9f951bcf"
-      },
-      "outputs": [],
-      "source": [
-        "editable_mol.AddBond(0, 6, order=Chem.rdchem.BondType.SINGLE)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "07b045f6-f06d-4348-b547-900164d014ea",
-      "metadata": {
-        "id": "07b045f6-f06d-4348-b547-900164d014ea"
-      },
-      "outputs": [],
-      "source": [
-        "editable_mol"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "be786a94-cab6-4597-b139-267568eac415",
-      "metadata": {
-        "id": "be786a94-cab6-4597-b139-267568eac415"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-info\">\n",
-        "<strong>Molecular Sanitization</strong>\n",
-        "\n",
-        "When a molecule is loaded into RDKit, a [\"molecular sanitization\"](https://www.rdkit.org/docs/RDKit_Book.html#molecular-sanitization) step typically takes place.\n",
-        "Molecular sanitization ensures that molecules are \"reasonable\":that they can be represented with octet-complete Lewis dot structures.\n",
-        "</div>\n",
-        "\n",
-        "After we add new atoms like this, our molecule usually needs to be \"sanitized\". One way we can tell this is by viewing the molecule above. Our aromatic ring structure is now symbolized with a dotted line inside of the ring. We will want to use the `Chem.SanitizeMol` method to sanitize the molecule.\n",
-        "The step of sanitiziation that is important in this case is the `Kekulize` step, where aromatic rings are converted to the Kekule form. A Python error (exception) would occur if a problem is found with aromaticity."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fa9dbe5c-32cc-438d-9aca-aa3e1b515836",
-      "metadata": {
-        "id": "fa9dbe5c-32cc-438d-9aca-aa3e1b515836"
-      },
-      "outputs": [],
-      "source": [
-        "Chem.SanitizeMol(editable_mol)\n",
-        "editable_mol"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cf0b95ef-bf40-4349-bbd4-1eaa3e47982e",
-      "metadata": {
-        "id": "cf0b95ef-bf40-4349-bbd4-1eaa3e47982e"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h2>Final Challenge</h2>\n",
-        "\n",
-        "[Protein phoshorylation](https://www.thermofisher.com/us/en/home/life-science/protein-biology/protein-biology-learning-center/protein-biology-resource-library/pierce-protein-methods/phosphorylation.html) refers to the additon of a phosphate group to the -OH group of an amino acid and occurs for serine, threonine, or tyrosine residues.\n",
-        "\n",
-        "For this challenge, you should modify the tyrosine module (given below) to add a phosphate to the OH group.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "41f63879-b4e0-44af-b57e-69d61a738a79",
-      "metadata": {
-        "id": "41f63879-b4e0-44af-b57e-69d61a738a79"
-      },
-      "outputs": [],
-      "source": [
-        "tyrosine = Chem.MolFromSmiles(\"\")     # TO DO: Go to the PubChem site to get the SMILES string for tyrosine and place it between the quote marks\n",
-        "tyrosine"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "68f3753a-c5b2-4102-b3ac-b5d90dc60019",
-      "metadata": {
-        "id": "68f3753a-c5b2-4102-b3ac-b5d90dc60019"
-      },
-      "outputs": [],
-      "source": [
-        "phosphate = Chem.MolFromSmiles(\"\")    # TO DO: Write the SMILES string for a phosphate group (phosphorous bound to 3 oxygens)\n",
-        "phosphate"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "5372f1c9-c22e-4ea0-8bef-a996dd7a3485",
-      "metadata": {
-        "id": "5372f1c9-c22e-4ea0-8bef-a996dd7a3485"
-      },
-      "outputs": [],
-      "source": [
-        "combined2 = Chem.CombineMols()        # TO DO: Place the names of the two RDKit mol objects you want to combine in the parentheses\n",
-        "combined2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "91b5aae7-8c31-4e7b-9b2e-f0c5281e7b6c",
-      "metadata": {
-        "id": "91b5aae7-8c31-4e7b-9b2e-f0c5281e7b6c"
-      },
-      "outputs": [],
-      "source": [
-        "editable_mol2 = Chem.RWMol()          # TO DO: Make your new set of molecules editable (RW stands for Read Write)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a80d18bf-87fa-4f77-aeb7-fdb07c80b812",
-      "metadata": {
-        "id": "a80d18bf-87fa-4f77-aeb7-fdb07c80b812"
-      },
-      "outputs": [],
-      "source": [
-        "editable_mol2.AddBond(, , order=Chem.rdchem.BondType.SINGLE)    # TO DO: Add the bond to connect the two RDKit mol objects\n",
-        "editable_mol2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fe0f047a-cac2-4e80-9ac5-ebd993f8a9d9",
-      "metadata": {
-        "id": "fe0f047a-cac2-4e80-9ac5-ebd993f8a9d9"
-      },
-      "outputs": [],
-      "source": [
-        "Chem.SanitizeMol(editable_mol2)       # This will clean it up\n",
-        "editable_mol2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "775adf1b-9f14-4a3d-b864-05fd23dae849",
-      "metadata": {
-        "id": "775adf1b-9f14-4a3d-b864-05fd23dae849"
-      },
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.2"
-    },
-    "vscode": {
-      "interpreter": {
-        "hash": "16d4a7bb199d969b1271ebe46f77414b0d9cd01b3c3983c2b2742fc6cd4503d3"
-      }
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d9020474",
+   "metadata": {
+    "id": "d9020474"
+   },
+   "source": [
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+    "</div>\n",
+    "\n",
+    "\n",
+    "# Introduction to RDKit Molecules\n",
+    "\n",
+    "<strong>Author(s):</strong> Jessica A. Nash, The Molecular Sciences Software Institute\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2>Overview</h2>\n",
+    "\n",
+    "<strong>Questions:</strong>\n",
+    "\n",
+    "* What is RDKit?\n",
+    "\n",
+    "* What is an RDKit molecule object?\n",
+    "\n",
+    "* What can I do with RDKit molecules?\n",
+    "\n",
+    "<strong>Objectives:</strong>\n",
+    "\n",
+    "* Use RDKit to create molecules in Python\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "There are Python libraries that are made for working just with chemical data. One commonly used library in Python for data science (or cheminformatics) is called [RDKit](https://en.wikipedia.org/wiki/RDKit). RDKit is an open-source cheminformatics library, primarily developed in C++ and has been under development since the year 2000. We will be using the Python interface to RDKit, though there are interfaces in other languages.\n",
+    "\n",
+    "RDKit provides a molecule object that allows you to manipulate chemical structures. It has capabilities for reading and writing molecular file formats, calculating molecular properties, and performing substructure searches. In addition, it offers a wide range of cheminformatics algorithms such as molecular fingerprint generation, similarity metrics calculation, and molecular descriptor computation. This notebook introduces RDKit basics, but we will see more of all of these topics in later notebooks.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-success\">\n",
+    "<strong>Python Skills: Python Objects</strong>\n",
+    "\n",
+    "Most of this functionality is achieved through the RDKit `mol` object. In Python, we use the word \"object\" to refer to a variable type with associated data and methods.\n",
+    "One example of an object we have seen in notebooks is a list - we could also call it a \"list object\". An object has `attributes` (data) and `methods`.\n",
+    "You access information about objects with the syntax\n",
+    "```python\n",
+    "object.data\n",
+    "```\n",
+    "where data is the attribute name.\n",
+    "\n",
+    "You access object methods with the syntax\n",
+    "```python\n",
+    "object.method(arguments)\n",
+    "```\n",
+    "\n",
+    "For example, for a list \"`append` is a method that was covered in the introductory lesson.\n",
+    "\n",
+    "```\n",
+    "my_list = []\n",
+    "my_list.append(1) # \"append\" is a method that can be called for a list\n",
+    "```\n",
+    "</div>    \n",
+    "\n",
+    "In this lesson, we will create and manipulate RDKit `mol` objects. RDKit `mol` objects represent molecules and have\n",
+    "attributes (data) and methods (actions) associated with molecules.\n",
+    "\n",
+    "We are going to use a part of RDKit called `Chem`. To use `Chem`, we first have to import it."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eFjTn5wMHixe",
+   "metadata": {
+    "id": "eFjTn5wMHixe"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rdkit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afc9bc63",
+   "metadata": {
+    "id": "afc9bc63",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit import Chem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5b835ad",
+   "metadata": {
+    "id": "d5b835ad"
+   },
+   "source": [
+    "## Creating Molecules with RDKit\n",
+    "\n",
+    "Throughout this tutorial, it will be helpful to have access to the [RDKit documentation](https://www.rdkit.org/docs/index.html).\n",
+    "\n",
+    "To get information about molecules in RDKit, we have to first create objects representing molecules. RDKit has a molecule object that can be used to retrieve information or calculate properties. To create a molecule object, we have to communicate the molecule identity in a way that computers understand.\n",
+    "\n",
+    "We will use SMILES strings to create our objects, though RDKit also has methods for creating molecules from the file formats listed in the previous notebook.\n",
+    "\n",
+    "### Creating molecules using SMILES\n",
+    "\n",
+    "In the last lesson, we learned about molecular representations using SMILES strings. Now we will use SMILES strings to create molecule objects in RDKIT.\n",
+    "\n",
+    "We can create a representation of methane using RDKit by using the `MolFromSmiles` function in `rdkit.Chem`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40b29a7c",
+   "metadata": {
+    "id": "40b29a7c",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "methane = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Enter a capital C between the quote marks in the parentheses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da5b102b-e997-47b4-8a0d-7cc5befc1b7e",
+   "metadata": {
+    "id": "da5b102b-e997-47b4-8a0d-7cc5befc1b7e"
+   },
+   "source": [
+    "The `methane` variable is now an RDKit \"molecule object\".\n",
+    "\n",
+    "In a Jupyter environment, putting a variable that is an RDKit molecule as the only or last thing in a cell,\n",
+    "will result in a picture of the molecule as an output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99734c44",
+   "metadata": {
+    "id": "99734c44",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "methane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fae858d1-503d-4dc9-a220-f713ed075847",
+   "metadata": {
+    "id": "fae858d1-503d-4dc9-a220-f713ed075847"
+   },
+   "outputs": [],
+   "source": [
+    "ethane = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Enter a capital CC between the quote marks in the parentheses\n",
+    "ethane"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e98c39d3",
+   "metadata": {
+    "id": "e98c39d3"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Check Your Understanding</h3>\n",
+    "<p> Create RDKit molecules for the following molecules. You can look up the SMILES strings on <a href=\"https://pubchem.ncbi.nlm.nih.gov/\">PubChem</a>:\n",
+    "<p>\n",
+    "    <ul>\n",
+    "        <li> Propane\n",
+    "        <li> Ethene\n",
+    "        <li> Cyclohexane\n",
+    "        <li> Benzene </li>\n",
+    "        <li> Acetic Acid\n",
+    "    </ul>\n",
+    "</p>\n",
+    "<p>Create variables for each molecule. The variable names should be the molecule name (all lowercase)</p>\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbae7a92-6647-4361-b5ed-f45363f4d249",
+   "metadata": {
+    "id": "bbae7a92-6647-4361-b5ed-f45363f4d249",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Your answers go here\n",
+    "propane = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Enter the SMILES string for propane between the quote marks in the parentheses\n",
+    "ethene = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Enter the SMILES string for ethene between the quote marks in the parentheses\n",
+    "cyclohexane = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Enter the SMILES string for cyclohexane between the quote marks in the parentheses\n",
+    "benzene = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Enter the SMILES string for benzene between the quote marks in the parentheses\n",
+    "acetic_acid = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Enter the SMILES string for acetic acid between the quote marks in the parentheses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "395bc20c-bef9-4941-a2f8-fca830baae2b",
+   "metadata": {
+    "id": "395bc20c-bef9-4941-a2f8-fca830baae2b"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
+    "propane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e22a13a2-305e-458b-9caa-ba636b836e1e",
+   "metadata": {
+    "id": "e22a13a2-305e-458b-9caa-ba636b836e1e"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
+    "ethene"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fc9b578-6889-43d9-85c0-0f07111053b3",
+   "metadata": {
+    "id": "2fc9b578-6889-43d9-85c0-0f07111053b3"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
+    "cyclohexane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0942cfe3-0ca2-4145-baaf-c7dff83fed24",
+   "metadata": {
+    "id": "0942cfe3-0ca2-4145-baaf-c7dff83fed24"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
+    "benzene"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "670f07a8-c1ac-41bc-b4d9-62ac7bf342fd",
+   "metadata": {
+    "id": "670f07a8-c1ac-41bc-b4d9-62ac7bf342fd"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
+    "acetic_acid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee8b5f19-d326-4c5c-a563-ef06e7890b9f",
+   "metadata": {
+    "id": "ee8b5f19-d326-4c5c-a563-ef06e7890b9f"
+   },
+   "source": [
+    "## Working with RDKit Molecules\n",
+    "\n",
+    "RDKit molecule objects have a number of methods we can use to get more information about the molecule.\n",
+    "In the next few cells, we'll look at some methods that can tell us some things about the molecules we've created.\n",
+    "The next cell has settings for modifying drawing molecules. It adds labels of atom indices and sets the image size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "761d0c31-0e04-453a-9be7-cb93cb9386a5",
+   "metadata": {
+    "id": "761d0c31-0e04-453a-9be7-cb93cb9386a5"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem.Draw import IPythonConsole as ipc\n",
+    "\n",
+    "# Configuration for displaying in Jupyter notebooks\n",
+    "ipc.ipython_useSVG = True  # Use SVG for higher quality images\n",
+    "ipc.drawOptions.addAtomIndices = True  # Show atom indices\n",
+    "ipc.molSize = 250, 250  # Set size of image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07cfae6b-3159-44df-8acf-67c35a68b99d",
+   "metadata": {
+    "id": "07cfae6b-3159-44df-8acf-67c35a68b99d"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-success\">\n",
+    "<strong>Jupyter Skills: The Tab Key</strong>\n",
+    "\n",
+    "When working with Python objects in the Jupyter notebook, you can type a variable or object name to see the methods available on that object.\n",
+    "\n",
+    "In the cell below, type `acetic_acid.` (notice how there is a dot (`.`) at the end), then press the `tab` key.\n",
+    "A list of possible methods and attributes will come up.\n",
+    "\n",
+    "Look through the methods until you find one that gives you the number of atoms in the molecule.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91d1dd84-e932-4f2d-a170-dc9a15ab5447",
+   "metadata": {
+    "id": "91d1dd84-e932-4f2d-a170-dc9a15ab5447"
+   },
+   "outputs": [],
+   "source": [
+    "# Pick a method that will tell you the number of atoms acetic acid has.\n",
+    "\n",
+    "x = acetic_acid  # TO DO: Type a period after acetic_acid and look for a function that will give you the number of atoms in the molecule\n",
+    "\n",
+    "print(\"Acetic acid has\", x, \"heavy atoms.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c69990f5-4a31-4fa5-9787-546faab4b071",
+   "metadata": {
+    "id": "c69990f5-4a31-4fa5-9787-546faab4b071"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-success\">\n",
+    "<strong>Python Skills: Getting Help</strong>\n",
+    "\n",
+    "Is this the number of atoms you expected for a benzene molecule?\n",
+    "\n",
+    "We can use the `help` function on the method you found in the previous step to find a method argument to figure out a method argument to get the number of atoms we expect.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb159c7b-fb4f-4024-85e6-22f5d90d51ff",
+   "metadata": {
+    "id": "eb159c7b-fb4f-4024-85e6-22f5d90d51ff"
+   },
+   "outputs": [],
+   "source": [
+    "help(acetic_acid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66d59a12-0dd4-4e7a-adbc-e874c4f036ec",
+   "metadata": {
+    "id": "66d59a12-0dd4-4e7a-adbc-e874c4f036ec"
+   },
+   "outputs": [],
+   "source": [
+    "# Add an argument to your function to get the number of atoms that gives you\n",
+    "# the total number of atoms in acetic_acid including hydrogens\n",
+    "\n",
+    "x = acetic_acid.GetNumAtoms()\n",
+    "y = acetic_acid.GetNumAtoms()  # TO DO: Insert the expression      onlyExplicit = False      inside the parentheses so that it will include hydrogens.\n",
+    "\n",
+    "print(f\"There are {x} heavy atoms in acetic acid and {y} total atoms in acetic acid.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71567da6-cd35-4265-9c16-813c3d008456",
+   "metadata": {
+    "id": "71567da6-cd35-4265-9c16-813c3d008456"
+   },
+   "source": [
+    "Each molecule is made up of RDKit atom objects and RDKit bond objects.\n",
+    "If we want to get the atoms for a particular molecule, we can use the `GetAtoms` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1f14353-5f81-4c43-a7ea-8d8a5c5cfe8f",
+   "metadata": {
+    "id": "d1f14353-5f81-4c43-a7ea-8d8a5c5cfe8f"
+   },
+   "outputs": [],
+   "source": [
+    "acetic_acid_atoms = acetic_acid.GetAtoms()\n",
+    "print(acetic_acid_atoms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c674690-c889-4e43-8d39-99ec703c3534",
+   "metadata": {
+    "id": "5c674690-c889-4e43-8d39-99ec703c3534"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-success\">\n",
+    "<strong>Python Skills: Iterators</strong>\n",
+    "\n",
+    "When we look at the results of the `GetAtoms` method, it tells us that we have a `GetAtomsIterator`.\n",
+    "In Python, an iterator is an object that contains values that can be looped through and indexed in.\n",
+    "\n",
+    "Although we haven't used this terminology before, a Python list is an example of an iterator.\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "Like a list, we can also call `len` on the iterator.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc8318c2-0adf-48ae-b41a-c4cf99f129d8",
+   "metadata": {
+    "id": "fc8318c2-0adf-48ae-b41a-c4cf99f129d8"
+   },
+   "outputs": [],
+   "source": [
+    "len(acetic_acid_atoms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "578df920-172d-4d23-a42b-7cb9a27a4903",
+   "metadata": {
+    "id": "578df920-172d-4d23-a42b-7cb9a27a4903"
+   },
+   "source": [
+    "Because `acetic_acid_atoms` is an iterator, we can use indexing to get a particular atom.\n",
+    "Atoms in RDKit molecules are represented by Atom objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9af16d3f-b730-4f5d-8763-75470ef5995b",
+   "metadata": {
+    "id": "9af16d3f-b730-4f5d-8763-75470ef5995b"
+   },
+   "outputs": [],
+   "source": [
+    "atom = acetic_acid_atoms[0]\n",
+    "atom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15254adb-2bff-4b0c-8a59-4001cf55b5bd",
+   "metadata": {
+    "id": "15254adb-2bff-4b0c-8a59-4001cf55b5bd"
+   },
+   "source": [
+    "When we examine one atom, we see there that there are many methods associated with the atom.\n",
+    "For example, we can print the atom element or atom hybridization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c438feec-6021-4403-948c-924cd5a9afa1",
+   "metadata": {
+    "id": "c438feec-6021-4403-948c-924cd5a9afa1"
+   },
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    atom\n",
+    ")  # TO DO: Type a . after atom and look for a method that will print out the symbol for the atom\n",
+    "print(\n",
+    "    atom\n",
+    ")  # TO DO: Type a . after atom and look for a method that will tell you the hydridization of the atom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36750053-e4d8-4ce1-a8ff-4b71f5c33a0d",
+   "metadata": {
+    "id": "36750053-e4d8-4ce1-a8ff-4b71f5c33a0d"
+   },
+   "source": [
+    "We can use a for loop to give information about each atom."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f93df84c-f808-493a-a7d1-07e75841cdbb",
+   "metadata": {
+    "id": "f93df84c-f808-493a-a7d1-07e75841cdbb"
+   },
+   "outputs": [],
+   "source": [
+    "for (\n",
+    "    atom\n",
+    ") in acetic_acid_atoms:  # We can do this because acetic_acid_atoms is an iterator\n",
+    "    print(f\"Atom {atom.GetSymbol()} has hybridization {atom.GetHybridization()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a32c170-b190-4def-a24e-721f2bf9c50e",
+   "metadata": {
+    "id": "3a32c170-b190-4def-a24e-721f2bf9c50e"
+   },
+   "source": [
+    "Bonds are also objects in RDKit, and we can iterate over them the same way we can iterate over atoms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64a6fb8f-bfc2-45a6-8659-641a6c47f574",
+   "metadata": {
+    "id": "64a6fb8f-bfc2-45a6-8659-641a6c47f574"
+   },
+   "outputs": [],
+   "source": [
+    "acetic_acid_bonds = acetic_acid.GetBonds()\n",
+    "bond = acetic_acid_bonds[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7af42942-0bf1-49c0-9478-ad162495c92e",
+   "metadata": {
+    "id": "7af42942-0bf1-49c0-9478-ad162495c92e"
+   },
+   "outputs": [],
+   "source": [
+    "bond.GetBondType()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1288c516-437e-4651-ba08-79592621793e",
+   "metadata": {
+    "id": "1288c516-437e-4651-ba08-79592621793e"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Challenge</h3>\n",
+    "\n",
+    "Use a `for` loop to print information about each bond.\n",
+    "For each bond, you should print the starting atom symbol, the ending atom symbol,\n",
+    "and the bond type.\n",
+    "\n",
+    "Your output should look like the following:\n",
+    "\n",
+    "```\n",
+    "Bond between C and C is a SINGLE bond.\n",
+    "Bond between C and O is a DOUBLE bond.\n",
+    "Bond between C and O is a SINGLE bond.\n",
+    "```\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71c91dce-e046-46ea-a74f-069f9aba99f6",
+   "metadata": {
+    "id": "71c91dce-e046-46ea-a74f-069f9aba99f6"
+   },
+   "outputs": [],
+   "source": [
+    "for bond in acetic_acid_bonds:\n",
+    "    start_atom = bond.GetBeginAtom()\n",
+    "    end_atom = bond.GetEndAtom()\n",
+    "    bond_type = bond.GetBondType()\n",
+    "    print(\n",
+    "        f\"Bond between {start_atom.GetSymbol()} and {end_atom.GetSymbol()} is a {bond_type} bond.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c076e9e2-1b3d-4979-bfb5-aa4e643b813b",
+   "metadata": {
+    "id": "c076e9e2-1b3d-4979-bfb5-aa4e643b813b"
+   },
+   "source": [
+    "## Editing Atoms with RDKit\n",
+    "\n",
+    "In addition to seeing information about atoms and bonds in our molecule, we can also use RDKit to change our molecule structure.\n",
+    "Let's consider benzene for our example. We will change one of the carbons in the benzene ring to a nitrogen to make pyridine.\n",
+    "\n",
+    "We are going to create a copy of our benzene molecule using another function from RDKit called `RWMol`. `RWMol` makes our molecule readable and writeable (or \"editable\")."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "382e0906-f3cb-4413-9bee-b1a2f2f1f718",
+   "metadata": {
+    "id": "382e0906-f3cb-4413-9bee-b1a2f2f1f718"
+   },
+   "outputs": [],
+   "source": [
+    "pyridine = Chem.RWMol()  # TO DO: we will create pyridine from benzene, an RDKit mol object we already created in this noteobook\n",
+    "pyridine  # but you can see it's still benzene, not pyridine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0bd6d4f-0d4d-4536-9bf0-79e596fa01c8",
+   "metadata": {
+    "id": "d0bd6d4f-0d4d-4536-9bf0-79e596fa01c8"
+   },
+   "source": [
+    "One way we can change molecules in RDKit is to set the atomic number of a particular atom to another number.\n",
+    "To change one of the carbons in our ring to nitrogen, we can select one of the atoms and then set its atomic number to that of nitrogen (7)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f852ffe-d424-413f-8ce3-0d6e82b3324c",
+   "metadata": {
+    "id": "6f852ffe-d424-413f-8ce3-0d6e82b3324c"
+   },
+   "outputs": [],
+   "source": [
+    "atom = pyridine.GetAtomWithIdx()  # TO DO: Get atom with index 0 (labeled 0 above)\n",
+    "atom.SetAtomicNum()  # TO DO: Set the atomic number to 7\n",
+    "pyridine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63eb53d6-af12-4b67-bede-1faaf9f760a6",
+   "metadata": {
+    "id": "63eb53d6-af12-4b67-bede-1faaf9f760a6"
+   },
+   "outputs": [],
+   "source": [
+    "Chem.MolToSmiles(pyridine)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "607cba74-d60d-43a2-befa-11b74777580c",
+   "metadata": {
+    "id": "607cba74-d60d-43a2-befa-11b74777580c"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Challenge</h3>\n",
+    "\n",
+    "Change another atom in the pyridine ring to create [pyrimidine](https://en.wikipedia.org/wiki/Pyrimidine).\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d31fdcc6-6fdd-4fc2-b820-2bc17fcd3048",
+   "metadata": {
+    "id": "d31fdcc6-6fdd-4fc2-b820-2bc17fcd3048"
+   },
+   "outputs": [],
+   "source": [
+    "pyrimidine = Chem.RWMol()  # TO DO: Create pyrimidine by starting with pyridine\n",
+    "atom = pyrimidine.GetAtomWithIdx()  # TO DO: Get atom with index 2 (labeled 2 above)\n",
+    "atom.SetAtomicNum()  # TO DO: Set the atomic number to 7\n",
+    "pyrimidine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a62f8686-83aa-4dc8-841e-2eb4e931b375",
+   "metadata": {
+    "id": "a62f8686-83aa-4dc8-841e-2eb4e931b375"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "021f75c5-a9d2-4767-935c-8a46d4f22812",
+   "metadata": {
+    "id": "021f75c5-a9d2-4767-935c-8a46d4f22812"
+   },
+   "source": [
+    "## Combining two molecules\n",
+    "\n",
+    "We can also create and combine molecules using RDKit. This approach might be necessary when we want to add a more complex functional group. In the example below we create a carboxyl group and add it to benzene to make benzoic acid.\n",
+    "\n",
+    "First we create the molecule for our functional group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ca7648c-8857-405c-a747-8c41ee5db922",
+   "metadata": {
+    "id": "1ca7648c-8857-405c-a747-8c41ee5db922"
+   },
+   "outputs": [],
+   "source": [
+    "carboxyl = Chem.MolFromSmiles(\"C(=O)O\")\n",
+    "carboxyl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f81da17-5b67-486c-821e-74cba04c053d",
+   "metadata": {
+    "id": "3f81da17-5b67-486c-821e-74cba04c053d"
+   },
+   "source": [
+    "Next, we combine the two molecules together using the `CombineMols` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13dd67a7-afd2-4698-92e5-455bbdeca12a",
+   "metadata": {
+    "id": "13dd67a7-afd2-4698-92e5-455bbdeca12a"
+   },
+   "outputs": [],
+   "source": [
+    "combined = Chem.CombineMols(benzene, carboxyl)\n",
+    "combined"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec93dc59-4468-446e-a03f-b2715597c45c",
+   "metadata": {
+    "id": "ec93dc59-4468-446e-a03f-b2715597c45c"
+   },
+   "source": [
+    "After the combining, we have to make our combined molecules editable so that we can change the bonds and atoms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5459cbf8-5773-43a5-b947-03fcd8da515d",
+   "metadata": {
+    "id": "5459cbf8-5773-43a5-b947-03fcd8da515d"
+   },
+   "outputs": [],
+   "source": [
+    "editable_mol = Chem.RWMol(combined)\n",
+    "editable_mol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddbcf42c-2c42-437d-aca1-88fd8ba4475a",
+   "metadata": {
+    "id": "ddbcf42c-2c42-437d-aca1-88fd8ba4475a"
+   },
+   "source": [
+    "Finally, we can use `AddBonds` to add a bond between the carbon on our carboxyl group (6) to an atom on benzene. We could have picked any carbon, but the example below uses index 5."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e6035b7-3594-4e20-8347-254d9f951bcf",
+   "metadata": {
+    "id": "7e6035b7-3594-4e20-8347-254d9f951bcf"
+   },
+   "outputs": [],
+   "source": [
+    "editable_mol.AddBond(0, 6, order=Chem.rdchem.BondType.SINGLE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07b045f6-f06d-4348-b547-900164d014ea",
+   "metadata": {
+    "id": "07b045f6-f06d-4348-b547-900164d014ea"
+   },
+   "outputs": [],
+   "source": [
+    "editable_mol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be786a94-cab6-4597-b139-267568eac415",
+   "metadata": {
+    "id": "be786a94-cab6-4597-b139-267568eac415"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<strong>Molecular Sanitization</strong>\n",
+    "\n",
+    "When a molecule is loaded into RDKit, a [\"molecular sanitization\"](https://www.rdkit.org/docs/RDKit_Book.html#molecular-sanitization) step typically takes place.\n",
+    "Molecular sanitization ensures that molecules are \"reasonable\":that they can be represented with octet-complete Lewis dot structures.\n",
+    "</div>\n",
+    "\n",
+    "After we add new atoms like this, our molecule usually needs to be \"sanitized\". One way we can tell this is by viewing the molecule above. Our aromatic ring structure is now symbolized with a dotted line inside of the ring. We will want to use the `Chem.SanitizeMol` method to sanitize the molecule.\n",
+    "The step of sanitiziation that is important in this case is the `Kekulize` step, where aromatic rings are converted to the Kekule form. A Python error (exception) would occur if a problem is found with aromaticity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa9dbe5c-32cc-438d-9aca-aa3e1b515836",
+   "metadata": {
+    "id": "fa9dbe5c-32cc-438d-9aca-aa3e1b515836"
+   },
+   "outputs": [],
+   "source": [
+    "Chem.SanitizeMol(editable_mol)\n",
+    "editable_mol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf0b95ef-bf40-4349-bbd4-1eaa3e47982e",
+   "metadata": {
+    "id": "cf0b95ef-bf40-4349-bbd4-1eaa3e47982e"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h2>Final Challenge</h2>\n",
+    "\n",
+    "[Protein phoshorylation](https://www.thermofisher.com/us/en/home/life-science/protein-biology/protein-biology-learning-center/protein-biology-resource-library/pierce-protein-methods/phosphorylation.html) refers to the additon of a phosphate group to the -OH group of an amino acid and occurs for serine, threonine, or tyrosine residues.\n",
+    "\n",
+    "For this challenge, you should modify the tyrosine module (given below) to add a phosphate to the OH group.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41f63879-b4e0-44af-b57e-69d61a738a79",
+   "metadata": {
+    "id": "41f63879-b4e0-44af-b57e-69d61a738a79"
+   },
+   "outputs": [],
+   "source": [
+    "tyrosine = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Go to the PubChem site to get the SMILES string for tyrosine and place it between the quote marks\n",
+    "tyrosine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68f3753a-c5b2-4102-b3ac-b5d90dc60019",
+   "metadata": {
+    "id": "68f3753a-c5b2-4102-b3ac-b5d90dc60019"
+   },
+   "outputs": [],
+   "source": [
+    "phosphate = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Write the SMILES string for a phosphate group (phosphorous bound to 3 oxygens)\n",
+    "phosphate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5372f1c9-c22e-4ea0-8bef-a996dd7a3485",
+   "metadata": {
+    "id": "5372f1c9-c22e-4ea0-8bef-a996dd7a3485"
+   },
+   "outputs": [],
+   "source": [
+    "combined2 = Chem.CombineMols()  # TO DO: Place the names of the two RDKit mol objects you want to combine in the parentheses\n",
+    "combined2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91b5aae7-8c31-4e7b-9b2e-f0c5281e7b6c",
+   "metadata": {
+    "id": "91b5aae7-8c31-4e7b-9b2e-f0c5281e7b6c"
+   },
+   "outputs": [],
+   "source": [
+    "editable_mol2 = (\n",
+    "    Chem.RWMol()\n",
+    ")  # TO DO: Make your new set of molecules editable (RW stands for Read Write)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a80d18bf-87fa-4f77-aeb7-fdb07c80b812",
+   "metadata": {
+    "id": "a80d18bf-87fa-4f77-aeb7-fdb07c80b812"
+   },
+   "outputs": [],
+   "source": [
+    "editable_mol2.AddBond(\n",
+    "    ..., ..., order=Chem.rdchem.BondType.SINGLE\n",
+    ")  # TO DO: Add the bond to connect the two RDKit mol objects\n",
+    "editable_mol2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe0f047a-cac2-4e80-9ac5-ebd993f8a9d9",
+   "metadata": {
+    "id": "fe0f047a-cac2-4e80-9ac5-ebd993f8a9d9"
+   },
+   "outputs": [],
+   "source": [
+    "Chem.SanitizeMol(editable_mol2)  # This will clean it up\n",
+    "editable_mol2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "775adf1b-9f14-4a3d-b864-05fd23dae849",
+   "metadata": {
+    "id": "775adf1b-9f14-4a3d-b864-05fd23dae849"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.1"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "16d4a7bb199d969b1271ebe46f77414b0d9cd01b3c3983c2b2742fc6cd4503d3"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/prep/D_molecular_similarity.ipynb
+++ b/prep/D_molecular_similarity.ipynb
@@ -1,620 +1,656 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "10110027-0410-40ea-8950-8e4047699603",
-      "metadata": {
-        "id": "10110027-0410-40ea-8950-8e4047699603"
-      },
-      "source": [
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
-        "</div>\n",
-        "\n",
-        "\n",
-        "# Cheminformatics: Molecular Similarity and Molecular Descriptors\n",
-        "\n",
-        "<strong>Author(s):</strong> Jessica A. Nash, The Molecular Sciences Software Institute\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "<h2>Overview</h2>\n",
-        "\n",
-        "<strong>Questions:</strong>\n",
-        "\n",
-        "* How are molecules represented on computers for cheminformatics applications?\n",
-        "\n",
-        "* How can I measure the similarity of two molecules?\n",
-        "\n",
-        "* How can I find out if a molecule contains a particular substructure?\n",
-        "\n",
-        "<strong>Objectives:</strong>\n",
-        "\n",
-        "* Learn about graph representation of molecules.\n",
-        "\n",
-        "* Learn about molecular fingerprints.\n",
-        "\n",
-        "* Use RDKit to measure molecular similarity.\n",
-        "\n",
-        "</div>\n",
-        "\n",
-        "\n",
-        "Cheminformatics is often used in the context of molecular discovery.\n",
-        "For example, you might want to process a large number of molecules to find molecules that are similar to a target, or that contain a particular functional group.\n",
-        "But how can you tell if two molecules are similar?\n",
-        "\n",
-        "A chemist looking at two molecules might be able to make a judgment based on their chemical knowledge. However, when dealing with a large number of molecules, this problem can become intractable. There are ways to detect molecular similarity on a computer that allow fast comparison and processing of molecules.\n",
-        "\n",
-        "## Graph Representation of Molecules\n",
-        "Graph theory is a branch of mathematics that studies the properties and applications of graphs, which are structures made up of nodes (or vertices) connected by edges (or lines).\n",
-        "A molecule can be represented as a graph where atoms are nodes and bonds are edges. This representation allows the use of various graph-based algorithms to analyze molecular structures.\n",
-        "The figure below (borrowed from Wikipedia) shows a graph with numbered nodes (circles) connected by edges (lines).\n",
-        "\n",
-        "\n",
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/images/molecular_graph.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:300px;\">\n",
-        "</div>\n",
-        "\n",
-        "Image from [Wikipedia: Graph theory](https://en.wikipedia.org/wiki/Graph_theory)\n",
-        "\n",
-        "As a chemist, you probably don't have a hard time imagining a molecule as a graph. The atoms would be \"nodes\" in the graph, while the bonds would be \"edges\".\n",
-        "One can also represent bond order by changing the \"weight\" of graph edges.\n",
-        "In this view, one way to tell if molecules are the same is to check that their molecular graphs are the same.\n",
-        "\n",
-        "### Substructure Searches\n",
-        "\n",
-        "A substructure search is a cheminformatics technique used to identify molecules that contain a specific pattern or structure within a larger molecule.\n",
-        "\n",
-        "The figure below shows the beneze substructure matched in the aspirin molecule.\n",
-        "\n",
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/images/substructure.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:300px;\">\n",
-        "</div>\n",
-        "\n",
-        "\n",
-        "One way this can be done is with graph representation and graph theory.\n",
-        "When doing substructure search using RDKit, it can check to see if the molecular graph for one molecule contains the molecular graph of a smaller molecule.\n",
-        "This is a concept called \"**subgraph isomorphism**\". You can see more about this topic in this [presentation](https://www.rdkit.org/UGM/2012/Landrum_RDKit_UGM.Fingerprints.Final.pptx.pdf).\n",
-        "\n",
-        "This is all very nice information, but you actually don't have to fully understand it in order to do a substructure search. In the cells below, we demonstrate searching molecules for a smaller structure using substructure search. As you can see from the cells, this functionality is very nicely built into RDKit."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "nn2PUoVduv_5",
-      "metadata": {
-        "id": "nn2PUoVduv_5"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install rdkit"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "7a031ff5-bf4f-4c65-b79f-5ea81ae6fdac",
-      "metadata": {
-        "id": "7a031ff5-bf4f-4c65-b79f-5ea81ae6fdac"
-      },
-      "source": [
-        "## Substracture Matches with RDKit\n",
-        "\n",
-        "Now we will move to RDKit and start looking at substructure matches. We'll begin with the SMILES string for caffeine (CN1C=NC2=C1C(=O)N(C(=O)N2C)C) which can be obtained from [PubChem](https://pubchem.ncbi.nlm.nih.gov/)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a58f4581-13c4-478d-bafe-1e0846d3b412",
-      "metadata": {
-        "id": "a58f4581-13c4-478d-bafe-1e0846d3b412"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit import Chem\n",
-        "\n",
-        "caffeine = Chem.MolFromSmiles('')                      # TO DO: Get the SMILES string for caffeine from PubChem(https://pubchem.ncbi.nlm.nih.gov/)\n",
-        "carbonyl = Chem.MolFromSmiles('')                      # TO DO: Create or find the SMILES string for a carbonyl group\n",
-        "\n",
-        "matches = caffeine.GetSubstructMatches(carbonyl)       # TO DO: Insert the variable that represents the substructure you want to find in caffeine in the parentheses\n",
-        "\n",
-        "caffeine"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "32a4c55b-362f-472b-a784-105b5c4fe015",
-      "metadata": {
-        "id": "32a4c55b-362f-472b-a784-105b5c4fe015"
-      },
-      "source": [
-        "As you can see above, we can define two molecules and search for one inside of the other.\n",
-        "\n",
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Check Your Understanding</h3>\n",
-        "\n",
-        "Using the skills you've learned already, perform a substructure search for methyl groups in caffeine in the cell below.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "efabcc57-46cf-4742-b39a-e0261307c07f",
-      "metadata": {
-        "id": "efabcc57-46cf-4742-b39a-e0261307c07f"
-      },
-      "outputs": [],
-      "source": [
-        "# put your code for a caffeine substructure search here\n",
-        "\n",
-        "caffeine = Chem.MolFromSmiles('')                                # TO DO: Insert the SMILES string for caffeine\n",
-        "methyl = Chem.MolFromSmiles('')                                  # TO DO: Insert the SMILES string for a methyl group\n",
-        "\n",
-        "matches = caffeine.GetSubstructMatches()                         # TO DO: Look for methyl groups in caffeine\n",
-        "\n",
-        "caffeine"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cd03244e-945a-4265-b544-10a2dbffd5e4",
-      "metadata": {
-        "id": "cd03244e-945a-4265-b544-10a2dbffd5e4"
-      },
-      "source": [
-        "From the substructure search in the cell above, you are probably seeing that you're not matching exactly what you want. In order to find just the methyl groups, we have to use yet another molecular representation.\n",
-        "\n",
-        "#### SMARTS Strings\n",
-        "A [SMARTS (SMiles ARbitrary Target Specification)](https://en.wikipedia.org/wiki/SMILES_arbitrary_target_specification) string is a pattern-matching language for specifying substructures in molecules. It is similar to SMILES but has additional features for specifying atom and bond properties. In contrast to SMILES, SMARTS allows for specifying substructures based on patterns of atoms and bonds, rather than just specifying the exact arrangement of atoms and bonds in a molecule.\n",
-        "\n",
-        "In this case, we want to highlight the methyl group in caffeine, which contains a single carbon atom bonded to three hydrogen atoms. We can use a SMARTS string to define this substructure as `[CH3]`, which represents a carbon atom with three hydrogen atoms bonded to it.\n",
-        "\n",
-        "Using a SMARTS string is necessary in this case because simply searching for a single carbon atom with the code `carbon = Chem.MolFromSmiles('C')` highlights all carbons in the molecule, not just the methyl group. By using a SMARTS string, we can specify the exact substructure we want to highlight and avoid highlighting unintended parts of the molecule."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1b5bba4e-91de-4c91-986b-049e0cac168c",
-      "metadata": {
-        "id": "1b5bba4e-91de-4c91-986b-049e0cac168c"
-      },
-      "outputs": [],
-      "source": [
-        "caffeine = Chem.MolFromSmiles(\"\")                    # TO DO: Enter the SMILES string for caffeine\n",
-        "methyl_pattern = Chem.MolFromSmarts(\"\")              # TO DO: Enter the SMARTS string for the methyl group [CH3]\n",
-        "\n",
-        "# Get the indices of the matching atoms\n",
-        "matches = caffeine.GetSubstructMatches()             # TO DO: Enter the variable for the pattern you are looking for in caffeine\n",
-        "caffeine"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "89d4a8b5-0454-46bd-9805-8e72a60f08ef",
-      "metadata": {
-        "id": "89d4a8b5-0454-46bd-9805-8e72a60f08ef"
-      },
-      "source": [
-        "### Exercise\n",
-        "\n",
-        "Create an RDKit molecule object for aspirin. You can find its SMILES representation by using [PubChem](https://pubchem.ncbi.nlm.nih.gov/).\n",
-        "\n",
-        "Visualize the molecule, highlighting any carboxyl groups in the structure. Use a SMARTS string to define the carboxyl group substructure.\n",
-        "\n",
-        "**Important:** Unless you know the rules for writing SMARTS strings (which you would have learned somewhere else, because we didn't cover it), it's unlikely that you'll guess what the SMARTS for carboxyl is. You can see a list of SMARTS strings for different functional groups [at this link](https://www.daylight.com/dayhtml_tutorials/languages/smarts/smarts_examples.html).\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "03bf284b-6730-43b6-8c5b-242d095853eb",
-      "metadata": {
-        "id": "03bf284b-6730-43b6-8c5b-242d095853eb"
-      },
-      "outputs": [],
-      "source": [
-        "aspirin = Chem.MolFromSmiles('')                         # TO DO: Insert the SMILES string for aspirin between the quote signs\n",
-        "carboxyl_pattern = Chem.MolFromSmarts('')                # TO DO: Go to https://www.daylight.com/dayhtml_tutorials/languages/smarts/smarts_examples.html to find the SMARTS string for carboxyl group\n",
-        "\n",
-        "# Get the indices of the matching atoms\n",
-        "\n",
-        "matches = aspirin.GetSubstructMatches()                  # TO DO: Enter the variable for the pattern you are looking for in aspirin\n",
-        "aspirin\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "4a25724d-2e54-4a1a-b5b8-3a0da72b8e97",
-      "metadata": {
-        "id": "4a25724d-2e54-4a1a-b5b8-3a0da72b8e97"
-      },
-      "source": [
-        "## Molecular Fingerprints\n",
-        "Molecular fingerprints are representations of molecules that are usually bit strings, or vectors of 0's and 1's. Fingerprints are built by considering the molecular structure (often as a graph representation) and applying a certain algorithm to create the vector. The image below shows a representation of a molecular fingerprint. The molecule is separated into different parts with each part setting a bit (changing a 0 to a 1) in the fingerprint.\n",
-        "\n",
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/images/molecular_fingerprint.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
-        "</div>\n",
-        "\n",
-        "\n",
-        "\n",
-        "Image from [Chemistry LibreTexts](https://chem.libretexts.org/Courses/Intercollegiate_Courses/Cheminformatics/06%3A_Molecular_Similarity/6.01%3A_Molecular_Descriptors) [Cheminformatics Course](https://chem.libretexts.org/Courses/Intercollegiate_Courses/Cheminformatics)\n",
-        "\n",
-        "The exact fingerprint will depend on the algorithm that is used to construct it.\n",
-        "There are many different fingerprinting algorithms. But they tend to fall into two types of groups - similarity or substructure fingerprints. A common similarity fingerprint that is used is the Morgan fingerprint. A common substructure fingerprint that is used is the [Daylight fingerprint](https://www.daylight.com/dayhtml/doc/theory/theory.finger.html) (the RDKFingerprint is a Daylight-like fingerprint).\n",
-        "\n",
-        "The cell below calculates the RDKit fingerprint for caffeine."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ca97af7e-cc2c-49e1-ab71-7e8058106131",
-      "metadata": {
-        "id": "ca97af7e-cc2c-49e1-ab71-7e8058106131"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem import AllChem\n",
-        "\n",
-        "aspirin = Chem.MolFromSmiles(\"\")                            # TO DO: Insert the SMILES string for aspirin\n",
-        "benzene = Chem.MolFromSmiles(\"\")                            # TO DO: Insert the SMILES string for benzene - Can you predict it?\n",
-        "\n",
-        "aspirin_fingerprint = AllChem.RDKFingerprint(aspirin)\n",
-        "\n",
-        "type(aspirin_fingerprint)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c3ef1152-d5c1-40a9-a66d-0a0f3c83facc",
-      "metadata": {
-        "id": "c3ef1152-d5c1-40a9-a66d-0a0f3c83facc"
-      },
-      "source": [
-        "You usually wouldn't interact with a fingerprint directly, but using RDKit we can examine it to understand more about how it works.\n",
-        "We can print the bit string representation using `.ToBitString`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "71d91ca4-4848-46ee-9441-9bb81bec48ae",
-      "metadata": {
-        "id": "71d91ca4-4848-46ee-9441-9bb81bec48ae"
-      },
-      "outputs": [],
-      "source": [
-        "aspirin_fingerprint.ToBitString()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c79828c2-5b84-43f0-bb2d-f04d95141d9a",
-      "metadata": {
-        "id": "c79828c2-5b84-43f0-bb2d-f04d95141d9a"
-      },
-      "source": [
-        "If you print the benzene string, you will see a string of the same length, but with fewer bits set.\n",
-        "There are fewer bits because there are fewer molecular patterns in the smaller molecule."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9018a8f0-0e32-4e32-8cad-377e5cfe5838",
-      "metadata": {
-        "id": "9018a8f0-0e32-4e32-8cad-377e5cfe5838"
-      },
-      "outputs": [],
-      "source": [
-        "benzene_fingerprint = AllChem.RDKFingerprint()            # TO DO: Insert the variable that represents the benzene mol object\n",
-        "benzene_string = benzene_fingerprint.ToBitString()        # You need the parentheses after ToBitString because it is a method, but the parentheses are empty in this case.\n",
-        "\n",
-        "print(benzene_string)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "781dd591-b789-4283-93b2-ffe684ee61c9",
-      "metadata": {
-        "id": "781dd591-b789-4283-93b2-ffe684ee61c9"
-      },
-      "source": [
-        "Using this bit string, we can do a number of different analyses.\n",
-        "For example, substructure searches using bit strings check that bits that are set in the smaller molecule are also set in the larger target molecule.\n",
-        "\n",
-        "\n",
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Exercise</h3>\n",
-        "\n",
-        "Fill in the for loop below to check that bits set in the aspirin fingerprint string are also set in the benzene fingerprint string.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "e0869b43-18dd-4714-af92-1de49932eb2b",
-      "metadata": {
-        "id": "e0869b43-18dd-4714-af92-1de49932eb2b"
-      },
-      "outputs": [],
-      "source": [
-        "aspirin_string = aspirin_fingerprint.ToBitString()\n",
-        "num_bits = len(benzene_string)\n",
-        "matches = 0\n",
-        "\n",
-        "for i in range(num_bits):\n",
-        "    if benzene_string[i] == \"1\":\n",
-        "        print()                                 # TO DO: enter a boolean comparison of each item in the aspirin string to each item in the benzene string\n",
-        "        matches                                 # TO DO: increment the counter\n",
-        "\n",
-        "print(f\"There are {matches} positions where the benzene fingerprint matches the aspirin fingerprint.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "9778634e-0344-4d87-a406-c0ab48b8ff75",
-      "metadata": {
-        "id": "9778634e-0344-4d87-a406-c0ab48b8ff75"
-      },
-      "source": [
-        "The above output tells us that every bit that is set in the benzene fingerprint is also set in the aspirin target. Fingerprint substructure searches are often used for faster, but less accurate substructure searches, and are commonly used for screen large numbers of molecules quickly."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c9e5ecb4-5348-4f3d-b519-4fbff21f666a",
-      "metadata": {
-        "id": "c9e5ecb4-5348-4f3d-b519-4fbff21f666a"
-      },
-      "source": [
-        "### Measuring Similarity\n",
-        "\n",
-        "Because the fingerprints are numbers, we can measure how similar two fingerprints are using different similarity metrics.\n",
-        "One common similarity metric is called the Tanimoto similarity.\n",
-        " The Tanimoto similarity is calculated as follows:\n",
-        "\n",
-        "$$\n",
-        "T(A, B) = \\frac{A \\cap B}{A + B - A \\cap B}\n",
-        "$$\n",
-        "\n",
-        "Where:\n",
-        "- $A$ and $B$: are the sets of bits in the fingerprint vectors for molecules $A$ and $B$ respectively.\n",
-        "- $A \\cap B$: This represents the intersection of sets $A$ and $B$, i.e., the number of bits that are '1' (set) in both $A$ and $B$.\n",
-        "- $A + B$: This is the sum of all '1' bits in both $A$ and $B$.\n",
-        "- $A + B - A \\cap B$: This term represents the union of sets $A$ and $B$, calculated as the total number of unique '1' bits across both fingerprints.\n",
-        "\n",
-        "The Tanimoto similarity ranges from 0.0 to 1.0, with 1.0 representing identical fingerprints."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "820dd583-c661-4db5-b510-aa204e0c0f26",
-      "metadata": {
-        "id": "820dd583-c661-4db5-b510-aa204e0c0f26"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit import DataStructs\n",
-        "\n",
-        "DataStructs.TanimotoSimilarity(benzene_fingerprint, aspirin_fingerprint)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "75edf094-0dbb-4094-93bc-cf0cc113c51d",
-      "metadata": {
-        "id": "75edf094-0dbb-4094-93bc-cf0cc113c51d"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Exercise</h3>\n",
-        "\n",
-        "Use the Tanimoto similarity to measure if benzene is more similar to pyridine or aniline using the RDKit fingerprint. For this type of exercise, it is best to break it down in a series of steps. In this case:\n",
-        "\n",
-        "* Get the SMILES strings for aniline and pyridine from [PubChem](https://pubchem.ncbi.nlm.nih.gov/) and assign each to a variable.\n",
-        "* Use AllChem.RDKFingerprint to generate the fingerprint for each molecule.\n",
-        "* Use the TanimotoSimilarity function to compare each molecule to benzene.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a47675e2-4294-4625-a71a-4b411566f908",
-      "metadata": {
-        "id": "a47675e2-4294-4625-a71a-4b411566f908"
-      },
-      "outputs": [],
-      "source": [
-        "aniline = Chem.MolFromSmiles('')                             # TO DO: Get the SMILES string for aniline from PubChem(https://pubchem.ncbi.nlm.nih.gov/)\n",
-        "pyridine = Chem.MolFromSmiles('')                            # TO DO: Get the SMILES string for pyridine from PubChem(https://pubchem.ncbi.nlm.nih.gov/)\n",
-        "\n",
-        "aniline_fingerprint = AllChem.RDKFingerprint()               # TO DO: Generate the fingerprint for aniline\n",
-        "pyridine_fingerprint = AllChem.RDKFingerprint()              # TO DO: Generate the fingerprint for pyridine\n",
-        "\n",
-        "similarity = DataStructs.TanimotoSimilarity()                                   # TO DO: Compare the fingerprints for benzene and aniline\n",
-        "print(f\"The Tanimoto similarity of benzene and aniline is {similarity}.\")\n",
-        "\n",
-        "similarity = DataStructs.TanimotoSimilarity()                                   # TO DO: Compare the fingerprints for benzene and pyridine\n",
-        "print(f\"The Tanimoto similarity of benzene and pyridine is {similarity}.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "92228613-2c40-46c0-823b-63ec2700da07",
-      "metadata": {
-        "id": "92228613-2c40-46c0-823b-63ec2700da07"
-      },
-      "source": [
-        "## Molecular Descriptors\n",
-        "\n",
-        "The fingerprints discussed above are examples of **molecular descriptors**.\n",
-        "\n",
-        "A molecular descriptor is a numerical value that represents some property of a molecule.\n",
-        "If we want to be able to create a model that describes chemical behavior, we have to be able to convert information about molecules into numerical representations.\n",
-        "This is where the concept of a molecular descriptor comes in.\n",
-        "\n",
-        "Descriptors can be 0 dimensional (molecular weight, number of heavy atoms, etc.), 1 dimensional (counts of atom types, hydrogen bond donors/acceptors), 2 dimensional (fingerprints, other graph representations), 3 dimensional (polar surface area). The dimensionality of the descriptor defines what kind of dimensional information you need about the molecule in order to define the descriptor. For example, the fingerprint, a 2D descriptor, depends on the connectivity, or 2 dimensional structure of the molecule.\n",
-        "\n",
-        "RDKit supports the calculation of many molecular descriptors. You can see a [full list of RDKit descriptors](https://www.rdkit.org/docs/GettingStartedInPython.html#list-of-available-descriptors) or [see the module documentation](https://www.rdkit.org/docs/source/rdkit.Chem.Descriptors.html).\n",
-        "\n",
-        "To get molecular descriptors from RDKit, we import the `Descriptors` module.\n",
-        "\n",
-        "```python\n",
-        "from rdkit.Chem import Descriptors\n",
-        "```\n",
-        "\n",
-        "To get a descriptor, you do\n",
-        "\n",
-        "```python\n",
-        "Descriptors.descriptor_name(molecule_variable)\n",
-        "\n",
-        "```\n",
-        "\n",
-        "For example, we can calculate the molecular weight of our caffeine molecule"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6e860c2f-672b-419f-ab2c-ee58602ab422",
-      "metadata": {
-        "id": "6e860c2f-672b-419f-ab2c-ee58602ab422"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem import Descriptors\n",
-        "\n",
-        "caffeine_mol_wt = Descriptors.MolWt()     # TO DO: insert the name of the RDKit mol object for caffeine that you defined above\n",
-        "print()                                   # TO DO: print the molecular weight of caffeine"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "7986dcba-1058-49f6-9788-5433288377bd",
-      "metadata": {
-        "id": "7986dcba-1058-49f6-9788-5433288377bd"
-      },
-      "source": [
-        "RDKit provides hundreds of molecular descriptors.\n",
-        "You can calculate all of the molecular descriptors for a molecule at once using `CalcMolDescriptors`.\n",
-        "\n",
-        "As an example of how we can apply molecular descriptors to make predictions, we will consider Lipinski's Rule of 5.\n",
-        "Lipinski's Rule of 5 is a **guideline** that helps determine if a drug is likely to be absorbed well by the body. It states that good oral drugs typically have no more than 5 hydrogen bond donors, 10 hydrogen bond acceptors, a molecular weight under 500 daltons, and a log P (measure of solubility) under 5.\n",
-        "\n",
-        "* Molecular Weight <= 500 Da\n",
-        "* No. Hydrogen Bond Donors <= 5\n",
-        "* No. Hydrogen Bond Acceptors <= 10\n",
-        "* LogP <= 5"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "988dcfa9-389a-42c4-bb9b-4f68666f4583",
-      "metadata": {
-        "id": "988dcfa9-389a-42c4-bb9b-4f68666f4583"
-      },
-      "outputs": [],
-      "source": [
-        "MW = Descriptors.MolWt(aspirin)\n",
-        "HBA = Descriptors.NOCount(aspirin)\n",
-        "HBD = Descriptors.NHOHCount(aspirin)\n",
-        "LogP = Descriptors.MolLogP(aspirin)\n",
-        "\n",
-        "rules = [ MW <= 500, HBD <=5, HBA <=10, LogP <=5 ]\n",
-        "print(rules)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "8cc4c878-c5c6-4cbc-9e10-91b9760b9201",
-      "metadata": {
-        "id": "8cc4c878-c5c6-4cbc-9e10-91b9760b9201"
-      },
-      "source": [
-        "Based on these rules, aspirin is expected to be well-absorbed by the body.\n",
-        "\n",
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h2>Final Challenge</h2>\n",
-        "\n",
-        "Check Lipinski's Rule of 5 for [insulin](https://pubchem.ncbi.nlm.nih.gov/compound/Insulin#section=Canonical-SMILES).\n",
-        "Do you expect that insulin will be well-absorbed when taken orally based on these criteria?\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1c0aa9ee-1f21-40c6-ae04-86c6abdeb245",
-      "metadata": {
-        "id": "1c0aa9ee-1f21-40c6-ae04-86c6abdeb245"
-      },
-      "outputs": [],
-      "source": [
-        "# Create an RDKit mol object for insulin, using the SMILES string for insulin from PubChem\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f00ab72a-2e36-4562-b5ad-e829a2a93e8b",
-      "metadata": {
-        "id": "f00ab72a-2e36-4562-b5ad-e829a2a93e8b"
-      },
-      "outputs": [],
-      "source": [
-        "# Determine the Lipinski descriptors for insulin using the RDKit mol object for insulin\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "7c22fe39-8bb3-4476-a11f-56e4e8f6508d",
-      "metadata": {
-        "id": "7c22fe39-8bb3-4476-a11f-56e4e8f6508d"
-      },
-      "outputs": [],
-      "source": [
-        "# Determine how these descriptors compare with Lipinski's rule of 5\n",
-        "\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.2"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "10110027-0410-40ea-8950-8e4047699603",
+   "metadata": {
+    "id": "10110027-0410-40ea-8950-8e4047699603"
+   },
+   "source": [
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+    "</div>\n",
+    "\n",
+    "\n",
+    "# Cheminformatics: Molecular Similarity and Molecular Descriptors\n",
+    "\n",
+    "<strong>Author(s):</strong> Jessica A. Nash, The Molecular Sciences Software Institute\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2>Overview</h2>\n",
+    "\n",
+    "<strong>Questions:</strong>\n",
+    "\n",
+    "* How are molecules represented on computers for cheminformatics applications?\n",
+    "\n",
+    "* How can I measure the similarity of two molecules?\n",
+    "\n",
+    "* How can I find out if a molecule contains a particular substructure?\n",
+    "\n",
+    "<strong>Objectives:</strong>\n",
+    "\n",
+    "* Learn about graph representation of molecules.\n",
+    "\n",
+    "* Learn about molecular fingerprints.\n",
+    "\n",
+    "* Use RDKit to measure molecular similarity.\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "\n",
+    "Cheminformatics is often used in the context of molecular discovery.\n",
+    "For example, you might want to process a large number of molecules to find molecules that are similar to a target, or that contain a particular functional group.\n",
+    "But how can you tell if two molecules are similar?\n",
+    "\n",
+    "A chemist looking at two molecules might be able to make a judgment based on their chemical knowledge. However, when dealing with a large number of molecules, this problem can become intractable. There are ways to detect molecular similarity on a computer that allow fast comparison and processing of molecules.\n",
+    "\n",
+    "## Graph Representation of Molecules\n",
+    "Graph theory is a branch of mathematics that studies the properties and applications of graphs, which are structures made up of nodes (or vertices) connected by edges (or lines).\n",
+    "A molecule can be represented as a graph where atoms are nodes and bonds are edges. This representation allows the use of various graph-based algorithms to analyze molecular structures.\n",
+    "The figure below (borrowed from Wikipedia) shows a graph with numbered nodes (circles) connected by edges (lines).\n",
+    "\n",
+    "\n",
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/images/molecular_graph.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:300px;\">\n",
+    "</div>\n",
+    "\n",
+    "Image from [Wikipedia: Graph theory](https://en.wikipedia.org/wiki/Graph_theory)\n",
+    "\n",
+    "As a chemist, you probably don't have a hard time imagining a molecule as a graph. The atoms would be \"nodes\" in the graph, while the bonds would be \"edges\".\n",
+    "One can also represent bond order by changing the \"weight\" of graph edges.\n",
+    "In this view, one way to tell if molecules are the same is to check that their molecular graphs are the same.\n",
+    "\n",
+    "### Substructure Searches\n",
+    "\n",
+    "A substructure search is a cheminformatics technique used to identify molecules that contain a specific pattern or structure within a larger molecule.\n",
+    "\n",
+    "The figure below shows the beneze substructure matched in the aspirin molecule.\n",
+    "\n",
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/images/substructure.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:300px;\">\n",
+    "</div>\n",
+    "\n",
+    "\n",
+    "One way this can be done is with graph representation and graph theory.\n",
+    "When doing substructure search using RDKit, it can check to see if the molecular graph for one molecule contains the molecular graph of a smaller molecule.\n",
+    "This is a concept called \"**subgraph isomorphism**\". You can see more about this topic in this [presentation](https://www.rdkit.org/UGM/2012/Landrum_RDKit_UGM.Fingerprints.Final.pptx.pdf).\n",
+    "\n",
+    "This is all very nice information, but you actually don't have to fully understand it in order to do a substructure search. In the cells below, we demonstrate searching molecules for a smaller structure using substructure search. As you can see from the cells, this functionality is very nicely built into RDKit."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nn2PUoVduv_5",
+   "metadata": {
+    "id": "nn2PUoVduv_5"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rdkit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a031ff5-bf4f-4c65-b79f-5ea81ae6fdac",
+   "metadata": {
+    "id": "7a031ff5-bf4f-4c65-b79f-5ea81ae6fdac"
+   },
+   "source": [
+    "## Substracture Matches with RDKit\n",
+    "\n",
+    "Now we will move to RDKit and start looking at substructure matches. We'll begin with the SMILES string for caffeine (CN1C=NC2=C1C(=O)N(C(=O)N2C)C) which can be obtained from [PubChem](https://pubchem.ncbi.nlm.nih.gov/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a58f4581-13c4-478d-bafe-1e0846d3b412",
+   "metadata": {
+    "id": "a58f4581-13c4-478d-bafe-1e0846d3b412"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit import Chem\n",
+    "\n",
+    "caffeine = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Get the SMILES string for caffeine from PubChem(https://pubchem.ncbi.nlm.nih.gov/)\n",
+    "carbonyl = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Create or find the SMILES string for a carbonyl group\n",
+    "\n",
+    "matches = caffeine.GetSubstructMatches(\n",
+    "    carbonyl\n",
+    ")  # TO DO: Insert the variable that represents the substructure you want to find in caffeine in the parentheses\n",
+    "\n",
+    "caffeine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32a4c55b-362f-472b-a784-105b5c4fe015",
+   "metadata": {
+    "id": "32a4c55b-362f-472b-a784-105b5c4fe015"
+   },
+   "source": [
+    "As you can see above, we can define two molecules and search for one inside of the other.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Check Your Understanding</h3>\n",
+    "\n",
+    "Using the skills you've learned already, perform a substructure search for methyl groups in caffeine in the cell below.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efabcc57-46cf-4742-b39a-e0261307c07f",
+   "metadata": {
+    "id": "efabcc57-46cf-4742-b39a-e0261307c07f"
+   },
+   "outputs": [],
+   "source": [
+    "# put your code for a caffeine substructure search here\n",
+    "\n",
+    "caffeine = Chem.MolFromSmiles(\"\")  # TO DO: Insert the SMILES string for caffeine\n",
+    "methyl = Chem.MolFromSmiles(\"\")  # TO DO: Insert the SMILES string for a methyl group\n",
+    "\n",
+    "matches = caffeine.GetSubstructMatches()  # TO DO: Look for methyl groups in caffeine\n",
+    "\n",
+    "caffeine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd03244e-945a-4265-b544-10a2dbffd5e4",
+   "metadata": {
+    "id": "cd03244e-945a-4265-b544-10a2dbffd5e4"
+   },
+   "source": [
+    "From the substructure search in the cell above, you are probably seeing that you're not matching exactly what you want. In order to find just the methyl groups, we have to use yet another molecular representation.\n",
+    "\n",
+    "#### SMARTS Strings\n",
+    "A [SMARTS (SMiles ARbitrary Target Specification)](https://en.wikipedia.org/wiki/SMILES_arbitrary_target_specification) string is a pattern-matching language for specifying substructures in molecules. It is similar to SMILES but has additional features for specifying atom and bond properties. In contrast to SMILES, SMARTS allows for specifying substructures based on patterns of atoms and bonds, rather than just specifying the exact arrangement of atoms and bonds in a molecule.\n",
+    "\n",
+    "In this case, we want to highlight the methyl group in caffeine, which contains a single carbon atom bonded to three hydrogen atoms. We can use a SMARTS string to define this substructure as `[CH3]`, which represents a carbon atom with three hydrogen atoms bonded to it.\n",
+    "\n",
+    "Using a SMARTS string is necessary in this case because simply searching for a single carbon atom with the code `carbon = Chem.MolFromSmiles('C')` highlights all carbons in the molecule, not just the methyl group. By using a SMARTS string, we can specify the exact substructure we want to highlight and avoid highlighting unintended parts of the molecule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b5bba4e-91de-4c91-986b-049e0cac168c",
+   "metadata": {
+    "id": "1b5bba4e-91de-4c91-986b-049e0cac168c"
+   },
+   "outputs": [],
+   "source": [
+    "caffeine = Chem.MolFromSmiles(\"\")  # TO DO: Enter the SMILES string for caffeine\n",
+    "methyl_pattern = Chem.MolFromSmarts(\n",
+    "    \"\"\n",
+    ")  # TO DO: Enter the SMARTS string for the methyl group [CH3]\n",
+    "\n",
+    "# Get the indices of the matching atoms\n",
+    "matches = (\n",
+    "    caffeine.GetSubstructMatches()\n",
+    ")  # TO DO: Enter the variable for the pattern you are looking for in caffeine\n",
+    "caffeine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89d4a8b5-0454-46bd-9805-8e72a60f08ef",
+   "metadata": {
+    "id": "89d4a8b5-0454-46bd-9805-8e72a60f08ef"
+   },
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Create an RDKit molecule object for aspirin. You can find its SMILES representation by using [PubChem](https://pubchem.ncbi.nlm.nih.gov/).\n",
+    "\n",
+    "Visualize the molecule, highlighting any carboxyl groups in the structure. Use a SMARTS string to define the carboxyl group substructure.\n",
+    "\n",
+    "**Important:** Unless you know the rules for writing SMARTS strings (which you would have learned somewhere else, because we didn't cover it), it's unlikely that you'll guess what the SMARTS for carboxyl is. You can see a list of SMARTS strings for different functional groups [at this link](https://www.daylight.com/dayhtml_tutorials/languages/smarts/smarts_examples.html).\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03bf284b-6730-43b6-8c5b-242d095853eb",
+   "metadata": {
+    "id": "03bf284b-6730-43b6-8c5b-242d095853eb"
+   },
+   "outputs": [],
+   "source": [
+    "aspirin = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Insert the SMILES string for aspirin between the quote signs\n",
+    "carboxyl_pattern = Chem.MolFromSmarts(\n",
+    "    \"\"\n",
+    ")  # TO DO: Go to https://www.daylight.com/dayhtml_tutorials/languages/smarts/smarts_examples.html to find the SMARTS string for carboxyl group\n",
+    "\n",
+    "# Get the indices of the matching atoms\n",
+    "\n",
+    "matches = (\n",
+    "    aspirin.GetSubstructMatches()\n",
+    ")  # TO DO: Enter the variable for the pattern you are looking for in aspirin\n",
+    "aspirin"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a25724d-2e54-4a1a-b5b8-3a0da72b8e97",
+   "metadata": {
+    "id": "4a25724d-2e54-4a1a-b5b8-3a0da72b8e97"
+   },
+   "source": [
+    "## Molecular Fingerprints\n",
+    "Molecular fingerprints are representations of molecules that are usually bit strings, or vectors of 0's and 1's. Fingerprints are built by considering the molecular structure (often as a graph representation) and applying a certain algorithm to create the vector. The image below shows a representation of a molecular fingerprint. The molecule is separated into different parts with each part setting a bit (changing a 0 to a 1) in the fingerprint.\n",
+    "\n",
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/images/molecular_fingerprint.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+    "</div>\n",
+    "\n",
+    "\n",
+    "\n",
+    "Image from [Chemistry LibreTexts](https://chem.libretexts.org/Courses/Intercollegiate_Courses/Cheminformatics/06%3A_Molecular_Similarity/6.01%3A_Molecular_Descriptors) [Cheminformatics Course](https://chem.libretexts.org/Courses/Intercollegiate_Courses/Cheminformatics)\n",
+    "\n",
+    "The exact fingerprint will depend on the algorithm that is used to construct it.\n",
+    "There are many different fingerprinting algorithms. But they tend to fall into two types of groups - similarity or substructure fingerprints. A common similarity fingerprint that is used is the Morgan fingerprint. A common substructure fingerprint that is used is the [Daylight fingerprint](https://www.daylight.com/dayhtml/doc/theory/theory.finger.html) (the RDKFingerprint is a Daylight-like fingerprint).\n",
+    "\n",
+    "The cell below calculates the RDKit fingerprint for caffeine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca97af7e-cc2c-49e1-ab71-7e8058106131",
+   "metadata": {
+    "id": "ca97af7e-cc2c-49e1-ab71-7e8058106131"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem import AllChem\n",
+    "\n",
+    "aspirin = Chem.MolFromSmiles(\"\")  # TO DO: Insert the SMILES string for aspirin\n",
+    "benzene = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Insert the SMILES string for benzene - Can you predict it?\n",
+    "\n",
+    "aspirin_fingerprint = AllChem.RDKFingerprint(aspirin)\n",
+    "\n",
+    "type(aspirin_fingerprint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3ef1152-d5c1-40a9-a66d-0a0f3c83facc",
+   "metadata": {
+    "id": "c3ef1152-d5c1-40a9-a66d-0a0f3c83facc"
+   },
+   "source": [
+    "You usually wouldn't interact with a fingerprint directly, but using RDKit we can examine it to understand more about how it works.\n",
+    "We can print the bit string representation using `.ToBitString`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71d91ca4-4848-46ee-9441-9bb81bec48ae",
+   "metadata": {
+    "id": "71d91ca4-4848-46ee-9441-9bb81bec48ae"
+   },
+   "outputs": [],
+   "source": [
+    "aspirin_fingerprint.ToBitString()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c79828c2-5b84-43f0-bb2d-f04d95141d9a",
+   "metadata": {
+    "id": "c79828c2-5b84-43f0-bb2d-f04d95141d9a"
+   },
+   "source": [
+    "If you print the benzene string, you will see a string of the same length, but with fewer bits set.\n",
+    "There are fewer bits because there are fewer molecular patterns in the smaller molecule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9018a8f0-0e32-4e32-8cad-377e5cfe5838",
+   "metadata": {
+    "id": "9018a8f0-0e32-4e32-8cad-377e5cfe5838"
+   },
+   "outputs": [],
+   "source": [
+    "benzene_fingerprint = (\n",
+    "    AllChem.RDKFingerprint()\n",
+    ")  # TO DO: Insert the variable that represents the benzene mol object\n",
+    "benzene_string = benzene_fingerprint.ToBitString()  # You need the parentheses after ToBitString because it is a method, but the parentheses are empty in this case.\n",
+    "\n",
+    "print(benzene_string)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "781dd591-b789-4283-93b2-ffe684ee61c9",
+   "metadata": {
+    "id": "781dd591-b789-4283-93b2-ffe684ee61c9"
+   },
+   "source": [
+    "Using this bit string, we can do a number of different analyses.\n",
+    "For example, substructure searches using bit strings check that bits that are set in the smaller molecule are also set in the larger target molecule.\n",
+    "\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Exercise</h3>\n",
+    "\n",
+    "Fill in the for loop below to check that bits set in the aspirin fingerprint string are also set in the benzene fingerprint string.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0869b43-18dd-4714-af92-1de49932eb2b",
+   "metadata": {
+    "id": "e0869b43-18dd-4714-af92-1de49932eb2b"
+   },
+   "outputs": [],
+   "source": [
+    "aspirin_string = aspirin_fingerprint.ToBitString()\n",
+    "num_bits = len(benzene_string)\n",
+    "matches = 0\n",
+    "\n",
+    "for i in range(num_bits):\n",
+    "    if benzene_string[i] == \"1\":\n",
+    "        print()  # TO DO: enter a boolean comparison of each item in the aspirin string to each item in the benzene string\n",
+    "        matches  # TO DO: increment the counter\n",
+    "\n",
+    "print(\n",
+    "    f\"There are {matches} positions where the benzene fingerprint matches the aspirin fingerprint.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9778634e-0344-4d87-a406-c0ab48b8ff75",
+   "metadata": {
+    "id": "9778634e-0344-4d87-a406-c0ab48b8ff75"
+   },
+   "source": [
+    "The above output tells us that every bit that is set in the benzene fingerprint is also set in the aspirin target. Fingerprint substructure searches are often used for faster, but less accurate substructure searches, and are commonly used for screen large numbers of molecules quickly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9e5ecb4-5348-4f3d-b519-4fbff21f666a",
+   "metadata": {
+    "id": "c9e5ecb4-5348-4f3d-b519-4fbff21f666a"
+   },
+   "source": [
+    "### Measuring Similarity\n",
+    "\n",
+    "Because the fingerprints are numbers, we can measure how similar two fingerprints are using different similarity metrics.\n",
+    "One common similarity metric is called the Tanimoto similarity.\n",
+    " The Tanimoto similarity is calculated as follows:\n",
+    "\n",
+    "$$\n",
+    "T(A, B) = \\frac{A \\cap B}{A + B - A \\cap B}\n",
+    "$$\n",
+    "\n",
+    "Where:\n",
+    "- $A$ and $B$: are the sets of bits in the fingerprint vectors for molecules $A$ and $B$ respectively.\n",
+    "- $A \\cap B$: This represents the intersection of sets $A$ and $B$, i.e., the number of bits that are '1' (set) in both $A$ and $B$.\n",
+    "- $A + B$: This is the sum of all '1' bits in both $A$ and $B$.\n",
+    "- $A + B - A \\cap B$: This term represents the union of sets $A$ and $B$, calculated as the total number of unique '1' bits across both fingerprints.\n",
+    "\n",
+    "The Tanimoto similarity ranges from 0.0 to 1.0, with 1.0 representing identical fingerprints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "820dd583-c661-4db5-b510-aa204e0c0f26",
+   "metadata": {
+    "id": "820dd583-c661-4db5-b510-aa204e0c0f26"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit import DataStructs\n",
+    "\n",
+    "DataStructs.TanimotoSimilarity(benzene_fingerprint, aspirin_fingerprint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75edf094-0dbb-4094-93bc-cf0cc113c51d",
+   "metadata": {
+    "id": "75edf094-0dbb-4094-93bc-cf0cc113c51d"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Exercise</h3>\n",
+    "\n",
+    "Use the Tanimoto similarity to measure if benzene is more similar to pyridine or aniline using the RDKit fingerprint. For this type of exercise, it is best to break it down in a series of steps. In this case:\n",
+    "\n",
+    "* Get the SMILES strings for aniline and pyridine from [PubChem](https://pubchem.ncbi.nlm.nih.gov/) and assign each to a variable.\n",
+    "* Use AllChem.RDKFingerprint to generate the fingerprint for each molecule.\n",
+    "* Use the TanimotoSimilarity function to compare each molecule to benzene.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a47675e2-4294-4625-a71a-4b411566f908",
+   "metadata": {
+    "id": "a47675e2-4294-4625-a71a-4b411566f908"
+   },
+   "outputs": [],
+   "source": [
+    "aniline = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Get the SMILES string for aniline from PubChem(https://pubchem.ncbi.nlm.nih.gov/)\n",
+    "pyridine = Chem.MolFromSmiles(\n",
+    "    \"\"\n",
+    ")  # TO DO: Get the SMILES string for pyridine from PubChem(https://pubchem.ncbi.nlm.nih.gov/)\n",
+    "\n",
+    "aniline_fingerprint = (\n",
+    "    AllChem.RDKFingerprint()\n",
+    ")  # TO DO: Generate the fingerprint for aniline\n",
+    "pyridine_fingerprint = (\n",
+    "    AllChem.RDKFingerprint()\n",
+    ")  # TO DO: Generate the fingerprint for pyridine\n",
+    "\n",
+    "similarity = (\n",
+    "    DataStructs.TanimotoSimilarity()\n",
+    ")  # TO DO: Compare the fingerprints for benzene and aniline\n",
+    "print(f\"The Tanimoto similarity of benzene and aniline is {similarity}.\")\n",
+    "\n",
+    "similarity = (\n",
+    "    DataStructs.TanimotoSimilarity()\n",
+    ")  # TO DO: Compare the fingerprints for benzene and pyridine\n",
+    "print(f\"The Tanimoto similarity of benzene and pyridine is {similarity}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92228613-2c40-46c0-823b-63ec2700da07",
+   "metadata": {
+    "id": "92228613-2c40-46c0-823b-63ec2700da07"
+   },
+   "source": [
+    "## Molecular Descriptors\n",
+    "\n",
+    "The fingerprints discussed above are examples of **molecular descriptors**.\n",
+    "\n",
+    "A molecular descriptor is a numerical value that represents some property of a molecule.\n",
+    "If we want to be able to create a model that describes chemical behavior, we have to be able to convert information about molecules into numerical representations.\n",
+    "This is where the concept of a molecular descriptor comes in.\n",
+    "\n",
+    "Descriptors can be 0 dimensional (molecular weight, number of heavy atoms, etc.), 1 dimensional (counts of atom types, hydrogen bond donors/acceptors), 2 dimensional (fingerprints, other graph representations), 3 dimensional (polar surface area). The dimensionality of the descriptor defines what kind of dimensional information you need about the molecule in order to define the descriptor. For example, the fingerprint, a 2D descriptor, depends on the connectivity, or 2 dimensional structure of the molecule.\n",
+    "\n",
+    "RDKit supports the calculation of many molecular descriptors. You can see a [full list of RDKit descriptors](https://www.rdkit.org/docs/GettingStartedInPython.html#list-of-available-descriptors) or [see the module documentation](https://www.rdkit.org/docs/source/rdkit.Chem.Descriptors.html).\n",
+    "\n",
+    "To get molecular descriptors from RDKit, we import the `Descriptors` module.\n",
+    "\n",
+    "```python\n",
+    "from rdkit.Chem import Descriptors\n",
+    "```\n",
+    "\n",
+    "To get a descriptor, you do\n",
+    "\n",
+    "```python\n",
+    "Descriptors.descriptor_name(molecule_variable)\n",
+    "\n",
+    "```\n",
+    "\n",
+    "For example, we can calculate the molecular weight of our caffeine molecule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e860c2f-672b-419f-ab2c-ee58602ab422",
+   "metadata": {
+    "id": "6e860c2f-672b-419f-ab2c-ee58602ab422"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem import Descriptors\n",
+    "\n",
+    "caffeine_mol_wt = (\n",
+    "    Descriptors.MolWt()\n",
+    ")  # TO DO: insert the name of the RDKit mol object for caffeine that you defined above\n",
+    "print()  # TO DO: print the molecular weight of caffeine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7986dcba-1058-49f6-9788-5433288377bd",
+   "metadata": {
+    "id": "7986dcba-1058-49f6-9788-5433288377bd"
+   },
+   "source": [
+    "RDKit provides hundreds of molecular descriptors.\n",
+    "You can calculate all of the molecular descriptors for a molecule at once using `CalcMolDescriptors`.\n",
+    "\n",
+    "As an example of how we can apply molecular descriptors to make predictions, we will consider Lipinski's Rule of 5.\n",
+    "Lipinski's Rule of 5 is a **guideline** that helps determine if a drug is likely to be absorbed well by the body. It states that good oral drugs typically have no more than 5 hydrogen bond donors, 10 hydrogen bond acceptors, a molecular weight under 500 daltons, and a log P (measure of solubility) under 5.\n",
+    "\n",
+    "* Molecular Weight <= 500 Da\n",
+    "* No. Hydrogen Bond Donors <= 5\n",
+    "* No. Hydrogen Bond Acceptors <= 10\n",
+    "* LogP <= 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "988dcfa9-389a-42c4-bb9b-4f68666f4583",
+   "metadata": {
+    "id": "988dcfa9-389a-42c4-bb9b-4f68666f4583"
+   },
+   "outputs": [],
+   "source": [
+    "MW = Descriptors.MolWt(aspirin)\n",
+    "HBA = Descriptors.NOCount(aspirin)\n",
+    "HBD = Descriptors.NHOHCount(aspirin)\n",
+    "LogP = Descriptors.MolLogP(aspirin)\n",
+    "\n",
+    "rules = [MW <= 500, HBD <= 5, HBA <= 10, LogP <= 5]\n",
+    "print(rules)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cc4c878-c5c6-4cbc-9e10-91b9760b9201",
+   "metadata": {
+    "id": "8cc4c878-c5c6-4cbc-9e10-91b9760b9201"
+   },
+   "source": [
+    "Based on these rules, aspirin is expected to be well-absorbed by the body.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h2>Final Challenge</h2>\n",
+    "\n",
+    "Check Lipinski's Rule of 5 for [insulin](https://pubchem.ncbi.nlm.nih.gov/compound/Insulin#section=Canonical-SMILES).\n",
+    "Do you expect that insulin will be well-absorbed when taken orally based on these criteria?\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c0aa9ee-1f21-40c6-ae04-86c6abdeb245",
+   "metadata": {
+    "id": "1c0aa9ee-1f21-40c6-ae04-86c6abdeb245"
+   },
+   "outputs": [],
+   "source": [
+    "# Create an RDKit mol object for insulin, using the SMILES string for insulin from PubChem\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f00ab72a-2e36-4562-b5ad-e829a2a93e8b",
+   "metadata": {
+    "id": "f00ab72a-2e36-4562-b5ad-e829a2a93e8b"
+   },
+   "outputs": [],
+   "source": [
+    "# Determine the Lipinski descriptors for insulin using the RDKit mol object for insulin\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c22fe39-8bb3-4476-a11f-56e4e8f6508d",
+   "metadata": {
+    "id": "7c22fe39-8bb3-4476-a11f-56e4e8f6508d"
+   },
+   "outputs": [],
+   "source": [
+    "# Determine how these descriptors compare with Lipinski's rule of 5\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/prep/E_pandas_seaborn.ipynb
+++ b/prep/E_pandas_seaborn.ipynb
@@ -1,799 +1,809 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "1Gl__1mt1BL4"
-      },
-      "source": [
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
-        "</div>\n",
-        "\n",
-        "\n",
-        "\n",
-        "Examining and Visualizing Data\n",
-        "=============================\n",
-        "\n",
-        "<strong>Author(s):</strong> Jessica A. Nash, The Molecular Sciences Software Institute\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "<h2>Overview</h2>\n",
-        "\n",
-        "<strong>Questions:</strong>\n",
-        "\n",
-        "* How can I use pandas to process data?\n",
-        "\n",
-        "* How can I visualize relationships between different parts of my data?\n",
-        "\n",
-        "<strong>Objectives:</strong>\n",
-        "\n",
-        "* Use pandas and seaborn to load and explore data\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "lNVJomRi1BL6"
-      },
-      "source": [
-        "[Pandas](https://pandas.pydata.org/docs/) is a Python library used for data analysis and manipulation. Within the world of data science, it is a ubiquitous and widely used library. If you are learning how to analyze data in Python, it will be almost impossible to avoid pandas.\n",
-        "\n",
-        "The central data structure of pandas is called a DataFrame. Pandas DataFrames work very closely with NumPy arrays and Pandas dataframes are specifically for data which is two dimensional (rows and columns). NumPy arrays, while similar in some ways, can work with higher dimensional data.\n",
-        "\n",
-        "Pandas is very powerful. In this session, we'll be learning how to access information in pandas dataframes and how to do some basic manipulation and analysis. We are going to be looking at a dataset which gives information about the elements in the periodic table."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "F72xtliv1KkY"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install pandas seaborn matplotlib rdkit"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Pandas Dataframes\n",
-        "\n",
-        "In this notebook, we will load from a comma separate file (.csv - kind of a simplified version of a spreadsheet) into a pandas dataframe, which is a two-dimensional array of data in rows and columns. In this notebooks we will take advantage of some of the features that are native to pandas dataframes for data analysis and plotting."
-      ],
-      "metadata": {
-        "id": "LZV-aEQ13TZS"
-      }
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "b7KUqqPf1BL6"
-      },
-      "outputs": [],
-      "source": [
-        "import pandas as pd\n",
-        "\n",
-        "from urllib.request import urlretrieve\n",
-        "url = (\"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/PubChemElements_all.csv\")\n",
-        "filename = \"PubChemElements_all.csv\"\n",
-        "urlretrieve(url, filename)\n",
-        "\n",
-        "df = pd.read_csv(filename)\n",
-        "df"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NHnp9uqX1BL7"
-      },
-      "source": [
-        "## Examining Data"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wE8N3exr1BL7"
-      },
-      "source": [
-        "Initially when loading data in, and also at certain points as we're working with it, we'll want to see what our dataframe looks like. You can see a preview of your dataframe using the `.head` function"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "CJIaWKHf1BL7"
-      },
-      "outputs": [],
-      "source": [
-        "df.head()         # This command will display the first five rows of the dataframe. Click the variable record on the left {x} to learn more about this dataframe."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "hpDhoZea1BL7"
-      },
-      "source": [
-        "The `.info` function will give information about the columns and the data type of those columns. The data type will become very important later as we work with data more."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "x3eBcLoG1BL7",
-        "scrolled": true
-      },
-      "outputs": [],
-      "source": [
-        "df.info()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5valH56E1BL8"
-      },
-      "source": [
-        "For this dataframe, we see that the first column, `AtomicNumber` has the data type of `int64`. Here, `int` means `integer` and `64` means `64 bit`.  The `64 bit` refers to the amount of computer memory the variable can occupy. It won't really be important for us. Similarly, `float64` means `64 bit floating point`. These are decimal numbers.\n",
-        "\n",
-        "The other column names which read `object` are not numeric. They might be strings or they might be something else. We'll discuss more later.\n",
-        "\n",
-        "The `describe` function can be used on a dataframe to quickly see statistics about columns with numerical data. If you look at the columns that statistics are computed for and compare to the data type shown from `info`, you will see that we only get statistics for columns which had `int64` or `float64` data types."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "-RsOeMAv1BL8"
-      },
-      "outputs": [],
-      "source": [
-        "df.describe()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Z1M6VIS21BL8"
-      },
-      "source": [
-        "This information is extremely useful for understanding the data. We can also easily visualize the distribution of each column using Pandas's ``hist`` function."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "padZJvd91BL8"
-      },
-      "outputs": [],
-      "source": [
-        "df.hist(figsize=(8,8), edgecolor='black', grid=False)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "i4gGStV81BL8"
-      },
-      "source": [
-        "## Accessing Data\n",
-        "\n",
-        "Pandas dataframes have names for rows (called the \"index\" in Pandas) and columns.\n",
-        "\n",
-        "Pandas dataframes have rows and columns, you can see how many rows and columns using `.shape`. This will return the shape as `(num_rows, num_columns)`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "VTjUSi9s1BL8"
-      },
-      "outputs": [],
-      "source": [
-        "df.shape"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jQNFLJk21BL8"
-      },
-      "source": [
-        "There are a few methods for accessing information in a Pandas dataframe, but the one that will be most important in this workshop is selecting particular columns of data."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "d0GzycHy1BL9"
-      },
-      "outputs": [],
-      "source": [
-        "df[\"AtomicNumber\"].head()          # You can select one column by putting the column header in the square brackets. The header is a string, so it must be in quotes."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ODTdsHzj1BL9"
-      },
-      "outputs": [],
-      "source": [
-        "df[[\"Symbol\", \"ElectronConfiguration\"]].head()           # To select multiple columns, put list in brackets"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qpSayfPS1BL9"
-      },
-      "source": [
-        "## Performing calculations with pandas: No more `for` loops!\n",
-        "\n",
-        "Both pandas and NumPy dataframes have the convenient feature that they can do element-wise operations and use something called `broadcasting`. This means that if you are doing something like subtracting a number, multiplying, etc to a column or dataframe of information, it can be done all at once instead of with a `for` loop. Consider if we wanted to calculate the melting point in degrees celsius for all of the elements.\n",
-        "\n",
-        "Instead of writing a `for` loop that does this, we can just write the following code. This will return a pandas Series (one dimensional dataframe)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "PSaWkwpb1BL9"
-      },
-      "outputs": [],
-      "source": [
-        "df['MeltingPoint'] - 273.15"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5uQx_WLb1BL9"
-      },
-      "source": [
-        "We could do this one two columns as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "3wrRpOL41BL9"
-      },
-      "outputs": [],
-      "source": [
-        "df[['MeltingPoint', 'BoilingPoint']] - 273.15"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VQyz3nrz1BL9"
-      },
-      "source": [
-        "We can save these in new dataframe columns"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "rkynyMMS1BL9"
-      },
-      "outputs": [],
-      "source": [
-        "df[[\"MeltingPointC\", \"BoilingPointC\"]] = df[['MeltingPoint', 'BoilingPoint']] - 273.15\n",
-        "df.head()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rJqiEad11BL9"
-      },
-      "source": [
-        "### The `.apply` method\n",
-        "\n",
-        "The `.apply` method in pandas is used to apply a function along a row or column of a dataframe.\n",
-        "This is useful when you have a custom function that you need to use on every value in a column, but there is not a NumPy or Pandas function for it.\n",
-        "\n",
-        "For example, we could apply the `len` function to our `Name` column to get the number of letters in the name for each element."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "oKzShBBv1BL-"
-      },
-      "outputs": [],
-      "source": [
-        "# Number of letters in name -\n",
-        "df[\"Name\"].apply(len)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "m_kPq_OQ1BL-"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-success\">\n",
-        "<strong>The .apply function</strong>\n",
-        "\n",
-        "Notice that when we use `.apply`, we write the <strong>name</strong> of the function we want to apply,\n",
-        "but we do not <strong>call</strong> the function.\n",
-        "If we were to call the `len` function, we would use parentheses `()` with an argument.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vzV4auDh1BL-"
-      },
-      "source": [
-        "## Using RDKit Functions with Pandas DataFrames\n",
-        "For an example more related to our work with RDKit, let's add some additional atomic data.\n",
-        "RDKit has the ability to get information about atoms.\n",
-        "We can create a periodic table with `Chem.GetPeriodicTable`, then use associated functions to get information about atoms."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "6qcsRNRz1BL-"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit import Chem\n",
-        "\n",
-        "# Initialize the periodic table\n",
-        "periodic_table = Chem.GetPeriodicTable()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dCrZ0fUd1BL-"
-      },
-      "source": [
-        "After we have a periodic table, we can apply functions from the periodic table to the atoms in our dataframe."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "PPRUFOa-1BL-"
-      },
-      "outputs": [],
-      "source": [
-        "df[\"NOuter\"] = df[\"Symbol\"].apply(periodic_table.GetNOuterElecs)\n",
-        "df.head()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TVyJsCUL1BL-"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Exercise</h3>\n",
-        "\n",
-        "Use the `tab` key on your periodic table object to check for other values you can calculate for atoms.\n",
-        "Pick one to add to your periodic table dataset.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "BUW7mA3p1BL-"
-      },
-      "outputs": [],
-      "source": [
-        "df[\"Default_Valence\"] = df[\"Symbol\"].apply(periodic_table.)        # TO DO: Find a method that will give you the default valence for an element\n",
-        "df.iloc[21:31]                                                    # The df.iloc command lists the contents of those rows in the dataframe"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "AxG6533i1BL_"
-      },
-      "source": [
-        "We can save a CSV file with our newly calculated values using the `to_csv` function."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "hHVoMLIz1BL_"
-      },
-      "outputs": [],
-      "source": [
-        "df.to_csv(\"periodic_data_processed.csv\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "O9IUuGGp1BL_"
-      },
-      "source": [
-        "## Visualization\n",
-        "\n",
-        "Visualizing data helps in understanding relationships and patterns that might not be apparent from raw data. Here, we will use Seaborn, a statistical visualization library, to create plots from our periodic table dataset. Seaborn is built on top of matplotlib, so if we would like to adjust any of the plots seaborn makes, we can do that through the Matplotlib interface we've used before.\n",
-        "\n",
-        "We will start with a bar plot to show the ionization energy of elements across different group blocks:\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "xHvxbNcV1BL_"
-      },
-      "outputs": [],
-      "source": [
-        "import seaborn as sns\n",
-        "import matplotlib.pyplot as plt"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "wZ3UM43P1BL_"
-      },
-      "outputs": [],
-      "source": [
-        "sns.catplot(data=df, x=\"NOuter\", y=\"IonizationEnergy\", kind=\"bar\")\n",
-        "# Rotate x-axis labels\n",
-        "plt.xticks(rotation=45, ha='right')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YMgszpBj1BL_"
-      },
-      "source": [
-        "The plot above shows us periodic trends that we learned about in introductory chemistry. The two highest ionization energy categories correspond to elements with 2 valence electrons and 8 valence electrons, representing filled shells.\n",
-        "\n",
-        "Seaborn can also allow us to easily create scatter plots to visualize relationships between continuous variables. For example, we can create a scatter plot to show the relationship between ionization energy and atomic radius:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "K2XGYxiH1BME"
-      },
-      "outputs": [],
-      "source": [
-        "sns.scatterplot(data=df, x=\"AtomicRadius\", y=\"Electronegativity\", hue=\"GroupBlock\")\n",
-        "plt.title('Electronegativity vs. Atomic Radius')\n",
-        "plt.xlabel('Atomic Radius')\n",
-        "plt.ylabel('Electronegativity')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ufsnV5FQ1BME"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Exercise</h3>\n",
-        "\n",
-        "Create a few other categorical plots to observe periodic trends:\n",
-        "\n",
-        "1. Electronegativity vs. Group Block as a bar plot.\n",
-        "\n",
-        "2. Melting Point vs. Group Block as a bar plot.\n",
-        "\n",
-        "3. Ionization Energy vs. Atomic Number as a scatter plot colored by GroupBlock.\n",
-        "   \n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2TTmY-SS1BME"
-      },
-      "outputs": [],
-      "source": [
-        "sns.barplot(data=df, x=\"\", y=\"\")             # TO DO: Remember to put the dataframe column title in quotes, but not square brackets\n",
-        "plt.title('Electronegativity vs. Group Block')\n",
-        "plt.xlabel('Group Block')\n",
-        "plt.ylabel('Electronegativity')\n",
-        "plt.xticks(rotation=45)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "sCIw2xAh1BME"
-      },
-      "outputs": [],
-      "source": [
-        "sns.barplot(data=df, x=\"\", y=\"\")             # TO DO: Remember to put the dataframe column title in quotes, but not square brackets\n",
-        "plt.title('Melting Point vs. Group Block')\n",
-        "plt.xlabel('Group Block')\n",
-        "plt.ylabel('Melting Point')\n",
-        "plt.xticks(rotation=45)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "vK-cP-bc1BMF"
-      },
-      "outputs": [],
-      "source": [
-        "sns.scatterplot(data=df, x=\"\", y=\"\", hue=\"GroupBlock\")             # TO DO: Remember to put the dataframe column title in quotes, but not square brackets\n",
-        "plt.title('Melting Point vs. Atomic Number')\n",
-        "plt.xlabel('Atomic Number')\n",
-        "plt.ylabel('Melting Point')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "S9QADUad1BMF"
-      },
-      "source": [
-        "### Visualizing Correlation\n",
-        "\n",
-        "A common way to visualize relationships between different categories of data categories is with a correlation plot.\n",
-        "The correlation matrix provides insights into the relationships between the variables. A correlation value close to 1 indicates a strong positive relationship, while a correlation value close to -1 indicates a strong negative relationship. A correlation value close to 0 indicates no relationship between the features."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "_dbZX9Yc1BMF"
-      },
-      "outputs": [],
-      "source": [
-        "# Calculate the correlation matrix\n",
-        "corr = df.corr(numeric_only=True)\n",
-        "corr"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mhVE4b_D1BMF"
-      },
-      "source": [
-        "Seaborn can be used to create a heatmap to allow easier examination of the correlation of different variables."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "_7urDyWr1BMF"
-      },
-      "outputs": [],
-      "source": [
-        "# Create a heatmap\n",
-        "plt.figure(figsize=(10, 8))\n",
-        "sns.heatmap(corr, annot=True, cmap=\"coolwarm\", fmt=\".2f\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "eCsmiHY01BMF"
-      },
-      "source": [
-        "The heatmap uses a \"coolwarm\" color scheme where red indicates positive correlation and blue indicates negative correlation between variables. Strongly correlated pairs are represented by darker shades of red, while strongly inversely correlated pairs are represented by darker shades of blue."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ZIArXkd41BMF"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Final Challenge</h3>\n",
-        "\n",
-        "For this challenge, you will retrieve a file called `amino_acids.txt` that contains SMILES for the 20 naturally occurring amino acids. Your task for the final challenge of today is to combine skills and concepts you have learned today to build a dataframe for molecules and write a file. Your goal is to create a comma-separated value file with columns `SMILES`, `num_heavy` (number of heavy atoms), `molecular_weight`, and one other molecular descriptor of your choice for the molecules in the file.\n",
-        "\n",
-        "For this task, you will need to complete the following steps. The first three steps are already completed.\n",
-        "\n",
-        "1. Retrieve the file amino_acids.txt.\n",
-        "1. Read the data in the file and place the SMILES strings in a list.\n",
-        "1. Create a pandas dataframe, aadf, with the SMILES string as the first column.\n",
-        "1. Use the .apply function to add a new column to aadf that contains an RDKit mol object for each of the SMILES strings.\n",
-        "1. Use the .apply function to then add a column with the number of heavy atoms, a column with the molecular weight and a column with one other molecular descriptor of your choice for each molecule in aadf.\n",
-        "1. Save your file as `data/amino_acids_processed.csv`.\n",
-        "\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Eqve_OjC1BMF"
-      },
-      "source": [
-        "### Read SMILES from a text file\n",
-        "I will use the ```with open``` command to do this."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "7ujrXpeB1BMG"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit import Chem\n",
-        "from rdkit.Chem import Descriptors\n",
-        "import pandas as pd\n",
-        "from rdkit.Chem import PandasTools\n",
-        "\n",
-        "## This cell is provided for the challenge\n",
-        "\n",
-        "# Ensure molecules are rendered in the notebook\n",
-        "PandasTools.RenderImagesInAllDataFrames(images=True)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "zYBJIN5w3fPi"
-      },
-      "outputs": [],
-      "source": [
-        "url = (\"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/amino_acids.txt\")\n",
-        "filename = \"amino_acids.txt\"\n",
-        "urlretrieve(url, filename)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "QA2YrDGV1BMG"
-      },
-      "outputs": [],
-      "source": [
-        "url = (\"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/amino_acids.txt\")\n",
-        "aa_file = \"amino_acids.txt\"\n",
-        "urlretrieve(url, aa_file)\n",
-        "\n",
-        "with open(aa_file,'r') as outfile:\n",
-        "    aasmiles = outfile.readlines()\n",
-        "\n",
-        "aasmiles_strip = []\n",
-        "for smiles in aasmiles:\n",
-        "    smiles = smiles.strip()\n",
-        "    aasmiles_strip.append(smiles)\n",
-        "\n",
-        "print(aasmiles_strip)\n",
-        "\n",
-        "aadf = pd.DataFrame(\n",
-        "    {'SMILES': aasmiles_strip})\n",
-        "\n",
-        "aadf\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Rbb47-d51BMG"
-      },
-      "source": [
-        "### Make an RDKit molecule for each SMILES\n",
-        "I did this before. This time, I'll add the SMILES string to the dataframe first, then use the apply function to create the RDKit molecules."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Bgi3HQaP1BMG"
-      },
-      "outputs": [],
-      "source": [
-        "# Create the list of molecules\n",
-        "\n",
-        "aadf['Molecule'] = aadf['SMILES'].apply(Chem.MolFromSmiles)\n",
-        "aadf"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Sx5jiRo31BMG"
-      },
-      "source": [
-        "### Write a file with the data\n",
-        "\n",
-        "Generate a .csv file from aadf."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "LjuP7LKJ1BMG"
-      },
-      "outputs": [],
-      "source": [
-        "outputfile = ('amino_acids_processed.csv')\n",
-        "aadf.to_csv(outputfile)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "QKdmd8V-1BMH"
-      },
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.2"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1Gl__1mt1BL4"
+   },
+   "source": [
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+    "</div>\n",
+    "\n",
+    "\n",
+    "\n",
+    "Examining and Visualizing Data\n",
+    "=============================\n",
+    "\n",
+    "<strong>Author(s):</strong> Jessica A. Nash, The Molecular Sciences Software Institute\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2>Overview</h2>\n",
+    "\n",
+    "<strong>Questions:</strong>\n",
+    "\n",
+    "* How can I use pandas to process data?\n",
+    "\n",
+    "* How can I visualize relationships between different parts of my data?\n",
+    "\n",
+    "<strong>Objectives:</strong>\n",
+    "\n",
+    "* Use pandas and seaborn to load and explore data\n",
+    "\n",
+    "</div>"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "lNVJomRi1BL6"
+   },
+   "source": [
+    "[Pandas](https://pandas.pydata.org/docs/) is a Python library used for data analysis and manipulation. Within the world of data science, it is a ubiquitous and widely used library. If you are learning how to analyze data in Python, it will be almost impossible to avoid pandas.\n",
+    "\n",
+    "The central data structure of pandas is called a DataFrame. Pandas DataFrames work very closely with NumPy arrays and Pandas dataframes are specifically for data which is two dimensional (rows and columns). NumPy arrays, while similar in some ways, can work with higher dimensional data.\n",
+    "\n",
+    "Pandas is very powerful. In this session, we'll be learning how to access information in pandas dataframes and how to do some basic manipulation and analysis. We are going to be looking at a dataset which gives information about the elements in the periodic table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "F72xtliv1KkY"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install pandas seaborn matplotlib rdkit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LZV-aEQ13TZS"
+   },
+   "source": [
+    "## Pandas Dataframes\n",
+    "\n",
+    "In this notebook, we will load from a comma separate file (.csv - kind of a simplified version of a spreadsheet) into a pandas dataframe, which is a two-dimensional array of data in rows and columns. In this notebooks we will take advantage of some of the features that are native to pandas dataframes for data analysis and plotting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "b7KUqqPf1BL6"
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "from urllib.request import urlretrieve\n",
+    "\n",
+    "url = \"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/PubChemElements_all.csv\"\n",
+    "filename = \"PubChemElements_all.csv\"\n",
+    "urlretrieve(url, filename)\n",
+    "\n",
+    "df = pd.read_csv(filename)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NHnp9uqX1BL7"
+   },
+   "source": [
+    "## Examining Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wE8N3exr1BL7"
+   },
+   "source": [
+    "Initially when loading data in, and also at certain points as we're working with it, we'll want to see what our dataframe looks like. You can see a preview of your dataframe using the `.head` function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "CJIaWKHf1BL7"
+   },
+   "outputs": [],
+   "source": [
+    "df.head()  # This command will display the first five rows of the dataframe. Click the variable record on the left {x} to learn more about this dataframe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hpDhoZea1BL7"
+   },
+   "source": [
+    "The `.info` function will give information about the columns and the data type of those columns. The data type will become very important later as we work with data more."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "x3eBcLoG1BL7",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5valH56E1BL8"
+   },
+   "source": [
+    "For this dataframe, we see that the first column, `AtomicNumber` has the data type of `int64`. Here, `int` means `integer` and `64` means `64 bit`.  The `64 bit` refers to the amount of computer memory the variable can occupy. It won't really be important for us. Similarly, `float64` means `64 bit floating point`. These are decimal numbers.\n",
+    "\n",
+    "The other column names which read `object` are not numeric. They might be strings or they might be something else. We'll discuss more later.\n",
+    "\n",
+    "The `describe` function can be used on a dataframe to quickly see statistics about columns with numerical data. If you look at the columns that statistics are computed for and compare to the data type shown from `info`, you will see that we only get statistics for columns which had `int64` or `float64` data types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-RsOeMAv1BL8"
+   },
+   "outputs": [],
+   "source": [
+    "df.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Z1M6VIS21BL8"
+   },
+   "source": [
+    "This information is extremely useful for understanding the data. We can also easily visualize the distribution of each column using Pandas's ``hist`` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "padZJvd91BL8"
+   },
+   "outputs": [],
+   "source": [
+    "df.hist(figsize=(8, 8), edgecolor=\"black\", grid=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "i4gGStV81BL8"
+   },
+   "source": [
+    "## Accessing Data\n",
+    "\n",
+    "Pandas dataframes have names for rows (called the \"index\" in Pandas) and columns.\n",
+    "\n",
+    "Pandas dataframes have rows and columns, you can see how many rows and columns using `.shape`. This will return the shape as `(num_rows, num_columns)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VTjUSi9s1BL8"
+   },
+   "outputs": [],
+   "source": [
+    "df.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jQNFLJk21BL8"
+   },
+   "source": [
+    "There are a few methods for accessing information in a Pandas dataframe, but the one that will be most important in this workshop is selecting particular columns of data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "d0GzycHy1BL9"
+   },
+   "outputs": [],
+   "source": [
+    "df[\n",
+    "    \"AtomicNumber\"\n",
+    "].head()  # You can select one column by putting the column header in the square brackets. The header is a string, so it must be in quotes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ODTdsHzj1BL9"
+   },
+   "outputs": [],
+   "source": [
+    "df[\n",
+    "    [\"Symbol\", \"ElectronConfiguration\"]\n",
+    "].head()  # To select multiple columns, put list in brackets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qpSayfPS1BL9"
+   },
+   "source": [
+    "## Performing calculations with pandas: No more `for` loops!\n",
+    "\n",
+    "Both pandas and NumPy dataframes have the convenient feature that they can do element-wise operations and use something called `broadcasting`. This means that if you are doing something like subtracting a number, multiplying, etc to a column or dataframe of information, it can be done all at once instead of with a `for` loop. Consider if we wanted to calculate the melting point in degrees celsius for all of the elements.\n",
+    "\n",
+    "Instead of writing a `for` loop that does this, we can just write the following code. This will return a pandas Series (one dimensional dataframe)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PSaWkwpb1BL9"
+   },
+   "outputs": [],
+   "source": [
+    "df[\"MeltingPoint\"] - 273.15"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5uQx_WLb1BL9"
+   },
+   "source": [
+    "We could do this one two columns as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "3wrRpOL41BL9"
+   },
+   "outputs": [],
+   "source": [
+    "df[[\"MeltingPoint\", \"BoilingPoint\"]] - 273.15"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VQyz3nrz1BL9"
+   },
+   "source": [
+    "We can save these in new dataframe columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rkynyMMS1BL9"
+   },
+   "outputs": [],
+   "source": [
+    "df[[\"MeltingPointC\", \"BoilingPointC\"]] = df[[\"MeltingPoint\", \"BoilingPoint\"]] - 273.15\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rJqiEad11BL9"
+   },
+   "source": [
+    "### The `.apply` method\n",
+    "\n",
+    "The `.apply` method in pandas is used to apply a function along a row or column of a dataframe.\n",
+    "This is useful when you have a custom function that you need to use on every value in a column, but there is not a NumPy or Pandas function for it.\n",
+    "\n",
+    "For example, we could apply the `len` function to our `Name` column to get the number of letters in the name for each element."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "oKzShBBv1BL-"
+   },
+   "outputs": [],
+   "source": [
+    "# Number of letters in name -\n",
+    "df[\"Name\"].apply(len)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "m_kPq_OQ1BL-"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-success\">\n",
+    "<strong>The .apply function</strong>\n",
+    "\n",
+    "Notice that when we use `.apply`, we write the <strong>name</strong> of the function we want to apply,\n",
+    "but we do not <strong>call</strong> the function.\n",
+    "If we were to call the `len` function, we would use parentheses `()` with an argument.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vzV4auDh1BL-"
+   },
+   "source": [
+    "## Using RDKit Functions with Pandas DataFrames\n",
+    "For an example more related to our work with RDKit, let's add some additional atomic data.\n",
+    "RDKit has the ability to get information about atoms.\n",
+    "We can create a periodic table with `Chem.GetPeriodicTable`, then use associated functions to get information about atoms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6qcsRNRz1BL-"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit import Chem\n",
+    "\n",
+    "# Initialize the periodic table\n",
+    "periodic_table = Chem.GetPeriodicTable()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dCrZ0fUd1BL-"
+   },
+   "source": [
+    "After we have a periodic table, we can apply functions from the periodic table to the atoms in our dataframe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PPRUFOa-1BL-"
+   },
+   "outputs": [],
+   "source": [
+    "df[\"NOuter\"] = df[\"Symbol\"].apply(periodic_table.GetNOuterElecs)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TVyJsCUL1BL-"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Exercise</h3>\n",
+    "\n",
+    "Use the `tab` key on your periodic table object to check for other values you can calculate for atoms.\n",
+    "Pick one to add to your periodic table dataset.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "BUW7mA3p1BL-"
+   },
+   "outputs": [],
+   "source": [
+    "df[\"Default_Valence\"] = df[\"Symbol\"].apply(\n",
+    "    ...\n",
+    ")  # TO DO: Find a method that will give you the default valence for an element\n",
+    "df.iloc[21:31]  # The df.iloc command lists the contents of those rows in the dataframe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AxG6533i1BL_"
+   },
+   "source": [
+    "We can save a CSV file with our newly calculated values using the `to_csv` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "hHVoMLIz1BL_"
+   },
+   "outputs": [],
+   "source": [
+    "df.to_csv(\"periodic_data_processed.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "O9IUuGGp1BL_"
+   },
+   "source": [
+    "## Visualization\n",
+    "\n",
+    "Visualizing data helps in understanding relationships and patterns that might not be apparent from raw data. Here, we will use Seaborn, a statistical visualization library, to create plots from our periodic table dataset. Seaborn is built on top of matplotlib, so if we would like to adjust any of the plots seaborn makes, we can do that through the Matplotlib interface we've used before.\n",
+    "\n",
+    "We will start with a bar plot to show the ionization energy of elements across different group blocks:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "xHvxbNcV1BL_"
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "wZ3UM43P1BL_"
+   },
+   "outputs": [],
+   "source": [
+    "sns.catplot(data=df, x=\"NOuter\", y=\"IonizationEnergy\", kind=\"bar\")\n",
+    "# Rotate x-axis labels\n",
+    "plt.xticks(rotation=45, ha=\"right\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "YMgszpBj1BL_"
+   },
+   "source": [
+    "The plot above shows us periodic trends that we learned about in introductory chemistry. The two highest ionization energy categories correspond to elements with 2 valence electrons and 8 valence electrons, representing filled shells.\n",
+    "\n",
+    "Seaborn can also allow us to easily create scatter plots to visualize relationships between continuous variables. For example, we can create a scatter plot to show the relationship between ionization energy and atomic radius:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "K2XGYxiH1BME"
+   },
+   "outputs": [],
+   "source": [
+    "sns.scatterplot(data=df, x=\"AtomicRadius\", y=\"Electronegativity\", hue=\"GroupBlock\")\n",
+    "plt.title(\"Electronegativity vs. Atomic Radius\")\n",
+    "plt.xlabel(\"Atomic Radius\")\n",
+    "plt.ylabel(\"Electronegativity\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ufsnV5FQ1BME"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Exercise</h3>\n",
+    "\n",
+    "Create a few other categorical plots to observe periodic trends:\n",
+    "\n",
+    "1. Electronegativity vs. Group Block as a bar plot.\n",
+    "\n",
+    "2. Melting Point vs. Group Block as a bar plot.\n",
+    "\n",
+    "3. Ionization Energy vs. Atomic Number as a scatter plot colored by GroupBlock.\n",
+    "   \n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2TTmY-SS1BME"
+   },
+   "outputs": [],
+   "source": [
+    "sns.barplot(\n",
+    "    data=df, x=\"\", y=\"\"\n",
+    ")  # TO DO: Remember to put the dataframe column title in quotes, but not square brackets\n",
+    "plt.title(\"Electronegativity vs. Group Block\")\n",
+    "plt.xlabel(\"Group Block\")\n",
+    "plt.ylabel(\"Electronegativity\")\n",
+    "plt.xticks(rotation=45)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "sCIw2xAh1BME"
+   },
+   "outputs": [],
+   "source": [
+    "sns.barplot(\n",
+    "    data=df, x=\"\", y=\"\"\n",
+    ")  # TO DO: Remember to put the dataframe column title in quotes, but not square brackets\n",
+    "plt.title(\"Melting Point vs. Group Block\")\n",
+    "plt.xlabel(\"Group Block\")\n",
+    "plt.ylabel(\"Melting Point\")\n",
+    "plt.xticks(rotation=45)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "vK-cP-bc1BMF"
+   },
+   "outputs": [],
+   "source": [
+    "sns.scatterplot(\n",
+    "    data=df, x=\"\", y=\"\", hue=\"GroupBlock\"\n",
+    ")  # TO DO: Remember to put the dataframe column title in quotes, but not square brackets\n",
+    "plt.title(\"Melting Point vs. Atomic Number\")\n",
+    "plt.xlabel(\"Atomic Number\")\n",
+    "plt.ylabel(\"Melting Point\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "S9QADUad1BMF"
+   },
+   "source": [
+    "### Visualizing Correlation\n",
+    "\n",
+    "A common way to visualize relationships between different categories of data categories is with a correlation plot.\n",
+    "The correlation matrix provides insights into the relationships between the variables. A correlation value close to 1 indicates a strong positive relationship, while a correlation value close to -1 indicates a strong negative relationship. A correlation value close to 0 indicates no relationship between the features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "_dbZX9Yc1BMF"
+   },
+   "outputs": [],
+   "source": [
+    "# Calculate the correlation matrix\n",
+    "corr = df.corr(numeric_only=True)\n",
+    "corr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mhVE4b_D1BMF"
+   },
+   "source": [
+    "Seaborn can be used to create a heatmap to allow easier examination of the correlation of different variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "_7urDyWr1BMF"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a heatmap\n",
+    "plt.figure(figsize=(10, 8))\n",
+    "sns.heatmap(corr, annot=True, cmap=\"coolwarm\", fmt=\".2f\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eCsmiHY01BMF"
+   },
+   "source": [
+    "The heatmap uses a \"coolwarm\" color scheme where red indicates positive correlation and blue indicates negative correlation between variables. Strongly correlated pairs are represented by darker shades of red, while strongly inversely correlated pairs are represented by darker shades of blue."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ZIArXkd41BMF"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Final Challenge</h3>\n",
+    "\n",
+    "For this challenge, you will retrieve a file called `amino_acids.txt` that contains SMILES for the 20 naturally occurring amino acids. Your task for the final challenge of today is to combine skills and concepts you have learned today to build a dataframe for molecules and write a file. Your goal is to create a comma-separated value file with columns `SMILES`, `num_heavy` (number of heavy atoms), `molecular_weight`, and one other molecular descriptor of your choice for the molecules in the file.\n",
+    "\n",
+    "For this task, you will need to complete the following steps. The first three steps are already completed.\n",
+    "\n",
+    "1. Retrieve the file amino_acids.txt.\n",
+    "1. Read the data in the file and place the SMILES strings in a list.\n",
+    "1. Create a pandas dataframe, aadf, with the SMILES string as the first column.\n",
+    "1. Use the .apply function to add a new column to aadf that contains an RDKit mol object for each of the SMILES strings.\n",
+    "1. Use the .apply function to then add a column with the number of heavy atoms, a column with the molecular weight and a column with one other molecular descriptor of your choice for each molecule in aadf.\n",
+    "1. Save your file as `data/amino_acids_processed.csv`.\n",
+    "\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Eqve_OjC1BMF"
+   },
+   "source": [
+    "### Read SMILES from a text file\n",
+    "I will use the ```with open``` command to do this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "7ujrXpeB1BMG"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit import Chem\n",
+    "import pandas as pd\n",
+    "from rdkit.Chem import PandasTools\n",
+    "\n",
+    "## This cell is provided for the challenge\n",
+    "\n",
+    "# Ensure molecules are rendered in the notebook\n",
+    "PandasTools.RenderImagesInAllDataFrames(images=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zYBJIN5w3fPi"
+   },
+   "outputs": [],
+   "source": [
+    "url = \"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/amino_acids.txt\"\n",
+    "filename = \"amino_acids.txt\"\n",
+    "urlretrieve(url, filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "QA2YrDGV1BMG"
+   },
+   "outputs": [],
+   "source": [
+    "url = \"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/amino_acids.txt\"\n",
+    "aa_file = \"amino_acids.txt\"\n",
+    "urlretrieve(url, aa_file)\n",
+    "\n",
+    "with open(aa_file, \"r\") as outfile:\n",
+    "    aasmiles = outfile.readlines()\n",
+    "\n",
+    "aasmiles_strip = []\n",
+    "for smiles in aasmiles:\n",
+    "    smiles = smiles.strip()\n",
+    "    aasmiles_strip.append(smiles)\n",
+    "\n",
+    "print(aasmiles_strip)\n",
+    "\n",
+    "aadf = pd.DataFrame({\"SMILES\": aasmiles_strip})\n",
+    "\n",
+    "aadf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Rbb47-d51BMG"
+   },
+   "source": [
+    "### Make an RDKit molecule for each SMILES\n",
+    "I did this before. This time, I'll add the SMILES string to the dataframe first, then use the apply function to create the RDKit molecules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Bgi3HQaP1BMG"
+   },
+   "outputs": [],
+   "source": [
+    "# Create the list of molecules\n",
+    "\n",
+    "aadf[\"Molecule\"] = aadf[\"SMILES\"].apply(Chem.MolFromSmiles)\n",
+    "aadf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Sx5jiRo31BMG"
+   },
+   "source": [
+    "### Write a file with the data\n",
+    "\n",
+    "Generate a .csv file from aadf."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "LjuP7LKJ1BMG"
+   },
+   "outputs": [],
+   "source": [
+    "outputfile = \"amino_acids_processed.csv\"\n",
+    "aadf.to_csv(outputfile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "QKdmd8V-1BMH"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/prep/Filled_Notebooks/A_python_basics.ipynb
+++ b/prep/Filled_Notebooks/A_python_basics.ipynb
@@ -1,787 +1,795 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Z441pTAW6Q1z"
-      },
-      "source": [
-        "\n",
-        "\n",
-        "<img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
-        "\n",
-        "# Introduction to Python\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "<h2>Overview</h2>\n",
-        "\n",
-        "Questions:\n",
-        "\n",
-        "* What is the Python programming language, and what is it used for?\n",
-        "\n",
-        "* What is the basic syntax of the Python programming language?\n",
-        "    \n",
-        "* What is a Python list?\n",
-        "    \n",
-        "* What is a Python dictionary?\n",
-        "    \n",
-        "* What is a `for` loop?\n",
-        "\n",
-        "Objectives:\n",
-        "\n",
-        "* Assign values to variables.\n",
-        "\n",
-        "* Use the `print` function to check how the code is working.\n",
-        "    \n",
-        "* Use a `for` loop to perform the same action on all the items in a list.\n",
-        "    \n",
-        "* Use the append function to create new lists in `for` loops.\n",
-        "\n",
-        "</div>\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "q4M4KDTS6Q11"
-      },
-      "source": [
-        "## What is Python and why use it?\n",
-        "\n",
-        "All of the software you use on a regular basis is created through the use of programming languages.\n",
-        "Programming languages allow us to write instructions to a computer.\n",
-        "There are many different programming languages, each with their own strengths, weaknesses, and uses.\n",
-        "Some popular programming languages you might hear about are Javascript (used on the web - any website with interactive content likely uses javascript), Python (scientific programming and many other applications), C++ (high performance applications - much of computational chemistry, self-driving cars, etc), SQL (databases), and many more.\n",
-        "\n",
-        "Python is a computer programming language that has become ubiquitous in scientific programming.\n",
-        "The Python programming language was first introduced in the year 1991, and has grown to be one of the most popular programming languages for both scientists and non-scientists.\n",
-        "According to the [2022 Stack Overflow Developer Survey](https://survey.stackoverflow.co/2022/#most-popular-technologies-language-prof), Python is the fourth most popular programming language.\n",
-        "Compared to other programming languages, Python is considered more intutitive to start learning and is also extremely versatile.\n",
-        "Python can be used to build web applications, interact with databases, and calculate and analyze data.\n",
-        "Python also has many libraries focused on science and machine learning.\n",
-        "\n",
-        "In computational chemistry, we will see that we can use Python to run and analyze our simulations.\n",
-        "We can also use some of Python's many libraries to fit data and predict properties.\n",
-        "\n",
-        "## Getting Started\n",
-        "\n",
-        "Our initial lessons will run python interactively through a Python interpreter.\n",
-        "We will use an environment called a Jupyter notebook.\n",
-        "The Jupyter notebook is an environment in your browser that can be used to write an execute Python code interactively.\n",
-        "You can view a Jupyter notebook using your browser or in some specialized text editors.\n",
-        "\n",
-        "Jupyter notebooks are made up of cells. Cells can either be markdown or code cells.\n",
-        "This cell is a Markdown Cell.\n",
-        "Code cells have executable Python code in them.\n",
-        "To change the type of a cell you can use the drop down option in the top window.\n",
-        "To run code in a cell, click inside of the cell and press `Shift+Enter`.\n",
-        "If the code executes successfully, the next cell will become the active cell.\n",
-        "\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EwBz5gji6Q11"
-      },
-      "source": [
-        "## Assigning variables\n",
-        "\n",
-        "Any Python interpreter can work just like a calculator.\n",
-        "This is not very useful.\n",
-        "Press the Shift Key and the Enter Key (`Shift + Enter`) at the same time to run (also called \"execute\") the code in a cell.\n",
-        "The following cell contains an expression to calculate `3 + 7`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "_e1DP-Li6Q12"
-      },
-      "outputs": [],
-      "source": [
-        " 3 + 7           # TO DO: Enter 3 + 7 in this cell and hit the play button or shift/return"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "IQb59E2u6Q12"
-      },
-      "source": [
-        "Here, Python has performed a calculation for us. To save this value, or other values, we assign them to a variable for later use.\n",
-        "Variable **assignment** is the technical term for doing this.\n",
-        "If we do not assign an expression to a variable, we will not be able to use its value later.\n",
-        "\n",
-        "The syntax for assigning variables is the following:\n",
-        "\n",
-        "```python\n",
-        "variable_name = varaible_value\n",
-        "```\n",
-        "\n",
-        "Let’s see this in action with a calculation.\n",
-        "Let's define some variables for our calculation.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "0yLHF6xQ6Q13"
-      },
-      "outputs": [],
-      "source": [
-        "deltaH = -541.5   #kJ/mole\n",
-        "deltaS =  10.4     #kJ/(mole K)\n",
-        "temp = 298      #Kelvin\n",
-        "deltaG = deltaH - temp * deltaS"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Cp2Kbg7N6Q13"
-      },
-      "source": [
-        "Notice several things about this code.\n",
-        "The lines that begin with # are comment lines.\n",
-        "The computer does not do anything with these comments.\n",
-        "They have been used here to remind the user what units each of their values are in.\n",
-        "Comments are also often used to explain what the code is doing or leave information for future people who might use the code.\n",
-        "\n",
-        "When choosing variable names, you should choose informative names so that someone reading your code can tell what they represent. Naming a variable temp or temperature is much more informative than naming that variable t.\n",
-        "\n",
-        "We can now access any of the variables from other cells. Let’s print the value that we calculated.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "rwh5dZHt6Q13"
-      },
-      "outputs": [],
-      "source": [
-        "print(deltaG)          # TO DO: enter the name of the variable whose value you want to know"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bEqyDx4W6Q13"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<strong>Check your understanding</strong>\n",
-        "    \n",
-        "Write Python code to calculate the pressure of 1 mol of nitrogen gas in a sealed container with volume 10 L at 273.15 K using the Ideal Gas Law. Use R=0.0821 L·atm/mol·K for your gas constant.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ac6oW9UJ6Q14"
-      },
-      "outputs": [],
-      "source": [
-        "n = 1 # mol of nitrogen gas                    # TO DO: Declare variables for all the know values for this problem\n",
-        "V = 10 # L\n",
-        "T = 273.15 # K\n",
-        "R = 0.0821 # L*atm/mol*K\n",
-        "P =  n * R * T / V               # TO DO: Use the ideal gas law to solve this problem\n",
-        "print(P)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "4JQ7fz776Q14"
-      },
-      "outputs": [],
-      "source": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3cwZnFar6Q14"
-      },
-      "source": [
-        "## Using Functions\n",
-        "\n",
-        "When we use `print`, we are using a `function`.\n",
-        "Functions are reusable pieces of code that perform certain tasks.\n",
-        "Examples include printing, opening files, performing a calculations, and many others.\n",
-        "Functions have a name that is followed by parenthesis containing the function inputs separated by commas (also called *arguments*).\n",
-        "\n",
-        "```python\n",
-        "function_name(argument1, argument2)\n",
-        "```\n",
-        "\n",
-        "In the previous code block, we introduced the `print` function. Often, we will use the print function just to make sure our code is working correctly.\n",
-        "\n",
-        "Note that if you do not specify a new name for a variable, then it doesn’t automatically change the value of the variable. For example if we typed"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "e3JOtxYk6Q15"
-      },
-      "outputs": [],
-      "source": [
-        "print(deltaG)\n",
-        "deltaG * 1000\n",
-        "print(deltaG)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3fOYQXvk6Q15"
-      },
-      "source": [
-        "Nothing happened to the value of deltaG. If we wanted to change the value of deltaG we would have to re-save the variable using the same name to overwrite the existing value."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "xjWwm0-I6Q15"
-      },
-      "outputs": [],
-      "source": [
-        "print(deltaG)\n",
-        "deltaG = deltaG * 1000\n",
-        "print(deltaG)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rvzkK-s16Q15"
-      },
-      "source": [
-        "There are situations where it is reasonable to overwrite a variable with a new value, but you should always think carefully about this. Usually it is a better practice to give the variable a new name and leave the existing variable as is."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "NEdXe7IV6Q15"
-      },
-      "outputs": [],
-      "source": [
-        "deltaG = deltaH - temp * deltaS         # This will reset the value of deltaG to reflect units of kilojoules\n",
-        "deltaG_joules = deltaG * 1000\n",
-        "print(deltaG)\n",
-        "print(deltaG_joules)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "U4IEpMO76Q15"
-      },
-      "source": [
-        "## Data Types\n",
-        "\n",
-        "Each variable is some particular type of data.\n",
-        "The most common types of data are strings (str),\n",
-        "integers (int), and floating point numbers (float).\n",
-        "You can identify the data type of any variable with the function `type(variable_name)`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "dxzyV0Ei6Q16"
-      },
-      "outputs": [],
-      "source": [
-        "type(deltaG)          # TO DO: Enter the variable whose value you want to know in the parentheses"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oLlD2SeW6Q16"
-      },
-      "source": [
-        "You can change the data type of a variable like this. This is called casting."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "zAQ48wXN6Q16"
-      },
-      "outputs": [],
-      "source": [
-        "deltaG_string = str(deltaG)\n",
-        "type(deltaG_string)           # # TO DO: Enter the variable whose type you want to know in the parentheses"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5wb7zLds6Q16"
-      },
-      "source": [
-        "We could have created a variable as a string originally by surrounding the value in quotes `\"\"`. It doesn't matter if you use single or double quotes, the first quote just has to match the closing quote."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "DKlZnioW6Q16"
-      },
-      "outputs": [],
-      "source": [
-        "string_variable = \"This is a string\"\n",
-        "print(type(string_variable))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Obx4E1yr6Q16"
-      },
-      "source": [
-        "## Lists\n",
-        "\n",
-        "Another common data structure in python is the list. Lists can be used to group several values or variables together, and are declared using square brackets `[ ]`.\n",
-        "List values are separated by commas.\n",
-        "Python has several built in functions which can be used on lists.\n",
-        "The built-in function `len` can be used to determine the length of a list.\n",
-        "This code block also demonstrates how to print multiple variables."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "5FUptHHh6Q16"
-      },
-      "outputs": [],
-      "source": [
-        "# This is a list\n",
-        "\n",
-        "energy_kcal = [-13.4, -2.7, 5.4, 42.1]\n",
-        "\n",
-        "\n",
-        "# I can determine its length\n",
-        "energy_length = len(energy_kcal)                     # # TO DO: Enter the list variable whose length you want to know in the parentheses\n",
-        "\n",
-        "# print the list length\n",
-        "\n",
-        "print('The length of this list is', energy_length)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wLfRsTv26Q16"
-      },
-      "source": [
-        "If I want to operate on a particular element of the list, you use the list name and then put in brackets which element of the list you want. In python counting starts at zero. So the first element of the list is list[0]."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "GuL4Wrc06Q17"
-      },
-      "outputs": [],
-      "source": [
-        "# Print the first element of the list\n",
-        "print(energy_kcal[0])                  # TO DO: Enter the number for the first element in the list"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "MNzJlt3j6Q17"
-      },
-      "source": [
-        "You can use an element of a list as a variable in a calculation."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "-CnmuFrV6Q17"
-      },
-      "outputs": [],
-      "source": [
-        "# Convert the second list element to kilojoules.\n",
-        "energy_kilojoules = energy_kcal[1] * 4.184\n",
-        "print(energy_kilojoules)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5uGB4iwf6Q17"
-      },
-      "source": [
-        "### Slices\n",
-        "\n",
-        "Sometimes you will want to make a new list that is a subset of an existing list. For example, we might want to make a new list that is just the first few elements of our previous list. This is called a slice. The general syntax is\n",
-        "\n",
-        "```python\n",
-        "new_list = list_name[start:end]\n",
-        "```\n",
-        "\n",
-        "When taking a slice, it is very important to remember how counting works in python. Remember that counting starts at zero so the first element of a list is `list_name[0]`. When you specify the last element for the slice, it goes *up to but not including* that element of the list. So a slice like\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "vPeEme_t6Q17"
-      },
-      "outputs": [],
-      "source": [
-        "short_list = energy_kcal[0:2]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "W9TzLj2n6Q17"
-      },
-      "source": [
-        "includes energy_kcal[0] and energy_kcal[1] but not energy_kcal[2].\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "8iudc3W46Q17"
-      },
-      "outputs": [],
-      "source": [
-        "print(short_list)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EN3gzR0Q6Q18"
-      },
-      "source": [
-        "If you do not include a start index, the slice automatically starts at list_name[0]. If you do not include an end index, the slice automatically goes to the end of the list.\n",
-        "\n",
-        "\n",
-        "<div class=\"exercise admonition\">\n",
-        "<p class=\"admonition-title\">Check Your Understanding</p>\n",
-        "\n",
-        "What does the following code block print?\n",
-        "```python\n",
-        "slice1 = energy_kcal[1:]\n",
-        "slice2 = energy_kcal[:3]\n",
-        "print('slice1 is', slice1)\n",
-        "print('slice2 is', slice2)\n",
-        "```\n",
-        "\n",
-        "<div class=\"solution admonition dropdown\">\n",
-        "<p class=\"admonition-title\">Solution</p>\n",
-        "\n",
-        "The code prints\n",
-        "\n",
-        "```output\n",
-        "slice1 is [-2.7, 5.4, 42.1]\n",
-        "slice2 is [-13.4, -2.7, 5.4]\n",
-        "```\n",
-        "\n",
-        "</div>\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "A4cQRftf6Q18"
-      },
-      "source": [
-        "## Repeating an operation many times: for loops\n",
-        "\n",
-        "Often, you will want to do something to every element of a list. The structure to do this is called a for loop. The general structure of a for loop is\n",
-        "\n",
-        "```python\n",
-        "for variable in list:\n",
-        "    do things using variable\n",
-        "\n",
-        "```\n",
-        "\n",
-        "There are two very important pieces of syntax for the for loop. Notice the colon : after the word list. You will always have a colon at the end of a for statement. If you forget the colon, you will get an error when you try to run your code.\n",
-        "\n",
-        "The second thing to notice is that the lines of code under the for loop (the things you want to do several times) are indented. Indentation is very important in python. There is nothing like an end or exit statement that tells you that you are finished with the loop. The indentation shows you what statements are in the loop. Each indentation is 4 spaces by convention in Python 3. However, if you are using an editor which understands Python, it will do the correct indentation for you when you press the tab key on your keyboard. In fact, the Jupyter notebook will notice that you used a colon (`:`) in the previous line, and will indent for you (so you will not need to press tab).\n",
-        "\n",
-        "Let’s use a loop to change all of our energies in kcal to kJ.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "0vZUvpoJ6Q18"
-      },
-      "outputs": [],
-      "source": [
-        "for number in energy_kcal:\n",
-        "    kJ = number * 4.184\n",
-        "    print(kJ)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jY6muhcv6Q18"
-      },
-      "source": [
-        "Now it seems like we are really getting somewhere with our program! But it would be even better if instead of just printing the values, it saved them in a new list. To do this, we are going to use the append function. The append function adds a new item to the end of an existing list. The general form of the append function is\n",
-        "\n",
-        "```python\n",
-        "list_name.append(new_thing)\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "Sj8oxoGW6Q18"
-      },
-      "outputs": [],
-      "source": [
-        "for number in energy_kcal:\n",
-        "    kJ = number * 4.184\n",
-        "    energy_kJ.append(kJ)\n",
-        "\n",
-        "print(energy_kJ)\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "zoOiQhhL6Q18"
-      },
-      "source": [
-        "This is an example of an error message. An error message is what occurs if there is something wrong with your code.\n",
-        "In Python, when you read error messagees, you should try to read the last line of the error message first.\n",
-        "It will have a message about what went wrong in the program execution.\n",
-        "\n",
-        "This code doesn’t work because on the first iteration of our loop, the list energy_kJ doesn’t exist. To make it work, we have to start the list outside of the loop. The list can be blank when we start it, but we have to start it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "lwtrAAp56Q2B"
-      },
-      "outputs": [],
-      "source": [
-        "energy_kJ = []                          # TO DO: When you declare a list variable, it must have square brackets, even for an empty list\n",
-        "for number in energy_kcal:\n",
-        "    kJ = number * 4.184\n",
-        "    energy_kJ.append(kJ)\n",
-        "\n",
-        "print(energy_kJ)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7Jca6K4H6Q2B"
-      },
-      "source": [
-        "## Making choices: logic statements\n",
-        "\n",
-        "Within your code, you may need to evaluate a variable and then do something if the variable has a particular value. This type of logic is handled by an if statement. In the following example, we only append the negative numbers to a new list."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "JVkY9icZ6Q2C"
-      },
-      "outputs": [],
-      "source": [
-        "negative_energy_kJ = []\n",
-        "\n",
-        "for number in energy_kJ:\n",
-        "    if number < 0:\n",
-        "        negative_energy_kJ.append(number)\n",
-        "\n",
-        "print(negative_energy_kJ)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FOFy7HFw6Q2C"
-      },
-      "source": [
-        "Other logic operations include\n",
-        "\n",
-        "* equal to `==`\n",
-        "* not equal to `!=`\n",
-        "* greater than `>`\n",
-        "* less than `<`\n",
-        "* greater than or equal to `>=`\n",
-        "* less than or equal to `<=`\n",
-        "\n",
-        "You can also use and, or, and not to check more than one condition.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "VIG-Xhhy6Q2C"
-      },
-      "outputs": [],
-      "source": [
-        "negative_numbers = []\n",
-        "for number in energy_kJ:\n",
-        "    if number < 0 or number == 0:\n",
-        "        negative_numbers.append(number)\n",
-        "\n",
-        "print(negative_numbers)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "shYOnOjN6Q2C"
-      },
-      "source": [
-        "To define what happens if the `if` statement is not met, you can use the `else` keyword."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "tags": [],
-        "id": "1nCZFepn6Q2C"
-      },
-      "outputs": [],
-      "source": [
-        "negative_numbers = []\n",
-        "positive_numbers = []\n",
-        "for number in energy_kJ:\n",
-        "    if number < 0 or number == 0:\n",
-        "        negative_numbers.append(number)\n",
-        "    else:\n",
-        "        positive_numbers.append(number)\n",
-        "\n",
-        "print(\"Negative numbers:\", negative_numbers)\n",
-        "print(\"Positive Numbers: \", positive_numbers)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "tags": [],
-        "id": "TbKB6K6U6Q2C"
-      },
-      "source": [
-        "## Formatted Strings\n",
-        "\n",
-        "Throughout the lesson we will sometimes use a special kind of string called a \"formatted string\". A formatted string is a string that has a variable in it.\n",
-        "To make a formatted string, you start your string with an `f`, and put variable names in curly braces."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "zj1Y6sZ86Q2C"
-      },
-      "outputs": [],
-      "source": [
-        "my_string = f\"The positive numbers are {positive_numbers}.\"\n",
-        "print(my_string)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "AkpawsHC6Q2D"
-      },
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.2"
-    },
-    "vscode": {
-      "interpreter": {
-        "hash": "16d4a7bb199d969b1271ebe46f77414b0d9cd01b3c3983c2b2742fc6cd4503d3"
-      }
-    },
-    "colab": {
-      "provenance": []
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Z441pTAW6Q1z"
+   },
+   "source": [
+    "\n",
+    "\n",
+    "<img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+    "\n",
+    "# Introduction to Python\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2>Overview</h2>\n",
+    "\n",
+    "Questions:\n",
+    "\n",
+    "* What is the Python programming language, and what is it used for?\n",
+    "\n",
+    "* What is the basic syntax of the Python programming language?\n",
+    "    \n",
+    "* What is a Python list?\n",
+    "    \n",
+    "* What is a Python dictionary?\n",
+    "    \n",
+    "* What is a `for` loop?\n",
+    "\n",
+    "Objectives:\n",
+    "\n",
+    "* Assign values to variables.\n",
+    "\n",
+    "* Use the `print` function to check how the code is working.\n",
+    "    \n",
+    "* Use a `for` loop to perform the same action on all the items in a list.\n",
+    "    \n",
+    "* Use the append function to create new lists in `for` loops.\n",
+    "\n",
+    "</div>\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "q4M4KDTS6Q11"
+   },
+   "source": [
+    "## What is Python and why use it?\n",
+    "\n",
+    "All of the software you use on a regular basis is created through the use of programming languages.\n",
+    "Programming languages allow us to write instructions to a computer.\n",
+    "There are many different programming languages, each with their own strengths, weaknesses, and uses.\n",
+    "Some popular programming languages you might hear about are Javascript (used on the web - any website with interactive content likely uses javascript), Python (scientific programming and many other applications), C++ (high performance applications - much of computational chemistry, self-driving cars, etc), SQL (databases), and many more.\n",
+    "\n",
+    "Python is a computer programming language that has become ubiquitous in scientific programming.\n",
+    "The Python programming language was first introduced in the year 1991, and has grown to be one of the most popular programming languages for both scientists and non-scientists.\n",
+    "According to the [2022 Stack Overflow Developer Survey](https://survey.stackoverflow.co/2022/#most-popular-technologies-language-prof), Python is the fourth most popular programming language.\n",
+    "Compared to other programming languages, Python is considered more intutitive to start learning and is also extremely versatile.\n",
+    "Python can be used to build web applications, interact with databases, and calculate and analyze data.\n",
+    "Python also has many libraries focused on science and machine learning.\n",
+    "\n",
+    "In computational chemistry, we will see that we can use Python to run and analyze our simulations.\n",
+    "We can also use some of Python's many libraries to fit data and predict properties.\n",
+    "\n",
+    "## Getting Started\n",
+    "\n",
+    "Our initial lessons will run python interactively through a Python interpreter.\n",
+    "We will use an environment called a Jupyter notebook.\n",
+    "The Jupyter notebook is an environment in your browser that can be used to write an execute Python code interactively.\n",
+    "You can view a Jupyter notebook using your browser or in some specialized text editors.\n",
+    "\n",
+    "Jupyter notebooks are made up of cells. Cells can either be markdown or code cells.\n",
+    "This cell is a Markdown Cell.\n",
+    "Code cells have executable Python code in them.\n",
+    "To change the type of a cell you can use the drop down option in the top window.\n",
+    "To run code in a cell, click inside of the cell and press `Shift+Enter`.\n",
+    "If the code executes successfully, the next cell will become the active cell.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EwBz5gji6Q11"
+   },
+   "source": [
+    "## Assigning variables\n",
+    "\n",
+    "Any Python interpreter can work just like a calculator.\n",
+    "This is not very useful.\n",
+    "Press the Shift Key and the Enter Key (`Shift + Enter`) at the same time to run (also called \"execute\") the code in a cell.\n",
+    "The following cell contains an expression to calculate `3 + 7`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "_e1DP-Li6Q12",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "3 + 7  # TO DO: Enter 3 + 7 in this cell and hit the play button or shift/return"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "IQb59E2u6Q12"
+   },
+   "source": [
+    "Here, Python has performed a calculation for us. To save this value, or other values, we assign them to a variable for later use.\n",
+    "Variable **assignment** is the technical term for doing this.\n",
+    "If we do not assign an expression to a variable, we will not be able to use its value later.\n",
+    "\n",
+    "The syntax for assigning variables is the following:\n",
+    "\n",
+    "```python\n",
+    "variable_name = varaible_value\n",
+    "```\n",
+    "\n",
+    "Let’s see this in action with a calculation.\n",
+    "Let's define some variables for our calculation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "0yLHF6xQ6Q13",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "deltaH = -541.5  # kJ/mole\n",
+    "deltaS = 10.4  # kJ/(mole K)\n",
+    "temp = 298  # Kelvin\n",
+    "deltaG = deltaH - temp * deltaS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Cp2Kbg7N6Q13"
+   },
+   "source": [
+    "Notice several things about this code.\n",
+    "The lines that begin with # are comment lines.\n",
+    "The computer does not do anything with these comments.\n",
+    "They have been used here to remind the user what units each of their values are in.\n",
+    "Comments are also often used to explain what the code is doing or leave information for future people who might use the code.\n",
+    "\n",
+    "When choosing variable names, you should choose informative names so that someone reading your code can tell what they represent. Naming a variable temp or temperature is much more informative than naming that variable t.\n",
+    "\n",
+    "We can now access any of the variables from other cells. Let’s print the value that we calculated.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rwh5dZHt6Q13",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(deltaG)  # TO DO: enter the name of the variable whose value you want to know"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bEqyDx4W6Q13"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<strong>Check your understanding</strong>\n",
+    "    \n",
+    "Write Python code to calculate the pressure of 1 mol of nitrogen gas in a sealed container with volume 10 L at 273.15 K using the Ideal Gas Law. Use R=0.0821 L·atm/mol·K for your gas constant.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ac6oW9UJ6Q14"
+   },
+   "outputs": [],
+   "source": [
+    "n = 1  # mol of nitrogen gas                    # TO DO: Declare variables for all the know values for this problem\n",
+    "V = 10  # L\n",
+    "T = 273.15  # K\n",
+    "R = 0.0821  # L*atm/mol*K\n",
+    "P = n * R * T / V  # TO DO: Use the ideal gas law to solve this problem\n",
+    "print(P)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "4JQ7fz776Q14"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3cwZnFar6Q14"
+   },
+   "source": [
+    "## Using Functions\n",
+    "\n",
+    "When we use `print`, we are using a `function`.\n",
+    "Functions are reusable pieces of code that perform certain tasks.\n",
+    "Examples include printing, opening files, performing a calculations, and many others.\n",
+    "Functions have a name that is followed by parenthesis containing the function inputs separated by commas (also called *arguments*).\n",
+    "\n",
+    "```python\n",
+    "function_name(argument1, argument2)\n",
+    "```\n",
+    "\n",
+    "In the previous code block, we introduced the `print` function. Often, we will use the print function just to make sure our code is working correctly.\n",
+    "\n",
+    "Note that if you do not specify a new name for a variable, then it doesn’t automatically change the value of the variable. For example if we typed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "e3JOtxYk6Q15",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(deltaG)\n",
+    "deltaG * 1000\n",
+    "print(deltaG)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3fOYQXvk6Q15"
+   },
+   "source": [
+    "Nothing happened to the value of deltaG. If we wanted to change the value of deltaG we would have to re-save the variable using the same name to overwrite the existing value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "xjWwm0-I6Q15",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(deltaG)\n",
+    "deltaG = deltaG * 1000\n",
+    "print(deltaG)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rvzkK-s16Q15"
+   },
+   "source": [
+    "There are situations where it is reasonable to overwrite a variable with a new value, but you should always think carefully about this. Usually it is a better practice to give the variable a new name and leave the existing variable as is."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NEdXe7IV6Q15",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "deltaG = (\n",
+    "    deltaH - temp * deltaS\n",
+    ")  # This will reset the value of deltaG to reflect units of kilojoules\n",
+    "deltaG_joules = deltaG * 1000\n",
+    "print(deltaG)\n",
+    "print(deltaG_joules)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "U4IEpMO76Q15"
+   },
+   "source": [
+    "## Data Types\n",
+    "\n",
+    "Each variable is some particular type of data.\n",
+    "The most common types of data are strings (str),\n",
+    "integers (int), and floating point numbers (float).\n",
+    "You can identify the data type of any variable with the function `type(variable_name)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "dxzyV0Ei6Q16",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "type(\n",
+    "    deltaG\n",
+    ")  # TO DO: Enter the variable whose value you want to know in the parentheses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "oLlD2SeW6Q16"
+   },
+   "source": [
+    "You can change the data type of a variable like this. This is called casting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zAQ48wXN6Q16",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "deltaG_string = str(deltaG)\n",
+    "type(\n",
+    "    deltaG_string\n",
+    ")  # # TO DO: Enter the variable whose type you want to know in the parentheses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5wb7zLds6Q16"
+   },
+   "source": [
+    "We could have created a variable as a string originally by surrounding the value in quotes `\"\"`. It doesn't matter if you use single or double quotes, the first quote just has to match the closing quote."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "DKlZnioW6Q16",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "string_variable = \"This is a string\"\n",
+    "print(type(string_variable))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Obx4E1yr6Q16"
+   },
+   "source": [
+    "## Lists\n",
+    "\n",
+    "Another common data structure in python is the list. Lists can be used to group several values or variables together, and are declared using square brackets `[ ]`.\n",
+    "List values are separated by commas.\n",
+    "Python has several built in functions which can be used on lists.\n",
+    "The built-in function `len` can be used to determine the length of a list.\n",
+    "This code block also demonstrates how to print multiple variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "5FUptHHh6Q16",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# This is a list\n",
+    "\n",
+    "energy_kcal = [-13.4, -2.7, 5.4, 42.1]\n",
+    "\n",
+    "\n",
+    "# I can determine its length\n",
+    "energy_length = len(\n",
+    "    energy_kcal\n",
+    ")  # # TO DO: Enter the list variable whose length you want to know in the parentheses\n",
+    "\n",
+    "# print the list length\n",
+    "\n",
+    "print(\"The length of this list is\", energy_length)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wLfRsTv26Q16"
+   },
+   "source": [
+    "If I want to operate on a particular element of the list, you use the list name and then put in brackets which element of the list you want. In python counting starts at zero. So the first element of the list is list[0]."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "GuL4Wrc06Q17",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Print the first element of the list\n",
+    "print(energy_kcal[0])  # TO DO: Enter the number for the first element in the list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MNzJlt3j6Q17"
+   },
+   "source": [
+    "You can use an element of a list as a variable in a calculation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-CnmuFrV6Q17",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Convert the second list element to kilojoules.\n",
+    "energy_kilojoules = energy_kcal[1] * 4.184\n",
+    "print(energy_kilojoules)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5uGB4iwf6Q17"
+   },
+   "source": [
+    "### Slices\n",
+    "\n",
+    "Sometimes you will want to make a new list that is a subset of an existing list. For example, we might want to make a new list that is just the first few elements of our previous list. This is called a slice. The general syntax is\n",
+    "\n",
+    "```python\n",
+    "new_list = list_name[start:end]\n",
+    "```\n",
+    "\n",
+    "When taking a slice, it is very important to remember how counting works in python. Remember that counting starts at zero so the first element of a list is `list_name[0]`. When you specify the last element for the slice, it goes *up to but not including* that element of the list. So a slice like\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "vPeEme_t6Q17",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "short_list = energy_kcal[0:2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "W9TzLj2n6Q17"
+   },
+   "source": [
+    "includes energy_kcal[0] and energy_kcal[1] but not energy_kcal[2].\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "8iudc3W46Q17",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(short_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EN3gzR0Q6Q18"
+   },
+   "source": [
+    "If you do not include a start index, the slice automatically starts at list_name[0]. If you do not include an end index, the slice automatically goes to the end of the list.\n",
+    "\n",
+    "\n",
+    "<div class=\"exercise admonition\">\n",
+    "<p class=\"admonition-title\">Check Your Understanding</p>\n",
+    "\n",
+    "What does the following code block print?\n",
+    "```python\n",
+    "slice1 = energy_kcal[1:]\n",
+    "slice2 = energy_kcal[:3]\n",
+    "print('slice1 is', slice1)\n",
+    "print('slice2 is', slice2)\n",
+    "```\n",
+    "\n",
+    "<div class=\"solution admonition dropdown\">\n",
+    "<p class=\"admonition-title\">Solution</p>\n",
+    "\n",
+    "The code prints\n",
+    "\n",
+    "```output\n",
+    "slice1 is [-2.7, 5.4, 42.1]\n",
+    "slice2 is [-13.4, -2.7, 5.4]\n",
+    "```\n",
+    "\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "A4cQRftf6Q18"
+   },
+   "source": [
+    "## Repeating an operation many times: for loops\n",
+    "\n",
+    "Often, you will want to do something to every element of a list. The structure to do this is called a for loop. The general structure of a for loop is\n",
+    "\n",
+    "```python\n",
+    "for variable in list:\n",
+    "    do things using variable\n",
+    "\n",
+    "```\n",
+    "\n",
+    "There are two very important pieces of syntax for the for loop. Notice the colon : after the word list. You will always have a colon at the end of a for statement. If you forget the colon, you will get an error when you try to run your code.\n",
+    "\n",
+    "The second thing to notice is that the lines of code under the for loop (the things you want to do several times) are indented. Indentation is very important in python. There is nothing like an end or exit statement that tells you that you are finished with the loop. The indentation shows you what statements are in the loop. Each indentation is 4 spaces by convention in Python 3. However, if you are using an editor which understands Python, it will do the correct indentation for you when you press the tab key on your keyboard. In fact, the Jupyter notebook will notice that you used a colon (`:`) in the previous line, and will indent for you (so you will not need to press tab).\n",
+    "\n",
+    "Let’s use a loop to change all of our energies in kcal to kJ.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "0vZUvpoJ6Q18",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for number in energy_kcal:\n",
+    "    kJ = number * 4.184\n",
+    "    print(kJ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jY6muhcv6Q18"
+   },
+   "source": [
+    "Now it seems like we are really getting somewhere with our program! But it would be even better if instead of just printing the values, it saved them in a new list. To do this, we are going to use the append function. The append function adds a new item to the end of an existing list. The general form of the append function is\n",
+    "\n",
+    "```python\n",
+    "list_name.append(new_thing)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Sj8oxoGW6Q18",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for number in energy_kcal:\n",
+    "    kJ = number * 4.184\n",
+    "    energy_kJ.append(kJ)  # noqa:F821\n",
+    "\n",
+    "print(energy_kJ)  # noqa:F821"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zoOiQhhL6Q18"
+   },
+   "source": [
+    "This is an example of an error message. An error message is what occurs if there is something wrong with your code.\n",
+    "In Python, when you read error messagees, you should try to read the last line of the error message first.\n",
+    "It will have a message about what went wrong in the program execution.\n",
+    "\n",
+    "This code doesn’t work because on the first iteration of our loop, the list energy_kJ doesn’t exist. To make it work, we have to start the list outside of the loop. The list can be blank when we start it, but we have to start it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "lwtrAAp56Q2B",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "energy_kJ = []  # TO DO: When you declare a list variable, it must have square brackets, even for an empty list\n",
+    "for number in energy_kcal:\n",
+    "    kJ = number * 4.184\n",
+    "    energy_kJ.append(kJ)\n",
+    "\n",
+    "print(energy_kJ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7Jca6K4H6Q2B"
+   },
+   "source": [
+    "## Making choices: logic statements\n",
+    "\n",
+    "Within your code, you may need to evaluate a variable and then do something if the variable has a particular value. This type of logic is handled by an if statement. In the following example, we only append the negative numbers to a new list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "JVkY9icZ6Q2C",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "negative_energy_kJ = []\n",
+    "\n",
+    "for number in energy_kJ:\n",
+    "    if number < 0:\n",
+    "        negative_energy_kJ.append(number)\n",
+    "\n",
+    "print(negative_energy_kJ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FOFy7HFw6Q2C"
+   },
+   "source": [
+    "Other logic operations include\n",
+    "\n",
+    "* equal to `==`\n",
+    "* not equal to `!=`\n",
+    "* greater than `>`\n",
+    "* less than `<`\n",
+    "* greater than or equal to `>=`\n",
+    "* less than or equal to `<=`\n",
+    "\n",
+    "You can also use and, or, and not to check more than one condition.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VIG-Xhhy6Q2C",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "negative_numbers = []\n",
+    "for number in energy_kJ:\n",
+    "    if number < 0 or number == 0:\n",
+    "        negative_numbers.append(number)\n",
+    "\n",
+    "print(negative_numbers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "shYOnOjN6Q2C"
+   },
+   "source": [
+    "To define what happens if the `if` statement is not met, you can use the `else` keyword."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "1nCZFepn6Q2C",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "negative_numbers = []\n",
+    "positive_numbers = []\n",
+    "for number in energy_kJ:\n",
+    "    if number < 0 or number == 0:\n",
+    "        negative_numbers.append(number)\n",
+    "    else:\n",
+    "        positive_numbers.append(number)\n",
+    "\n",
+    "print(\"Negative numbers:\", negative_numbers)\n",
+    "print(\"Positive Numbers: \", positive_numbers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TbKB6K6U6Q2C",
+    "tags": []
+   },
+   "source": [
+    "## Formatted Strings\n",
+    "\n",
+    "Throughout the lesson we will sometimes use a special kind of string called a \"formatted string\". A formatted string is a string that has a variable in it.\n",
+    "To make a formatted string, you start your string with an `f`, and put variable names in curly braces."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zj1Y6sZ86Q2C"
+   },
+   "outputs": [],
+   "source": [
+    "my_string = f\"The positive numbers are {positive_numbers}.\"\n",
+    "print(my_string)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "AkpawsHC6Q2D"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.1"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "16d4a7bb199d969b1271ebe46f77414b0d9cd01b3c3983c2b2742fc6cd4503d3"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/prep/Filled_Notebooks/C_rdkit_intro.ipynb
+++ b/prep/Filled_Notebooks/C_rdkit_intro.ipynb
@@ -1,970 +1,1005 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "d9020474",
-      "metadata": {
-        "id": "d9020474"
-      },
-      "source": [
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
-        "</div>\n",
-        "\n",
-        "\n",
-        "# Introduction to RDKit Molecules\n",
-        "\n",
-        "<strong>Author(s):</strong> Jessica A. Nash, The Molecular Sciences Software Institute\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "<h2>Overview</h2>\n",
-        "\n",
-        "<strong>Questions:</strong>\n",
-        "\n",
-        "* What is RDKit?\n",
-        "\n",
-        "* What is an RDKit molecule object?\n",
-        "\n",
-        "* What can I do with RDKit molecules?\n",
-        "\n",
-        "<strong>Objectives:</strong>\n",
-        "\n",
-        "* Use RDKit to create molecules in Python\n",
-        "\n",
-        "</div>\n",
-        "\n",
-        "There are Python libraries that are made for working just with chemical data. One commonly used library in Python for data science (or cheminformatics) is called [RDKit](https://en.wikipedia.org/wiki/RDKit). RDKit is an open-source cheminformatics library, primarily developed in C++ and has been under development since the year 2000. We will be using the Python interface to RDKit, though there are interfaces in other languages.\n",
-        "\n",
-        "RDKit provides a molecule object that allows you to manipulate chemical structures. It has capabilities for reading and writing molecular file formats, calculating molecular properties, and performing substructure searches. In addition, it offers a wide range of cheminformatics algorithms such as molecular fingerprint generation, similarity metrics calculation, and molecular descriptor computation. This notebook introduces RDKit basics, but we will see more of all of these topics in later notebooks.\n",
-        "\n",
-        "<div class=\"alert alert-block alert-success\">\n",
-        "<strong>Python Skills: Python Objects</strong>\n",
-        "\n",
-        "Most of this functionality is achieved through the RDKit `mol` object. In Python, we use the word \"object\" to refer to a variable type with associated data and methods.\n",
-        "One example of an object we have seen in notebooks is a list - we could also call it a \"list object\". An object has `attributes` (data) and `methods`.\n",
-        "You access information about objects with the syntax\n",
-        "```python\n",
-        "object.data\n",
-        "```\n",
-        "where data is the attribute name.\n",
-        "\n",
-        "You access object methods with the syntax\n",
-        "```python\n",
-        "object.method(arguments)\n",
-        "```\n",
-        "\n",
-        "For example, for a list \"`append` is a method that was covered in the introductory lesson.\n",
-        "\n",
-        "```\n",
-        "my_list = []\n",
-        "my_list.append(1) # \"append\" is a method\n",
-        "```\n",
-        "</div>    \n",
-        "\n",
-        "In this lesson, we will create and manipulate RDKit `mol` objects. RDKit `mol` objects represent molecules and have\n",
-        "attributes (data) and methods (actions) associated with molecules.\n",
-        "\n",
-        "We are going to use a part of RDKit called `Chem`. To use `Chem`, we first have to import it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!pip install rdkit"
-      ],
-      "metadata": {
-        "id": "eFjTn5wMHixe"
-      },
-      "id": "eFjTn5wMHixe",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "afc9bc63",
-      "metadata": {
-        "tags": [],
-        "id": "afc9bc63"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit import Chem"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d5b835ad",
-      "metadata": {
-        "id": "d5b835ad"
-      },
-      "source": [
-        "## Creating Molecules with RDKit\n",
-        "\n",
-        "Throughout this tutorial, it will be helpful to have access to the [RDKit documentation](https://www.rdkit.org/docs/index.html).\n",
-        "\n",
-        "To get information about molecules in RDKit, we have to first create objects representing molecules. RDKit has a molecule object that can be used to retrieve information or calculate properties. To create a molecule object, we have to communicate the molecule identity in a way that computers understand.\n",
-        "\n",
-        "We will use SMILES strings to create our objects, though RDKit also has methods for creating molecules from the file formats listed in the previous notebook.\n",
-        "\n",
-        "### Creating molecules using SMILES\n",
-        "\n",
-        "In the last lesson, we learned about molecular representations using SMILES strings. Now we will use SMILES strings to create molecule objects in RDKIT.\n",
-        "\n",
-        "We can create a representation of methane using RDKit by using the `MolFromSmiles` function in `rdkit.Chem`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "40b29a7c",
-      "metadata": {
-        "tags": [],
-        "id": "40b29a7c"
-      },
-      "outputs": [],
-      "source": [
-        "methane = Chem.MolFromSmiles(\"C\")           # TO DO: Enter a capital C between the quote marks in the parentheses"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "da5b102b-e997-47b4-8a0d-7cc5befc1b7e",
-      "metadata": {
-        "id": "da5b102b-e997-47b4-8a0d-7cc5befc1b7e"
-      },
-      "source": [
-        "The `methane` variable is now an RDKit \"molecule object\".\n",
-        "\n",
-        "In a Jupyter environment, putting a variable that is an RDKit molecule as the only or last thing in a cell,\n",
-        "will result in a picture of the molecule as an output."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "99734c44",
-      "metadata": {
-        "tags": [],
-        "id": "99734c44"
-      },
-      "outputs": [],
-      "source": [
-        "methane"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fae858d1-503d-4dc9-a220-f713ed075847",
-      "metadata": {
-        "id": "fae858d1-503d-4dc9-a220-f713ed075847"
-      },
-      "outputs": [],
-      "source": [
-        "ethane = Chem.MolFromSmiles(\"CC\")          # TO DO: Enter a capital CC between the quote marks in the parentheses\n",
-        "ethane"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e98c39d3",
-      "metadata": {
-        "id": "e98c39d3"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Check Your Understanding</h3>\n",
-        "<p> Create RDKit molecules for the following molecules. You can look up the SMILES strings on <a href=\"https://pubchem.ncbi.nlm.nih.gov/\">PubChem</a>:\n",
-        "<p>\n",
-        "    <ul>\n",
-        "        <li> Propane\n",
-        "        <li> Ethene\n",
-        "        <li> Cyclohexane\n",
-        "        <li> Benzene </li>\n",
-        "        <li> Acetic Acid\n",
-        "    </ul>\n",
-        "</p>\n",
-        "<p>Create variables for each molecule. The variable names should be the molecule name (all lowercase)</p>\n",
-        "</div>\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "bbae7a92-6647-4361-b5ed-f45363f4d249",
-      "metadata": {
-        "tags": [],
-        "id": "bbae7a92-6647-4361-b5ed-f45363f4d249"
-      },
-      "outputs": [],
-      "source": [
-        "# Your answers go here\n",
-        "propane = Chem.MolFromSmiles(\"CCC\")            # TO DO: Enter the SMILES string for propane between the quote marks in the parentheses\n",
-        "ethene = Chem.MolFromSmiles(\"C=C\")             # TO DO: Enter the SMILES string for ethene between the quote marks in the parentheses\n",
-        "cyclohexane = Chem.MolFromSmiles(\"C1CCCCC1\")        # TO DO: Enter the SMILES string for cyclohexane between the quote marks in the parentheses\n",
-        "benzene = Chem.MolFromSmiles('c1ccccc1')            # TO DO: Enter the SMILES string for benzene between the quote marks in the parentheses\n",
-        "acetic_acid = Chem.MolFromSmiles(\"CC(=O)O\")        # TO DO: Enter the SMILES string for acetic acid between the quote marks in the parentheses"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "395bc20c-bef9-4941-a2f8-fca830baae2b",
-      "metadata": {
-        "id": "395bc20c-bef9-4941-a2f8-fca830baae2b"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
-        "propane"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "e22a13a2-305e-458b-9caa-ba636b836e1e",
-      "metadata": {
-        "id": "e22a13a2-305e-458b-9caa-ba636b836e1e"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
-        "ethene"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "2fc9b578-6889-43d9-85c0-0f07111053b3",
-      "metadata": {
-        "id": "2fc9b578-6889-43d9-85c0-0f07111053b3"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
-        "cyclohexane"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "0942cfe3-0ca2-4145-baaf-c7dff83fed24",
-      "metadata": {
-        "id": "0942cfe3-0ca2-4145-baaf-c7dff83fed24"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
-        "benzene"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "670f07a8-c1ac-41bc-b4d9-62ac7bf342fd",
-      "metadata": {
-        "id": "670f07a8-c1ac-41bc-b4d9-62ac7bf342fd"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
-        "acetic_acid"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ee8b5f19-d326-4c5c-a563-ef06e7890b9f",
-      "metadata": {
-        "id": "ee8b5f19-d326-4c5c-a563-ef06e7890b9f"
-      },
-      "source": [
-        "## Working with RDKit Molecules\n",
-        "\n",
-        "RDKit molecule objects have a number of methods we can use to get more information about the molecule.\n",
-        "In the next few cells, we'll look at some methods that can tell us some things about the molecules we've created.\n",
-        "The next cell has settings for modifying drawing molecules. It adds labels of atom indices and sets the image size."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "761d0c31-0e04-453a-9be7-cb93cb9386a5",
-      "metadata": {
-        "id": "761d0c31-0e04-453a-9be7-cb93cb9386a5"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem.Draw import IPythonConsole as ipc\n",
-        "from rdkit.Chem import Draw\n",
-        "\n",
-        "# Configuration for displaying in Jupyter notebooks\n",
-        "ipc.ipython_useSVG = True  # Use SVG for higher quality images\n",
-        "ipc.drawOptions.addAtomIndices = True  # Show atom indices\n",
-        "ipc.molSize = 250,250 # Set size of image"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "07cfae6b-3159-44df-8acf-67c35a68b99d",
-      "metadata": {
-        "id": "07cfae6b-3159-44df-8acf-67c35a68b99d"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-success\">\n",
-        "<strong>Jupyter Skills: The Tab Key</strong>\n",
-        "\n",
-        "When working with Python objects in the Jupyter notebook, you can type a variable or object name to see the methods available on that object.\n",
-        "\n",
-        "In the cell below, type `acetic_acid.` (notice how there is a dot (`.`) at the end), then press the `tab` key.\n",
-        "A list of possible methods and attributes will come up.\n",
-        "\n",
-        "Look through the methods until you find one that gives you the number of atoms in the molecule.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "91d1dd84-e932-4f2d-a170-dc9a15ab5447",
-      "metadata": {
-        "id": "91d1dd84-e932-4f2d-a170-dc9a15ab5447"
-      },
-      "outputs": [],
-      "source": [
-        "# Pick a method that will tell you the number of atoms acetic acid has.\n",
-        "\n",
-        "x = acetic_acid.GetNumAtoms()                # TO DO: Type a period after acetic_acid and look for a function that will give you the number of atoms in the molecule\n",
-        "\n",
-        "print('Acetic acid has', x, 'heavy atoms.')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c69990f5-4a31-4fa5-9787-546faab4b071",
-      "metadata": {
-        "id": "c69990f5-4a31-4fa5-9787-546faab4b071"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-success\">\n",
-        "<strong>Python Skills: Getting Help</strong>\n",
-        "\n",
-        "Is this the number of atoms you expected for a benzene molecule?\n",
-        "\n",
-        "We can use the `help` function on the method you found in the previous step to find a method argument to figure out a method argument to get the number of atoms we expect.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "eb159c7b-fb4f-4024-85e6-22f5d90d51ff",
-      "metadata": {
-        "id": "eb159c7b-fb4f-4024-85e6-22f5d90d51ff"
-      },
-      "outputs": [],
-      "source": [
-        "help(acetic_acid)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "66d59a12-0dd4-4e7a-adbc-e874c4f036ec",
-      "metadata": {
-        "id": "66d59a12-0dd4-4e7a-adbc-e874c4f036ec"
-      },
-      "outputs": [],
-      "source": [
-        "# Add an argument to your function to get the number of atoms that gives you\n",
-        "# the total number of atoms in acetic_acid including hydrogens\n",
-        "\n",
-        "x = acetic_acid.GetNumAtoms()\n",
-        "y = acetic_acid.GetNumAtoms(onlyExplicit=False)          # TO DO: Insert the expression      onlyExplicit = False      inside the parentheses so that it will include hydrogens.\n",
-        "\n",
-        "print(f\"There are {x} heavy atoms in acetic acid and {y} total atoms in acetic acid.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "71567da6-cd35-4265-9c16-813c3d008456",
-      "metadata": {
-        "id": "71567da6-cd35-4265-9c16-813c3d008456"
-      },
-      "source": [
-        "Each molecule is made up of RDKit atom objects and RDKit bond objects.\n",
-        "If we want to get the atoms for a particular molecule, we can use the `GetAtoms` method."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d1f14353-5f81-4c43-a7ea-8d8a5c5cfe8f",
-      "metadata": {
-        "id": "d1f14353-5f81-4c43-a7ea-8d8a5c5cfe8f"
-      },
-      "outputs": [],
-      "source": [
-        "acetic_acid_atoms = acetic_acid.GetAtoms()\n",
-        "print(acetic_acid_atoms)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "5c674690-c889-4e43-8d39-99ec703c3534",
-      "metadata": {
-        "id": "5c674690-c889-4e43-8d39-99ec703c3534"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-success\">\n",
-        "<strong>Python Skills: Iterators</strong>\n",
-        "\n",
-        "When we look at the results of the `GetAtoms` method, it tells us that we have a `GetAtomsIterator`.\n",
-        "In Python, an iterator is an object that contains values that can be looped through and indexed in.\n",
-        "\n",
-        "Although we haven't used this terminology before, a Python list is an example of an iterator.\n",
-        "\n",
-        "</div>\n",
-        "\n",
-        "Like a list, we can also call `len` on the iterator.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fc8318c2-0adf-48ae-b41a-c4cf99f129d8",
-      "metadata": {
-        "id": "fc8318c2-0adf-48ae-b41a-c4cf99f129d8"
-      },
-      "outputs": [],
-      "source": [
-        "len(acetic_acid_atoms)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "578df920-172d-4d23-a42b-7cb9a27a4903",
-      "metadata": {
-        "id": "578df920-172d-4d23-a42b-7cb9a27a4903"
-      },
-      "source": [
-        "Because `acetic_acid_atoms` is an iterator, we can use indexing to get a particular atom.\n",
-        "Atoms in RDKit molecules are represented by Atom objects."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9af16d3f-b730-4f5d-8763-75470ef5995b",
-      "metadata": {
-        "id": "9af16d3f-b730-4f5d-8763-75470ef5995b"
-      },
-      "outputs": [],
-      "source": [
-        "atom = acetic_acid_atoms[0]\n",
-        "atom"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "15254adb-2bff-4b0c-8a59-4001cf55b5bd",
-      "metadata": {
-        "id": "15254adb-2bff-4b0c-8a59-4001cf55b5bd"
-      },
-      "source": [
-        "When we examine one atom, we see there that there are many methods associated with the atom.\n",
-        "For example, we can print the atom element or atom hybridization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "c438feec-6021-4403-948c-924cd5a9afa1",
-      "metadata": {
-        "id": "c438feec-6021-4403-948c-924cd5a9afa1"
-      },
-      "outputs": [],
-      "source": [
-        "print(atom.GetSymbol())             # TO DO: Type a . after atom and look for a method that will print out the symbol for the atom\n",
-        "print(atom.GetHybridization())             # TO DO: Type a . after atom and look for a method that will tell you the hydridization of the atom"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "36750053-e4d8-4ce1-a8ff-4b71f5c33a0d",
-      "metadata": {
-        "id": "36750053-e4d8-4ce1-a8ff-4b71f5c33a0d"
-      },
-      "source": [
-        "We can use a for loop to give information about each atom."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f93df84c-f808-493a-a7d1-07e75841cdbb",
-      "metadata": {
-        "id": "f93df84c-f808-493a-a7d1-07e75841cdbb"
-      },
-      "outputs": [],
-      "source": [
-        "for atom in acetic_acid_atoms:                                                      # We can do this because acetic_acid_atoms is an iterator\n",
-        "    print(f\"Atom {atom.GetSymbol()} has hybridization {atom.GetHybridization()}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "3a32c170-b190-4def-a24e-721f2bf9c50e",
-      "metadata": {
-        "id": "3a32c170-b190-4def-a24e-721f2bf9c50e"
-      },
-      "source": [
-        "Bonds are also objects in RDKit, and we can iterate over them the same way we can iterate over atoms."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "64a6fb8f-bfc2-45a6-8659-641a6c47f574",
-      "metadata": {
-        "id": "64a6fb8f-bfc2-45a6-8659-641a6c47f574"
-      },
-      "outputs": [],
-      "source": [
-        "acetic_acid_bonds = acetic_acid.GetBonds()\n",
-        "bond = acetic_acid_bonds[0]"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "7af42942-0bf1-49c0-9478-ad162495c92e",
-      "metadata": {
-        "id": "7af42942-0bf1-49c0-9478-ad162495c92e"
-      },
-      "outputs": [],
-      "source": [
-        "bond.GetBondType()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1288c516-437e-4651-ba08-79592621793e",
-      "metadata": {
-        "id": "1288c516-437e-4651-ba08-79592621793e"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Challenge</h3>\n",
-        "\n",
-        "Use a `for` loop to print information about each bond.\n",
-        "For each bond, you should print the starting atom symbol, the ending atom symbol,\n",
-        "and the bond type.\n",
-        "\n",
-        "Your output should look like the following:\n",
-        "\n",
-        "```\n",
-        "Bond between C and C is a SINGLE bond.\n",
-        "Bond between C and O is a DOUBLE bond.\n",
-        "Bond between C and O is a SINGLE bond.\n",
-        "```\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "71c91dce-e046-46ea-a74f-069f9aba99f6",
-      "metadata": {
-        "id": "71c91dce-e046-46ea-a74f-069f9aba99f6"
-      },
-      "outputs": [],
-      "source": [
-        "for bond in acetic_acid_bonds:\n",
-        "    start_atom = bond.GetBeginAtom()\n",
-        "    end_atom = bond.GetEndAtom()\n",
-        "    bond_type = bond.GetBondType()\n",
-        "    print(f\"Bond between {start_atom.GetSymbol()} and {end_atom.GetSymbol()} is a {bond_type} bond.\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c076e9e2-1b3d-4979-bfb5-aa4e643b813b",
-      "metadata": {
-        "id": "c076e9e2-1b3d-4979-bfb5-aa4e643b813b"
-      },
-      "source": [
-        "## Editing Atoms with RDKit\n",
-        "\n",
-        "In addition to seeing information about atoms and bonds in our molecule, we can also use RDKit to change our molecule structure.\n",
-        "Let's consider benzene for our example. We will change one of the carbons in the benzene ring to a nitrogen to make pyridine.\n",
-        "\n",
-        "We are going to create a copy of our benzene molecule using another function from RDKit called `RWMol`. `RWMol` makes our molecule readable and writeable (or \"editable\")."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "382e0906-f3cb-4413-9bee-b1a2f2f1f718",
-      "metadata": {
-        "id": "382e0906-f3cb-4413-9bee-b1a2f2f1f718"
-      },
-      "outputs": [],
-      "source": [
-        "pyridine = Chem.RWMol(benzene)             # TO DO: we will create pyridine from benzene, an RDKit mol object we already created in this noteobook\n",
-        "pyridine                            # but you can see it's still benzene, not pyridine"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d0bd6d4f-0d4d-4536-9bf0-79e596fa01c8",
-      "metadata": {
-        "id": "d0bd6d4f-0d4d-4536-9bf0-79e596fa01c8"
-      },
-      "source": [
-        "One way we can change molecules in RDKit is to set the atomic number of a particular atom to another number.\n",
-        "To change one of the carbons in our ring to nitrogen, we can select one of the atoms and then set its atomic number to that of nitrogen (7)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6f852ffe-d424-413f-8ce3-0d6e82b3324c",
-      "metadata": {
-        "id": "6f852ffe-d424-413f-8ce3-0d6e82b3324c"
-      },
-      "outputs": [],
-      "source": [
-        "atom = pyridine.GetAtomWithIdx(0)     # TO DO: Get atom with index 0 (labeled 0 above)\n",
-        "atom.SetAtomicNum(7)                  # TO DO: Set the atomic number to 7\n",
-        "pyridine"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "63eb53d6-af12-4b67-bede-1faaf9f760a6",
-      "metadata": {
-        "id": "63eb53d6-af12-4b67-bede-1faaf9f760a6"
-      },
-      "outputs": [],
-      "source": [
-        "Chem.MolToSmiles(pyridine)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "607cba74-d60d-43a2-befa-11b74777580c",
-      "metadata": {
-        "id": "607cba74-d60d-43a2-befa-11b74777580c"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Challenge</h3>\n",
-        "\n",
-        "Change another atom in the pyridine ring to create [pyrimidine](https://en.wikipedia.org/wiki/Pyrimidine).\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d31fdcc6-6fdd-4fc2-b820-2bc17fcd3048",
-      "metadata": {
-        "id": "d31fdcc6-6fdd-4fc2-b820-2bc17fcd3048"
-      },
-      "outputs": [],
-      "source": [
-        "pyrimidine = Chem.RWMol(pyridine)               # TO DO: Create pyrimidine by starting with pyridine\n",
-        "atom = pyrimidine.GetAtomWithIdx(2)      # TO DO: Get atom with index 2 (labeled 2 above)\n",
-        "atom.SetAtomicNum(7)                     # TO DO: Set the atomic number to 7\n",
-        "pyrimidine"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a62f8686-83aa-4dc8-841e-2eb4e931b375",
-      "metadata": {
-        "id": "a62f8686-83aa-4dc8-841e-2eb4e931b375"
-      },
-      "outputs": [],
-      "source": []
-    },
-    {
-      "cell_type": "markdown",
-      "id": "021f75c5-a9d2-4767-935c-8a46d4f22812",
-      "metadata": {
-        "id": "021f75c5-a9d2-4767-935c-8a46d4f22812"
-      },
-      "source": [
-        "## Combining two molecules\n",
-        "\n",
-        "We can also create and combine molecules using RDKit. This approach might be necessary when we want to add a more complex functional group. In the example below we create a carboxyl group and add it to benzene to make benzoic acid.\n",
-        "\n",
-        "First we create the molecule for our functional group."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1ca7648c-8857-405c-a747-8c41ee5db922",
-      "metadata": {
-        "id": "1ca7648c-8857-405c-a747-8c41ee5db922"
-      },
-      "outputs": [],
-      "source": [
-        "carboxyl = Chem.MolFromSmiles('C(=O)O')\n",
-        "carboxyl"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "3f81da17-5b67-486c-821e-74cba04c053d",
-      "metadata": {
-        "id": "3f81da17-5b67-486c-821e-74cba04c053d"
-      },
-      "source": [
-        "Next, we combine the two molecules together using the `CombineMols` function."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "13dd67a7-afd2-4698-92e5-455bbdeca12a",
-      "metadata": {
-        "id": "13dd67a7-afd2-4698-92e5-455bbdeca12a"
-      },
-      "outputs": [],
-      "source": [
-        "combined = Chem.CombineMols(benzene, carboxyl)\n",
-        "combined"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ec93dc59-4468-446e-a03f-b2715597c45c",
-      "metadata": {
-        "id": "ec93dc59-4468-446e-a03f-b2715597c45c"
-      },
-      "source": [
-        "After the combining, we have to make our combined molecules editable so that we can change the bonds and atoms."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "5459cbf8-5773-43a5-b947-03fcd8da515d",
-      "metadata": {
-        "id": "5459cbf8-5773-43a5-b947-03fcd8da515d"
-      },
-      "outputs": [],
-      "source": [
-        "editable_mol = Chem.RWMol(combined)\n",
-        "editable_mol"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ddbcf42c-2c42-437d-aca1-88fd8ba4475a",
-      "metadata": {
-        "id": "ddbcf42c-2c42-437d-aca1-88fd8ba4475a"
-      },
-      "source": [
-        "Finally, we can use `AddBonds` to add a bond between the carbon on our carboxyl group (6) to an atom on benzene. We could have picked any carbon, but the example below uses index 5."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "7e6035b7-3594-4e20-8347-254d9f951bcf",
-      "metadata": {
-        "id": "7e6035b7-3594-4e20-8347-254d9f951bcf"
-      },
-      "outputs": [],
-      "source": [
-        "editable_mol.AddBond(0, 6, order=Chem.rdchem.BondType.SINGLE)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "07b045f6-f06d-4348-b547-900164d014ea",
-      "metadata": {
-        "id": "07b045f6-f06d-4348-b547-900164d014ea"
-      },
-      "outputs": [],
-      "source": [
-        "editable_mol"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "be786a94-cab6-4597-b139-267568eac415",
-      "metadata": {
-        "id": "be786a94-cab6-4597-b139-267568eac415"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-info\">\n",
-        "<strong>Molecular Sanitization</strong>\n",
-        "\n",
-        "When a molecule is loaded into RDKit, a [\"molecular sanitization\"](https://www.rdkit.org/docs/RDKit_Book.html#molecular-sanitization) step typically takes place.\n",
-        "Molecular sanitization ensures that molecules are \"reasonable\":that they can be represented with octet-complete Lewis dot structures.\n",
-        "</div>\n",
-        "\n",
-        "After we add new atoms like this, our molecule usually needs to be \"sanitized\". One way we can tell this is by viewing the molecule above. Our aromatic ring structure is now symbolized with a dotted line inside of the ring. We will want to use the `Chem.SanitizeMol` method to sanitize the molecule.\n",
-        "The step of sanitiziation that is important in this case is the `Kekulize` step, where aromatic rings are converted to the Kekule form. A Python error (exception) would occur if a problem is found with aromaticity."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fa9dbe5c-32cc-438d-9aca-aa3e1b515836",
-      "metadata": {
-        "id": "fa9dbe5c-32cc-438d-9aca-aa3e1b515836"
-      },
-      "outputs": [],
-      "source": [
-        "Chem.SanitizeMol(editable_mol)\n",
-        "editable_mol"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cf0b95ef-bf40-4349-bbd4-1eaa3e47982e",
-      "metadata": {
-        "id": "cf0b95ef-bf40-4349-bbd4-1eaa3e47982e"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h2>Final Challenge</h2>\n",
-        "\n",
-        "[Protein phoshorylation](https://www.thermofisher.com/us/en/home/life-science/protein-biology/protein-biology-learning-center/protein-biology-resource-library/pierce-protein-methods/phosphorylation.html) refers to the additon of a phosphate group to the -OH group of an amino acid and occurs for serine, threonine, or tyrosine residues.\n",
-        "\n",
-        "For this challenge, you should modify the tyrosine module (given below) to add a phosphate to the OH group.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "41f63879-b4e0-44af-b57e-69d61a738a79",
-      "metadata": {
-        "id": "41f63879-b4e0-44af-b57e-69d61a738a79"
-      },
-      "outputs": [],
-      "source": [
-        "tyrosine = Chem.MolFromSmiles(\"C1=CC(=CC=C1C[C@@H](C(=O)O)N)O\")     # TO DO: Go to the PubChem site to get the SMILES string for tyrosine and place it between the quote marks\n",
-        "tyrosine"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "68f3753a-c5b2-4102-b3ac-b5d90dc60019",
-      "metadata": {
-        "id": "68f3753a-c5b2-4102-b3ac-b5d90dc60019"
-      },
-      "outputs": [],
-      "source": [
-        "phosphate = Chem.MolFromSmiles(\"P(=O)(O)O\")    # TO DO: Write the SMILES string for a phosphate group (phosphorous bound to 3 oxygens)\n",
-        "phosphate"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "5372f1c9-c22e-4ea0-8bef-a996dd7a3485",
-      "metadata": {
-        "id": "5372f1c9-c22e-4ea0-8bef-a996dd7a3485"
-      },
-      "outputs": [],
-      "source": [
-        "combined2 = Chem.CombineMols(tyrosine, phosphate)        # TO DO: Place the names of the two RDKit mol objects you want to combine in the parentheses\n",
-        "combined2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "91b5aae7-8c31-4e7b-9b2e-f0c5281e7b6c",
-      "metadata": {
-        "id": "91b5aae7-8c31-4e7b-9b2e-f0c5281e7b6c"
-      },
-      "outputs": [],
-      "source": [
-        "editable_mol2 = Chem.RWMol(combined2)          # TO DO: Make your new set of molecules editable (RW stands for Read Write)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a80d18bf-87fa-4f77-aeb7-fdb07c80b812",
-      "metadata": {
-        "id": "a80d18bf-87fa-4f77-aeb7-fdb07c80b812"
-      },
-      "outputs": [],
-      "source": [
-        "editable_mol2.AddBond(12, 13, order=Chem.rdchem.BondType.SINGLE)    # TO DO: Add the bond to connect the two RDKit mol objects\n",
-        "editable_mol2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fe0f047a-cac2-4e80-9ac5-ebd993f8a9d9",
-      "metadata": {
-        "id": "fe0f047a-cac2-4e80-9ac5-ebd993f8a9d9"
-      },
-      "outputs": [],
-      "source": [
-        "Chem.SanitizeMol(editable_mol2)       # This will clean it up\n",
-        "editable_mol2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "775adf1b-9f14-4a3d-b864-05fd23dae849",
-      "metadata": {
-        "id": "775adf1b-9f14-4a3d-b864-05fd23dae849"
-      },
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.2"
-    },
-    "vscode": {
-      "interpreter": {
-        "hash": "16d4a7bb199d969b1271ebe46f77414b0d9cd01b3c3983c2b2742fc6cd4503d3"
-      }
-    },
-    "colab": {
-      "provenance": []
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d9020474",
+   "metadata": {
+    "id": "d9020474"
+   },
+   "source": [
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+    "</div>\n",
+    "\n",
+    "\n",
+    "# Introduction to RDKit Molecules\n",
+    "\n",
+    "<strong>Author(s):</strong> Jessica A. Nash, The Molecular Sciences Software Institute\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2>Overview</h2>\n",
+    "\n",
+    "<strong>Questions:</strong>\n",
+    "\n",
+    "* What is RDKit?\n",
+    "\n",
+    "* What is an RDKit molecule object?\n",
+    "\n",
+    "* What can I do with RDKit molecules?\n",
+    "\n",
+    "<strong>Objectives:</strong>\n",
+    "\n",
+    "* Use RDKit to create molecules in Python\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "There are Python libraries that are made for working just with chemical data. One commonly used library in Python for data science (or cheminformatics) is called [RDKit](https://en.wikipedia.org/wiki/RDKit). RDKit is an open-source cheminformatics library, primarily developed in C++ and has been under development since the year 2000. We will be using the Python interface to RDKit, though there are interfaces in other languages.\n",
+    "\n",
+    "RDKit provides a molecule object that allows you to manipulate chemical structures. It has capabilities for reading and writing molecular file formats, calculating molecular properties, and performing substructure searches. In addition, it offers a wide range of cheminformatics algorithms such as molecular fingerprint generation, similarity metrics calculation, and molecular descriptor computation. This notebook introduces RDKit basics, but we will see more of all of these topics in later notebooks.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-success\">\n",
+    "<strong>Python Skills: Python Objects</strong>\n",
+    "\n",
+    "Most of this functionality is achieved through the RDKit `mol` object. In Python, we use the word \"object\" to refer to a variable type with associated data and methods.\n",
+    "One example of an object we have seen in notebooks is a list - we could also call it a \"list object\". An object has `attributes` (data) and `methods`.\n",
+    "You access information about objects with the syntax\n",
+    "```python\n",
+    "object.data\n",
+    "```\n",
+    "where data is the attribute name.\n",
+    "\n",
+    "You access object methods with the syntax\n",
+    "```python\n",
+    "object.method(arguments)\n",
+    "```\n",
+    "\n",
+    "For example, for a list \"`append` is a method that was covered in the introductory lesson.\n",
+    "\n",
+    "```\n",
+    "my_list = []\n",
+    "my_list.append(1) # \"append\" is a method\n",
+    "```\n",
+    "</div>    \n",
+    "\n",
+    "In this lesson, we will create and manipulate RDKit `mol` objects. RDKit `mol` objects represent molecules and have\n",
+    "attributes (data) and methods (actions) associated with molecules.\n",
+    "\n",
+    "We are going to use a part of RDKit called `Chem`. To use `Chem`, we first have to import it."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eFjTn5wMHixe",
+   "metadata": {
+    "id": "eFjTn5wMHixe"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rdkit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afc9bc63",
+   "metadata": {
+    "id": "afc9bc63",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit import Chem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5b835ad",
+   "metadata": {
+    "id": "d5b835ad"
+   },
+   "source": [
+    "## Creating Molecules with RDKit\n",
+    "\n",
+    "Throughout this tutorial, it will be helpful to have access to the [RDKit documentation](https://www.rdkit.org/docs/index.html).\n",
+    "\n",
+    "To get information about molecules in RDKit, we have to first create objects representing molecules. RDKit has a molecule object that can be used to retrieve information or calculate properties. To create a molecule object, we have to communicate the molecule identity in a way that computers understand.\n",
+    "\n",
+    "We will use SMILES strings to create our objects, though RDKit also has methods for creating molecules from the file formats listed in the previous notebook.\n",
+    "\n",
+    "### Creating molecules using SMILES\n",
+    "\n",
+    "In the last lesson, we learned about molecular representations using SMILES strings. Now we will use SMILES strings to create molecule objects in RDKIT.\n",
+    "\n",
+    "We can create a representation of methane using RDKit by using the `MolFromSmiles` function in `rdkit.Chem`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40b29a7c",
+   "metadata": {
+    "id": "40b29a7c",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "methane = Chem.MolFromSmiles(\n",
+    "    \"C\"\n",
+    ")  # TO DO: Enter a capital C between the quote marks in the parentheses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da5b102b-e997-47b4-8a0d-7cc5befc1b7e",
+   "metadata": {
+    "id": "da5b102b-e997-47b4-8a0d-7cc5befc1b7e"
+   },
+   "source": [
+    "The `methane` variable is now an RDKit \"molecule object\".\n",
+    "\n",
+    "In a Jupyter environment, putting a variable that is an RDKit molecule as the only or last thing in a cell,\n",
+    "will result in a picture of the molecule as an output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99734c44",
+   "metadata": {
+    "id": "99734c44",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "methane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fae858d1-503d-4dc9-a220-f713ed075847",
+   "metadata": {
+    "id": "fae858d1-503d-4dc9-a220-f713ed075847"
+   },
+   "outputs": [],
+   "source": [
+    "ethane = Chem.MolFromSmiles(\n",
+    "    \"CC\"\n",
+    ")  # TO DO: Enter a capital CC between the quote marks in the parentheses\n",
+    "ethane"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e98c39d3",
+   "metadata": {
+    "id": "e98c39d3"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Check Your Understanding</h3>\n",
+    "<p> Create RDKit molecules for the following molecules. You can look up the SMILES strings on <a href=\"https://pubchem.ncbi.nlm.nih.gov/\">PubChem</a>:\n",
+    "<p>\n",
+    "    <ul>\n",
+    "        <li> Propane\n",
+    "        <li> Ethene\n",
+    "        <li> Cyclohexane\n",
+    "        <li> Benzene </li>\n",
+    "        <li> Acetic Acid\n",
+    "    </ul>\n",
+    "</p>\n",
+    "<p>Create variables for each molecule. The variable names should be the molecule name (all lowercase)</p>\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbae7a92-6647-4361-b5ed-f45363f4d249",
+   "metadata": {
+    "id": "bbae7a92-6647-4361-b5ed-f45363f4d249",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Your answers go here\n",
+    "propane = Chem.MolFromSmiles(\n",
+    "    \"CCC\"\n",
+    ")  # TO DO: Enter the SMILES string for propane between the quote marks in the parentheses\n",
+    "ethene = Chem.MolFromSmiles(\n",
+    "    \"C=C\"\n",
+    ")  # TO DO: Enter the SMILES string for ethene between the quote marks in the parentheses\n",
+    "cyclohexane = Chem.MolFromSmiles(\n",
+    "    \"C1CCCCC1\"\n",
+    ")  # TO DO: Enter the SMILES string for cyclohexane between the quote marks in the parentheses\n",
+    "benzene = Chem.MolFromSmiles(\n",
+    "    \"c1ccccc1\"\n",
+    ")  # TO DO: Enter the SMILES string for benzene between the quote marks in the parentheses\n",
+    "acetic_acid = Chem.MolFromSmiles(\n",
+    "    \"CC(=O)O\"\n",
+    ")  # TO DO: Enter the SMILES string for acetic acid between the quote marks in the parentheses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "395bc20c-bef9-4941-a2f8-fca830baae2b",
+   "metadata": {
+    "id": "395bc20c-bef9-4941-a2f8-fca830baae2b"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
+    "propane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e22a13a2-305e-458b-9caa-ba636b836e1e",
+   "metadata": {
+    "id": "e22a13a2-305e-458b-9caa-ba636b836e1e"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
+    "ethene"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fc9b578-6889-43d9-85c0-0f07111053b3",
+   "metadata": {
+    "id": "2fc9b578-6889-43d9-85c0-0f07111053b3"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
+    "cyclohexane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0942cfe3-0ca2-4145-baaf-c7dff83fed24",
+   "metadata": {
+    "id": "0942cfe3-0ca2-4145-baaf-c7dff83fed24"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
+    "benzene"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "670f07a8-c1ac-41bc-b4d9-62ac7bf342fd",
+   "metadata": {
+    "id": "670f07a8-c1ac-41bc-b4d9-62ac7bf342fd"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here - you visualize a molecule as putting its variable name as the last thing in a cell\n",
+    "acetic_acid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee8b5f19-d326-4c5c-a563-ef06e7890b9f",
+   "metadata": {
+    "id": "ee8b5f19-d326-4c5c-a563-ef06e7890b9f"
+   },
+   "source": [
+    "## Working with RDKit Molecules\n",
+    "\n",
+    "RDKit molecule objects have a number of methods we can use to get more information about the molecule.\n",
+    "In the next few cells, we'll look at some methods that can tell us some things about the molecules we've created.\n",
+    "The next cell has settings for modifying drawing molecules. It adds labels of atom indices and sets the image size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "761d0c31-0e04-453a-9be7-cb93cb9386a5",
+   "metadata": {
+    "id": "761d0c31-0e04-453a-9be7-cb93cb9386a5"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem.Draw import IPythonConsole as ipc\n",
+    "\n",
+    "# Configuration for displaying in Jupyter notebooks\n",
+    "ipc.ipython_useSVG = True  # Use SVG for higher quality images\n",
+    "ipc.drawOptions.addAtomIndices = True  # Show atom indices\n",
+    "ipc.molSize = 250, 250  # Set size of image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07cfae6b-3159-44df-8acf-67c35a68b99d",
+   "metadata": {
+    "id": "07cfae6b-3159-44df-8acf-67c35a68b99d"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-success\">\n",
+    "<strong>Jupyter Skills: The Tab Key</strong>\n",
+    "\n",
+    "When working with Python objects in the Jupyter notebook, you can type a variable or object name to see the methods available on that object.\n",
+    "\n",
+    "In the cell below, type `acetic_acid.` (notice how there is a dot (`.`) at the end), then press the `tab` key.\n",
+    "A list of possible methods and attributes will come up.\n",
+    "\n",
+    "Look through the methods until you find one that gives you the number of atoms in the molecule.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91d1dd84-e932-4f2d-a170-dc9a15ab5447",
+   "metadata": {
+    "id": "91d1dd84-e932-4f2d-a170-dc9a15ab5447"
+   },
+   "outputs": [],
+   "source": [
+    "# Pick a method that will tell you the number of atoms acetic acid has.\n",
+    "\n",
+    "x = acetic_acid.GetNumAtoms()  # TO DO: Type a period after acetic_acid and look for a function that will give you the number of atoms in the molecule\n",
+    "\n",
+    "print(\"Acetic acid has\", x, \"heavy atoms.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c69990f5-4a31-4fa5-9787-546faab4b071",
+   "metadata": {
+    "id": "c69990f5-4a31-4fa5-9787-546faab4b071"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-success\">\n",
+    "<strong>Python Skills: Getting Help</strong>\n",
+    "\n",
+    "Is this the number of atoms you expected for a benzene molecule?\n",
+    "\n",
+    "We can use the `help` function on the method you found in the previous step to find a method argument to figure out a method argument to get the number of atoms we expect.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb159c7b-fb4f-4024-85e6-22f5d90d51ff",
+   "metadata": {
+    "id": "eb159c7b-fb4f-4024-85e6-22f5d90d51ff"
+   },
+   "outputs": [],
+   "source": [
+    "help(acetic_acid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66d59a12-0dd4-4e7a-adbc-e874c4f036ec",
+   "metadata": {
+    "id": "66d59a12-0dd4-4e7a-adbc-e874c4f036ec"
+   },
+   "outputs": [],
+   "source": [
+    "# Add an argument to your function to get the number of atoms that gives you\n",
+    "# the total number of atoms in acetic_acid including hydrogens\n",
+    "\n",
+    "x = acetic_acid.GetNumAtoms()\n",
+    "y = acetic_acid.GetNumAtoms(\n",
+    "    onlyExplicit=False\n",
+    ")  # TO DO: Insert the expression      onlyExplicit = False      inside the parentheses so that it will include hydrogens.\n",
+    "\n",
+    "print(f\"There are {x} heavy atoms in acetic acid and {y} total atoms in acetic acid.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71567da6-cd35-4265-9c16-813c3d008456",
+   "metadata": {
+    "id": "71567da6-cd35-4265-9c16-813c3d008456"
+   },
+   "source": [
+    "Each molecule is made up of RDKit atom objects and RDKit bond objects.\n",
+    "If we want to get the atoms for a particular molecule, we can use the `GetAtoms` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1f14353-5f81-4c43-a7ea-8d8a5c5cfe8f",
+   "metadata": {
+    "id": "d1f14353-5f81-4c43-a7ea-8d8a5c5cfe8f"
+   },
+   "outputs": [],
+   "source": [
+    "acetic_acid_atoms = acetic_acid.GetAtoms()\n",
+    "print(acetic_acid_atoms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c674690-c889-4e43-8d39-99ec703c3534",
+   "metadata": {
+    "id": "5c674690-c889-4e43-8d39-99ec703c3534"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-success\">\n",
+    "<strong>Python Skills: Iterators</strong>\n",
+    "\n",
+    "When we look at the results of the `GetAtoms` method, it tells us that we have a `GetAtomsIterator`.\n",
+    "In Python, an iterator is an object that contains values that can be looped through and indexed in.\n",
+    "\n",
+    "Although we haven't used this terminology before, a Python list is an example of an iterator.\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "Like a list, we can also call `len` on the iterator.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc8318c2-0adf-48ae-b41a-c4cf99f129d8",
+   "metadata": {
+    "id": "fc8318c2-0adf-48ae-b41a-c4cf99f129d8"
+   },
+   "outputs": [],
+   "source": [
+    "len(acetic_acid_atoms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "578df920-172d-4d23-a42b-7cb9a27a4903",
+   "metadata": {
+    "id": "578df920-172d-4d23-a42b-7cb9a27a4903"
+   },
+   "source": [
+    "Because `acetic_acid_atoms` is an iterator, we can use indexing to get a particular atom.\n",
+    "Atoms in RDKit molecules are represented by Atom objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9af16d3f-b730-4f5d-8763-75470ef5995b",
+   "metadata": {
+    "id": "9af16d3f-b730-4f5d-8763-75470ef5995b"
+   },
+   "outputs": [],
+   "source": [
+    "atom = acetic_acid_atoms[0]\n",
+    "atom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15254adb-2bff-4b0c-8a59-4001cf55b5bd",
+   "metadata": {
+    "id": "15254adb-2bff-4b0c-8a59-4001cf55b5bd"
+   },
+   "source": [
+    "When we examine one atom, we see there that there are many methods associated with the atom.\n",
+    "For example, we can print the atom element or atom hybridization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c438feec-6021-4403-948c-924cd5a9afa1",
+   "metadata": {
+    "id": "c438feec-6021-4403-948c-924cd5a9afa1"
+   },
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    atom.GetSymbol()\n",
+    ")  # TO DO: Type a . after atom and look for a method that will print out the symbol for the atom\n",
+    "print(\n",
+    "    atom.GetHybridization()\n",
+    ")  # TO DO: Type a . after atom and look for a method that will tell you the hydridization of the atom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36750053-e4d8-4ce1-a8ff-4b71f5c33a0d",
+   "metadata": {
+    "id": "36750053-e4d8-4ce1-a8ff-4b71f5c33a0d"
+   },
+   "source": [
+    "We can use a for loop to give information about each atom."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f93df84c-f808-493a-a7d1-07e75841cdbb",
+   "metadata": {
+    "id": "f93df84c-f808-493a-a7d1-07e75841cdbb"
+   },
+   "outputs": [],
+   "source": [
+    "for (\n",
+    "    atom\n",
+    ") in acetic_acid_atoms:  # We can do this because acetic_acid_atoms is an iterator\n",
+    "    print(f\"Atom {atom.GetSymbol()} has hybridization {atom.GetHybridization()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a32c170-b190-4def-a24e-721f2bf9c50e",
+   "metadata": {
+    "id": "3a32c170-b190-4def-a24e-721f2bf9c50e"
+   },
+   "source": [
+    "Bonds are also objects in RDKit, and we can iterate over them the same way we can iterate over atoms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64a6fb8f-bfc2-45a6-8659-641a6c47f574",
+   "metadata": {
+    "id": "64a6fb8f-bfc2-45a6-8659-641a6c47f574"
+   },
+   "outputs": [],
+   "source": [
+    "acetic_acid_bonds = acetic_acid.GetBonds()\n",
+    "bond = acetic_acid_bonds[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7af42942-0bf1-49c0-9478-ad162495c92e",
+   "metadata": {
+    "id": "7af42942-0bf1-49c0-9478-ad162495c92e"
+   },
+   "outputs": [],
+   "source": [
+    "bond.GetBondType()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1288c516-437e-4651-ba08-79592621793e",
+   "metadata": {
+    "id": "1288c516-437e-4651-ba08-79592621793e"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Challenge</h3>\n",
+    "\n",
+    "Use a `for` loop to print information about each bond.\n",
+    "For each bond, you should print the starting atom symbol, the ending atom symbol,\n",
+    "and the bond type.\n",
+    "\n",
+    "Your output should look like the following:\n",
+    "\n",
+    "```\n",
+    "Bond between C and C is a SINGLE bond.\n",
+    "Bond between C and O is a DOUBLE bond.\n",
+    "Bond between C and O is a SINGLE bond.\n",
+    "```\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71c91dce-e046-46ea-a74f-069f9aba99f6",
+   "metadata": {
+    "id": "71c91dce-e046-46ea-a74f-069f9aba99f6"
+   },
+   "outputs": [],
+   "source": [
+    "for bond in acetic_acid_bonds:\n",
+    "    start_atom = bond.GetBeginAtom()\n",
+    "    end_atom = bond.GetEndAtom()\n",
+    "    bond_type = bond.GetBondType()\n",
+    "    print(\n",
+    "        f\"Bond between {start_atom.GetSymbol()} and {end_atom.GetSymbol()} is a {bond_type} bond.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c076e9e2-1b3d-4979-bfb5-aa4e643b813b",
+   "metadata": {
+    "id": "c076e9e2-1b3d-4979-bfb5-aa4e643b813b"
+   },
+   "source": [
+    "## Editing Atoms with RDKit\n",
+    "\n",
+    "In addition to seeing information about atoms and bonds in our molecule, we can also use RDKit to change our molecule structure.\n",
+    "Let's consider benzene for our example. We will change one of the carbons in the benzene ring to a nitrogen to make pyridine.\n",
+    "\n",
+    "We are going to create a copy of our benzene molecule using another function from RDKit called `RWMol`. `RWMol` makes our molecule readable and writeable (or \"editable\")."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "382e0906-f3cb-4413-9bee-b1a2f2f1f718",
+   "metadata": {
+    "id": "382e0906-f3cb-4413-9bee-b1a2f2f1f718"
+   },
+   "outputs": [],
+   "source": [
+    "pyridine = Chem.RWMol(\n",
+    "    benzene\n",
+    ")  # TO DO: we will create pyridine from benzene, an RDKit mol object we already created in this noteobook\n",
+    "pyridine  # but you can see it's still benzene, not pyridine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0bd6d4f-0d4d-4536-9bf0-79e596fa01c8",
+   "metadata": {
+    "id": "d0bd6d4f-0d4d-4536-9bf0-79e596fa01c8"
+   },
+   "source": [
+    "One way we can change molecules in RDKit is to set the atomic number of a particular atom to another number.\n",
+    "To change one of the carbons in our ring to nitrogen, we can select one of the atoms and then set its atomic number to that of nitrogen (7)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f852ffe-d424-413f-8ce3-0d6e82b3324c",
+   "metadata": {
+    "id": "6f852ffe-d424-413f-8ce3-0d6e82b3324c"
+   },
+   "outputs": [],
+   "source": [
+    "atom = pyridine.GetAtomWithIdx(0)  # TO DO: Get atom with index 0 (labeled 0 above)\n",
+    "atom.SetAtomicNum(7)  # TO DO: Set the atomic number to 7\n",
+    "pyridine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63eb53d6-af12-4b67-bede-1faaf9f760a6",
+   "metadata": {
+    "id": "63eb53d6-af12-4b67-bede-1faaf9f760a6"
+   },
+   "outputs": [],
+   "source": [
+    "Chem.MolToSmiles(pyridine)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "607cba74-d60d-43a2-befa-11b74777580c",
+   "metadata": {
+    "id": "607cba74-d60d-43a2-befa-11b74777580c"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Challenge</h3>\n",
+    "\n",
+    "Change another atom in the pyridine ring to create [pyrimidine](https://en.wikipedia.org/wiki/Pyrimidine).\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d31fdcc6-6fdd-4fc2-b820-2bc17fcd3048",
+   "metadata": {
+    "id": "d31fdcc6-6fdd-4fc2-b820-2bc17fcd3048"
+   },
+   "outputs": [],
+   "source": [
+    "pyrimidine = Chem.RWMol(pyridine)  # TO DO: Create pyrimidine by starting with pyridine\n",
+    "atom = pyrimidine.GetAtomWithIdx(2)  # TO DO: Get atom with index 2 (labeled 2 above)\n",
+    "atom.SetAtomicNum(7)  # TO DO: Set the atomic number to 7\n",
+    "pyrimidine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a62f8686-83aa-4dc8-841e-2eb4e931b375",
+   "metadata": {
+    "id": "a62f8686-83aa-4dc8-841e-2eb4e931b375"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "021f75c5-a9d2-4767-935c-8a46d4f22812",
+   "metadata": {
+    "id": "021f75c5-a9d2-4767-935c-8a46d4f22812"
+   },
+   "source": [
+    "## Combining two molecules\n",
+    "\n",
+    "We can also create and combine molecules using RDKit. This approach might be necessary when we want to add a more complex functional group. In the example below we create a carboxyl group and add it to benzene to make benzoic acid.\n",
+    "\n",
+    "First we create the molecule for our functional group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ca7648c-8857-405c-a747-8c41ee5db922",
+   "metadata": {
+    "id": "1ca7648c-8857-405c-a747-8c41ee5db922"
+   },
+   "outputs": [],
+   "source": [
+    "carboxyl = Chem.MolFromSmiles(\"C(=O)O\")\n",
+    "carboxyl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f81da17-5b67-486c-821e-74cba04c053d",
+   "metadata": {
+    "id": "3f81da17-5b67-486c-821e-74cba04c053d"
+   },
+   "source": [
+    "Next, we combine the two molecules together using the `CombineMols` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13dd67a7-afd2-4698-92e5-455bbdeca12a",
+   "metadata": {
+    "id": "13dd67a7-afd2-4698-92e5-455bbdeca12a"
+   },
+   "outputs": [],
+   "source": [
+    "combined = Chem.CombineMols(benzene, carboxyl)\n",
+    "combined"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec93dc59-4468-446e-a03f-b2715597c45c",
+   "metadata": {
+    "id": "ec93dc59-4468-446e-a03f-b2715597c45c"
+   },
+   "source": [
+    "After the combining, we have to make our combined molecules editable so that we can change the bonds and atoms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5459cbf8-5773-43a5-b947-03fcd8da515d",
+   "metadata": {
+    "id": "5459cbf8-5773-43a5-b947-03fcd8da515d"
+   },
+   "outputs": [],
+   "source": [
+    "editable_mol = Chem.RWMol(combined)\n",
+    "editable_mol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddbcf42c-2c42-437d-aca1-88fd8ba4475a",
+   "metadata": {
+    "id": "ddbcf42c-2c42-437d-aca1-88fd8ba4475a"
+   },
+   "source": [
+    "Finally, we can use `AddBonds` to add a bond between the carbon on our carboxyl group (6) to an atom on benzene. We could have picked any carbon, but the example below uses index 5."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e6035b7-3594-4e20-8347-254d9f951bcf",
+   "metadata": {
+    "id": "7e6035b7-3594-4e20-8347-254d9f951bcf"
+   },
+   "outputs": [],
+   "source": [
+    "editable_mol.AddBond(0, 6, order=Chem.rdchem.BondType.SINGLE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07b045f6-f06d-4348-b547-900164d014ea",
+   "metadata": {
+    "id": "07b045f6-f06d-4348-b547-900164d014ea"
+   },
+   "outputs": [],
+   "source": [
+    "editable_mol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be786a94-cab6-4597-b139-267568eac415",
+   "metadata": {
+    "id": "be786a94-cab6-4597-b139-267568eac415"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<strong>Molecular Sanitization</strong>\n",
+    "\n",
+    "When a molecule is loaded into RDKit, a [\"molecular sanitization\"](https://www.rdkit.org/docs/RDKit_Book.html#molecular-sanitization) step typically takes place.\n",
+    "Molecular sanitization ensures that molecules are \"reasonable\":that they can be represented with octet-complete Lewis dot structures.\n",
+    "</div>\n",
+    "\n",
+    "After we add new atoms like this, our molecule usually needs to be \"sanitized\". One way we can tell this is by viewing the molecule above. Our aromatic ring structure is now symbolized with a dotted line inside of the ring. We will want to use the `Chem.SanitizeMol` method to sanitize the molecule.\n",
+    "The step of sanitiziation that is important in this case is the `Kekulize` step, where aromatic rings are converted to the Kekule form. A Python error (exception) would occur if a problem is found with aromaticity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa9dbe5c-32cc-438d-9aca-aa3e1b515836",
+   "metadata": {
+    "id": "fa9dbe5c-32cc-438d-9aca-aa3e1b515836"
+   },
+   "outputs": [],
+   "source": [
+    "Chem.SanitizeMol(editable_mol)\n",
+    "editable_mol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf0b95ef-bf40-4349-bbd4-1eaa3e47982e",
+   "metadata": {
+    "id": "cf0b95ef-bf40-4349-bbd4-1eaa3e47982e"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h2>Final Challenge</h2>\n",
+    "\n",
+    "[Protein phoshorylation](https://www.thermofisher.com/us/en/home/life-science/protein-biology/protein-biology-learning-center/protein-biology-resource-library/pierce-protein-methods/phosphorylation.html) refers to the additon of a phosphate group to the -OH group of an amino acid and occurs for serine, threonine, or tyrosine residues.\n",
+    "\n",
+    "For this challenge, you should modify the tyrosine module (given below) to add a phosphate to the OH group.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41f63879-b4e0-44af-b57e-69d61a738a79",
+   "metadata": {
+    "id": "41f63879-b4e0-44af-b57e-69d61a738a79"
+   },
+   "outputs": [],
+   "source": [
+    "tyrosine = Chem.MolFromSmiles(\n",
+    "    \"C1=CC(=CC=C1C[C@@H](C(=O)O)N)O\"\n",
+    ")  # TO DO: Go to the PubChem site to get the SMILES string for tyrosine and place it between the quote marks\n",
+    "tyrosine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68f3753a-c5b2-4102-b3ac-b5d90dc60019",
+   "metadata": {
+    "id": "68f3753a-c5b2-4102-b3ac-b5d90dc60019"
+   },
+   "outputs": [],
+   "source": [
+    "phosphate = Chem.MolFromSmiles(\n",
+    "    \"P(=O)(O)O\"\n",
+    ")  # TO DO: Write the SMILES string for a phosphate group (phosphorous bound to 3 oxygens)\n",
+    "phosphate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5372f1c9-c22e-4ea0-8bef-a996dd7a3485",
+   "metadata": {
+    "id": "5372f1c9-c22e-4ea0-8bef-a996dd7a3485"
+   },
+   "outputs": [],
+   "source": [
+    "combined2 = Chem.CombineMols(\n",
+    "    tyrosine, phosphate\n",
+    ")  # TO DO: Place the names of the two RDKit mol objects you want to combine in the parentheses\n",
+    "combined2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91b5aae7-8c31-4e7b-9b2e-f0c5281e7b6c",
+   "metadata": {
+    "id": "91b5aae7-8c31-4e7b-9b2e-f0c5281e7b6c"
+   },
+   "outputs": [],
+   "source": [
+    "editable_mol2 = Chem.RWMol(\n",
+    "    combined2\n",
+    ")  # TO DO: Make your new set of molecules editable (RW stands for Read Write)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a80d18bf-87fa-4f77-aeb7-fdb07c80b812",
+   "metadata": {
+    "id": "a80d18bf-87fa-4f77-aeb7-fdb07c80b812"
+   },
+   "outputs": [],
+   "source": [
+    "editable_mol2.AddBond(\n",
+    "    12, 13, order=Chem.rdchem.BondType.SINGLE\n",
+    ")  # TO DO: Add the bond to connect the two RDKit mol objects\n",
+    "editable_mol2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe0f047a-cac2-4e80-9ac5-ebd993f8a9d9",
+   "metadata": {
+    "id": "fe0f047a-cac2-4e80-9ac5-ebd993f8a9d9"
+   },
+   "outputs": [],
+   "source": [
+    "Chem.SanitizeMol(editable_mol2)  # This will clean it up\n",
+    "editable_mol2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "775adf1b-9f14-4a3d-b864-05fd23dae849",
+   "metadata": {
+    "id": "775adf1b-9f14-4a3d-b864-05fd23dae849"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "16d4a7bb199d969b1271ebe46f77414b0d9cd01b3c3983c2b2742fc6cd4503d3"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/prep/Filled_Notebooks/D_molecular_similarity.ipynb
+++ b/prep/Filled_Notebooks/D_molecular_similarity.ipynb
@@ -1,626 +1,670 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "10110027-0410-40ea-8950-8e4047699603",
-      "metadata": {
-        "id": "10110027-0410-40ea-8950-8e4047699603"
-      },
-      "source": [
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
-        "</div>\n",
-        "\n",
-        "# Cheminformatics: Molecular Similarity and Molecular Descriptors\n",
-        "\n",
-        "<strong>Author(s):</strong> Jessica A. Nash, The Molecular Sciences Software Institute\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "<h2>Overview</h2>\n",
-        "\n",
-        "<strong>Questions:</strong>\n",
-        "\n",
-        "- How are molecules represented on computers for cheminformatics applications?\n",
-        "\n",
-        "- How can I measure the similarity of two molecules?\n",
-        "\n",
-        "- How can I find out if a molecule contains a particular substructure?\n",
-        "\n",
-        "<strong>Objectives:</strong>\n",
-        "\n",
-        "- Learn about graph representation of molecules.\n",
-        "\n",
-        "- Learn about molecular fingerprints.\n",
-        "\n",
-        "- Use RDKit to measure molecular similarity.\n",
-        "\n",
-        "</div>\n",
-        "\n",
-        "Cheminformatics is often used in the context of molecular discovery.\n",
-        "For example, you might want to process a large number of molecules to find molecules that are similar to a target, or that contain a particular functional group.\n",
-        "But how can you tell if two molecules are similar?\n",
-        "\n",
-        "A chemist looking at two molecules might be able to make a judgment based on their chemical knowledge. However, when dealing with a large number of molecules, this problem can become intractable. There are ways to detect molecular similarity on a computer that allow fast comparison and processing of molecules.\n",
-        "\n",
-        "## Graph Representation of Molecules\n",
-        "\n",
-        "Graph theory is a branch of mathematics that studies the properties and applications of graphs, which are structures made up of nodes (or vertices) connected by edges (or lines).\n",
-        "A molecule can be represented as a graph where atoms are nodes and bonds are edges. This representation allows the use of various graph-based algorithms to analyze molecular structures.\n",
-        "The figure below (borrowed from Wikipedia) shows a graph with numbered nodes (circles) connected by edges (lines).\n",
-        "\n",
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/images/molecular_graph.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:300px;\">\n",
-        "</div>\n",
-        "\n",
-        "Image from [Wikipedia: Graph theory](https://en.wikipedia.org/wiki/Graph_theory)\n",
-        "\n",
-        "As a chemist, you probably don't have a hard time imagining a molecule as a graph. The atoms would be \"nodes\" in the graph, while the bonds would be \"edges\".\n",
-        "One can also represent bond order by changing the \"weight\" of graph edges.\n",
-        "In this view, one way to tell if molecules are the same is to check that their molecular graphs are the same.\n",
-        "\n",
-        "### Substructure Searches\n",
-        "\n",
-        "A substructure search is a cheminformatics technique used to identify molecules that contain a specific pattern or structure within a larger molecule.\n",
-        "\n",
-        "The figure below shows the beneze substructure matched in the aspirin molecule.\n",
-        "\n",
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/images/substructure.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:300px;\">\n",
-        "</div>\n",
-        "\n",
-        "One way this can be done is with graph representation and graph theory.\n",
-        "When doing substructure search using RDKit, it can check to see if the molecular graph for one molecule contains the molecular graph of a smaller molecule.\n",
-        "This is a concept called \"**subgraph isomorphism**\". You can see more about this topic in this [presentation](https://www.rdkit.org/UGM/2012/Landrum_RDKit_UGM.Fingerprints.Final.pptx.pdf).\n",
-        "\n",
-        "This is all very nice information, but you actually don't have to fully understand it in order to do a substructure search. In the cells below, we demonstrate searching molecules for a smaller structure using substructure search. As you can see from the cells, this functionality is very nicely built into RDKit.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "nn2PUoVduv_5",
-      "metadata": {
-        "id": "nn2PUoVduv_5"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install rdkit"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "7a031ff5-bf4f-4c65-b79f-5ea81ae6fdac",
-      "metadata": {
-        "id": "7a031ff5-bf4f-4c65-b79f-5ea81ae6fdac"
-      },
-      "source": [
-        "## Substracture Matches with RDKit\n",
-        "\n",
-        "Now we will move to RDKit and start looking at substructure matches. We'll begin with the SMILES string for caffeine (CN1C=NC2=C1C(=O)N(C(=O)N2C)C) which can be obtained from [PubChem](https://pubchem.ncbi.nlm.nih.gov/).\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a58f4581-13c4-478d-bafe-1e0846d3b412",
-      "metadata": {
-        "id": "a58f4581-13c4-478d-bafe-1e0846d3b412"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit import Chem\n",
-        "\n",
-        "caffeine = Chem.MolFromSmiles('CN1C=NC2=C1C(=O)N(C(=O)N2C)C')    # TO DO: Get the SMILES string for caffeine from PubChem(https://pubchem.ncbi.nlm.nih.gov/)\n",
-        "carbonyl = Chem.MolFromSmiles('C=O')                             # TO DO: Create or find the SMILES string for a carbonyl group\n",
-        "\n",
-        "matches = caffeine.GetSubstructMatches(carbonyl)       # Insert the variable that represents the substructure you want to find in caffeine in the parentheses\n",
-        "\n",
-        "caffeine"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "32a4c55b-362f-472b-a784-105b5c4fe015",
-      "metadata": {
-        "id": "32a4c55b-362f-472b-a784-105b5c4fe015"
-      },
-      "source": [
-        "As you can see above, we can define two molecules and search for one inside of the other.\n",
-        "\n",
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Check Your Understanding</h3>\n",
-        "\n",
-        "Using the skills you've learned already, perform a substructure search for methyl groups in caffeine in the cell below.\n",
-        "\n",
-        "</div>\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "efabcc57-46cf-4742-b39a-e0261307c07f",
-      "metadata": {
-        "id": "efabcc57-46cf-4742-b39a-e0261307c07f"
-      },
-      "outputs": [],
-      "source": [
-        "# put your code for a caffeine substructure search here\n",
-        "\n",
-        "caffeine = Chem.MolFromSmiles('CN1C=NC2=C1C(=O)N(C(=O)N2C)C')           # TO DO: Insert the SMILES string for caffeine\n",
-        "methyl = Chem.MolFromSmiles('C')                                         # TO DO: Insert the SMILES string for a methyl group\n",
-        "\n",
-        "matches = caffeine.GetSubstructMatches(methyl)                                # Look for methyl groups in caffeine\n",
-        "\n",
-        "caffeine"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cd03244e-945a-4265-b544-10a2dbffd5e4",
-      "metadata": {
-        "id": "cd03244e-945a-4265-b544-10a2dbffd5e4"
-      },
-      "source": [
-        "From the substructure search in the cell above, you are probably seeing that you're not matching exactly what you want. In order to find just the methyl groups, we have to use yet another molecular representation.\n",
-        "\n",
-        "#### SMARTS Strings\n",
-        "\n",
-        "A [SMARTS (SMiles ARbitrary Target Specification)](https://en.wikipedia.org/wiki/SMILES_arbitrary_target_specification) string is a pattern-matching language for specifying substructures in molecules. It is similar to SMILES but has additional features for specifying atom and bond properties. In contrast to SMILES, SMARTS allows for specifying substructures based on patterns of atoms and bonds, rather than just specifying the exact arrangement of atoms and bonds in a molecule.\n",
-        "\n",
-        "In this case, we want to highlight the methyl group in caffeine, which contains a single carbon atom bonded to three hydrogen atoms. We can use a SMARTS string to define this substructure as `[CH3]`, which represents a carbon atom with three hydrogen atoms bonded to it.\n",
-        "\n",
-        "Using a SMARTS string is necessary in this case because simply searching for a single carbon atom with the code `carbon = Chem.MolFromSmiles('C')` highlights all carbons in the molecule, not just the methyl group. By using a SMARTS string, we can specify the exact substructure we want to highlight and avoid highlighting unintended parts of the molecule.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1b5bba4e-91de-4c91-986b-049e0cac168c",
-      "metadata": {
-        "id": "1b5bba4e-91de-4c91-986b-049e0cac168c"
-      },
-      "outputs": [],
-      "source": [
-        "caffeine = Chem.MolFromSmiles(\"CN1C=NC2=C1C(=O)N(C(=O)N2C)C\")                 # TO DO: enter the SMILES string for caffeine\n",
-        "methyl_pattern = Chem.MolFromSmarts(\"[CH3]\")                                  # The SMARTS string for the methyl group is [CH3]\n",
-        "\n",
-        "# Get the indices of the matching atoms\n",
-        "matches = caffeine.GetSubstructMatches(methyl_pattern)                        # TO DO: Enter the match pattern\n",
-        "caffeine"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "89d4a8b5-0454-46bd-9805-8e72a60f08ef",
-      "metadata": {
-        "id": "89d4a8b5-0454-46bd-9805-8e72a60f08ef"
-      },
-      "source": [
-        "### Exercise\n",
-        "\n",
-        "Create an RDKit molecule object for aspirin. You can find its SMILES representation by using [PubChem](https://pubchem.ncbi.nlm.nih.gov/).\n",
-        "\n",
-        "Visualize the molecule, highlighting any carboxyl groups in the structure. Use a SMARTS string to define the carboxyl group substructure.\n",
-        "\n",
-        "**Important:** Unless you know the rules for writing SMARTS strings (which you would have learned somewhere else, because we didn't cover it), it's unlikely that you'll guess what the SMARTS for carboxyl is. You can see a list of SMARTS strings for different functional groups [at this link](https://www.daylight.com/dayhtml_tutorials/languages/smarts/smarts_examples.html).\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "03bf284b-6730-43b6-8c5b-242d095853eb",
-      "metadata": {
-        "id": "03bf284b-6730-43b6-8c5b-242d095853eb"
-      },
-      "outputs": [],
-      "source": [
-        "aspirin = Chem.MolFromSmiles('CC(=O)OC1=CC=CC=C1C(=O)O')        # TO DO: insert the SMILES string for aspirin between the quote signs\n",
-        "carboxyl_pattern = Chem.MolFromSmarts('[CX3](=O)[OX2H1]')       # TO DO: Go to https://www.daylight.com/dayhtml_tutorials/languages/smarts/smarts_examples.html to findthe SMARTS string for carboxyl group\n",
-        "\n",
-        "# Get the indices of the matching atoms\n",
-        "\n",
-        "matches = aspirin.GetSubstructMatches(carboxyl_pattern)         # TO DO: insert the variable name for the carboxyl pattern in the parentheses\n",
-        "aspirin\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "4a25724d-2e54-4a1a-b5b8-3a0da72b8e97",
-      "metadata": {
-        "id": "4a25724d-2e54-4a1a-b5b8-3a0da72b8e97"
-      },
-      "source": [
-        "## Molecular Fingerprints\n",
-        "\n",
-        "Molecular fingerprints are representations of molecules that are usually bit strings, or vectors of 0's and 1's. Fingerprints are built by considering the molecular structure (often as a graph representation) and applying a certain algorithm to create the vector. The image below shows a representation of a molecular fingerprint. The molecule is separated into different parts with each part setting a bit (changing a 0 to a 1) in the fingerprint.\n",
-        "\n",
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/images/molecular_fingerprint.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
-        "</div>\n",
-        "\n",
-        "Image from [Chemistry LibreTexts](https://chem.libretexts.org/Courses/Intercollegiate_Courses/Cheminformatics/06%3A_Molecular_Similarity/6.01%3A_Molecular_Descriptors) [Cheminformatics Course](https://chem.libretexts.org/Courses/Intercollegiate_Courses/Cheminformatics)\n",
-        "\n",
-        "The exact fingerprint will depend on the algorithm that is used to construct it.\n",
-        "There are many different fingerprinting algorithms. But they tend to fall into two types of groups - similarity or substructure fingerprints. A common similarity fingerprint that is used is the Morgan fingerprint. A common substructure fingerprint that is used is the [Daylight fingerprint](https://www.daylight.com/dayhtml/doc/theory/theory.finger.html) (the RDKFingerprint is a Daylight-like fingerprint).\n",
-        "\n",
-        "The cell below calculates the RDKit fingerprint for caffeine.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ca97af7e-cc2c-49e1-ab71-7e8058106131",
-      "metadata": {
-        "id": "ca97af7e-cc2c-49e1-ab71-7e8058106131"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem import AllChem\n",
-        "\n",
-        "aspirin = Chem.MolFromSmiles(\"CC(=O)OC1=CC=CC=C1C(=O)O\")   # TO DO: Insert the SMILES string for aspirin\n",
-        "benzene = Chem.MolFromSmiles(\"c1ccccc1\")                   # TO DO: Insert the SMILES string for benzene - Can you preduct it?\n",
-        "\n",
-        "aspirin_fingerprint = AllChem.RDKFingerprint(aspirin)\n",
-        "\n",
-        "type(aspirin_fingerprint)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c3ef1152-d5c1-40a9-a66d-0a0f3c83facc",
-      "metadata": {
-        "id": "c3ef1152-d5c1-40a9-a66d-0a0f3c83facc"
-      },
-      "source": [
-        "You usually wouldn't interact with a fingerprint directly, but using RDKit we can examine it to understand more about how it works.\n",
-        "We can print the bit string representation using `.ToBitString`.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "71d91ca4-4848-46ee-9441-9bb81bec48ae",
-      "metadata": {
-        "id": "71d91ca4-4848-46ee-9441-9bb81bec48ae"
-      },
-      "outputs": [],
-      "source": [
-        "aspirin_fingerprint.ToBitString()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c79828c2-5b84-43f0-bb2d-f04d95141d9a",
-      "metadata": {
-        "id": "c79828c2-5b84-43f0-bb2d-f04d95141d9a"
-      },
-      "source": [
-        "If you print the benzene string, you will see a string of the same length, but with fewer bits set.\n",
-        "There are fewer bits because there are fewer molecular patterns in the smaller molecule.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9018a8f0-0e32-4e32-8cad-377e5cfe5838",
-      "metadata": {
-        "id": "9018a8f0-0e32-4e32-8cad-377e5cfe5838"
-      },
-      "outputs": [],
-      "source": [
-        "benzene_fingerprint = AllChem.RDKFingerprint(benzene)     # TO DO: Insert the variable that represents the benzene mol object\n",
-        "benzene_string = benzene_fingerprint.ToBitString()        # You need the parentheses after ToBitString because it is a method, but you don't need to insert anything in the parentheses in this case.\n",
-        "\n",
-        "print(benzene_string)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "781dd591-b789-4283-93b2-ffe684ee61c9",
-      "metadata": {
-        "id": "781dd591-b789-4283-93b2-ffe684ee61c9"
-      },
-      "source": [
-        "Using this bit string, we can do a number of different analyses.\n",
-        "For example, substructure searches using bit strings check that bits that are set in the smaller molecule are also set in the larger target molecule.\n",
-        "\n",
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Exercise</h3>\n",
-        "\n",
-        "Fill in the for loop below to check that bits set in the aspirin fingerprint string are also set in the benzene fingerprint string.\n",
-        "\n",
-        "</div>\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "e0869b43-18dd-4714-af92-1de49932eb2b",
-      "metadata": {
-        "id": "e0869b43-18dd-4714-af92-1de49932eb2b"
-      },
-      "outputs": [],
-      "source": [
-        "aspirin_string = aspirin_fingerprint.ToBitString()\n",
-        "num_bits = len(benzene_string)\n",
-        "matches = 0\n",
-        "\n",
-        "for i in range(num_bits):\n",
-        "    if benzene_string[i] == \"1\":\n",
-        "        print(aspirin_string[i] == benzene_string[i])      # TO DO: enter a boolean comparison of the aspirin string to the benzene string\n",
-        "        matches =+ 1                                       # TO DO: increment the counter\n",
-        "\n",
-        "print(f\"There are {matches} positions where the benzene fingerprint matches the aspirin fingerprint.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "9778634e-0344-4d87-a406-c0ab48b8ff75",
-      "metadata": {
-        "id": "9778634e-0344-4d87-a406-c0ab48b8ff75"
-      },
-      "source": [
-        "The above output tells us that every bit that is set in the benzene fingerprint is also set in the aspirin target. Fingerprint substructure searches are often used for faster, but less accurate substructure searches, and are commonly used for screen large numbers of molecules quickly.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c9e5ecb4-5348-4f3d-b519-4fbff21f666a",
-      "metadata": {
-        "id": "c9e5ecb4-5348-4f3d-b519-4fbff21f666a"
-      },
-      "source": [
-        "### Measuring Similarity\n",
-        "\n",
-        "Because the fingerprints are numbers, we can measure how similar two fingerprints are using different similarity metrics.\n",
-        "One common similarity metric is called the Tanimoto similarity.\n",
-        "The Tanimoto similarity is calculated as follows:\n",
-        "\n",
-        "$$\n",
-        "T(A, B) = \\frac{A \\cap B}{A + B - A \\cap B}\n",
-        "$$\n",
-        "\n",
-        "Where:\n",
-        "\n",
-        "- $A$ and $B$: are the sets of bits in the fingerprint vectors for molecules $A$ and $B$ respectively.\n",
-        "- $A \\cap B$: This represents the intersection of sets $A$ and $B$, i.e., the number of bits that are '1' (set) in both $A$ and $B$.\n",
-        "- $A + B$: This is the sum of all '1' bits in both $A$ and $B$.\n",
-        "- $A + B - A \\cap B$: This term represents the union of sets $A$ and $B$, calculated as the total number of unique '1' bits across both fingerprints.\n",
-        "\n",
-        "The Tanimoto similarity ranges from 0.0 to 1.0, with 1.0 representing identical fingerprints.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "820dd583-c661-4db5-b510-aa204e0c0f26",
-      "metadata": {
-        "id": "820dd583-c661-4db5-b510-aa204e0c0f26"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit import DataStructs\n",
-        "\n",
-        "DataStructs.TanimotoSimilarity(benzene_fingerprint, aspirin_fingerprint)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "75edf094-0dbb-4094-93bc-cf0cc113c51d",
-      "metadata": {
-        "id": "75edf094-0dbb-4094-93bc-cf0cc113c51d"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Exercise</h3>\n",
-        "\n",
-        "Use the Tanimoto similarity to measure if benzene is more similar to pyridine or aniline using the RDKit fingerprint. For this type of exercise, it is best to break it down in a series of steps. In this case:\n",
-        "\n",
-        "- Get the SMILES strings for aniline and pyridine from [PubChem](https://pubchem.ncbi.nlm.nih.gov/) and assign each to a variable.\n",
-        "- Use AllChem.RDKFingerprint to generate the fingerprint for each molecule.\n",
-        "- Use the TanimotoSimilarity function to compare each molecule to benzene.\n",
-        "\n",
-        "</div>\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a47675e2-4294-4625-a71a-4b411566f908",
-      "metadata": {
-        "id": "a47675e2-4294-4625-a71a-4b411566f908"
-      },
-      "outputs": [],
-      "source": [
-        "aniline = Chem.MolFromSmiles('C1=CC=C(C=C1)N')                     # TO DO: Get the SMILES string for aniline from PubChem(https://pubchem.ncbi.nlm.nih.gov/)\n",
-        "pyridine = Chem.MolFromSmiles('C1=CC=NC=C1')                      # TO DO: Get the SMILES string for pyridine from PubChem(https://pubchem.ncbi.nlm.nih.gov/)\n",
-        "\n",
-        "aniline_fingerprint = AllChem.RDKFingerprint(aniline)              # TO DO: Generate the fingerprint for aniline\n",
-        "pyridine_fingerprint = AllChem.RDKFingerprint(pyridine)            # TO DO: Generate the fingerprint for pyridine\n",
-        "\n",
-        "similarity = DataStructs.TanimotoSimilarity(benzene_fingerprint, aniline_fingerprint)       # TO DO: Compare the fingerprints for benzene and aniline\n",
-        "print(f\"The Tanimoto similarity of benzene and aniline is {similarity}.\")\n",
-        "\n",
-        "similarity = DataStructs.TanimotoSimilarity(benzene_fingerprint, pyridine_fingerprint)      # TO DO: Compare the fingerprints for benzene and pyridine\n",
-        "print(f\"The Tanimoto similarity of benzene and pyridine is {similarity}.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "92228613-2c40-46c0-823b-63ec2700da07",
-      "metadata": {
-        "id": "92228613-2c40-46c0-823b-63ec2700da07"
-      },
-      "source": [
-        "## Molecular Descriptors\n",
-        "\n",
-        "The fingerprints discussed above are examples of **molecular descriptors**.\n",
-        "\n",
-        "A molecular descriptor is a numerical value that represents some property of a molecule.\n",
-        "If we want to be able to create a model that describes chemical behavior, we have to be able to convert information about molecules into numerical representations.\n",
-        "This is where the concept of a molecular descriptor comes in.\n",
-        "\n",
-        "Descriptors can be 0 dimensional (molecular weight, number of heavy atoms, etc.), 1 dimensional (counts of atom types, hydrogen bond donors/acceptors), 2 dimensional (fingerprints, other graph representations), 3 dimensional (polar surface area). The dimensionality of the descriptor defines what kind of dimensional information you need about the molecule in order to define the descriptor. For example, the fingerprint, a 2D descriptor, depends on the connectivity, or 2 dimensional structure of the molecule.\n",
-        "\n",
-        "RDKit supports the calculation of many molecular descriptors. You can see a [full list of RDKit descriptors](https://www.rdkit.org/docs/GettingStartedInPython.html#list-of-available-descriptors) or [see the module documentation](https://www.rdkit.org/docs/source/rdkit.Chem.Descriptors.html).\n",
-        "\n",
-        "To get molecular descriptors from RDKit, we import the `Descriptors` module.\n",
-        "\n",
-        "```python\n",
-        "from rdkit.Chem import Descriptors\n",
-        "```\n",
-        "\n",
-        "To get a descriptor, you do\n",
-        "\n",
-        "```python\n",
-        "Descriptors.descriptor_name(molecule_variable)\n",
-        "\n",
-        "```\n",
-        "\n",
-        "For example, we can calculate the molecular weight of our caffeine molecule\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6e860c2f-672b-419f-ab2c-ee58602ab422",
-      "metadata": {
-        "id": "6e860c2f-672b-419f-ab2c-ee58602ab422"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem import Descriptors\n",
-        "\n",
-        "caffeine_mol_wt = Descriptors.MolWt(caffeine)     # TO DO: insert the name of the RDKit mol object for caffeine that you defined above\n",
-        "print(caffeine_mol_wt)                            # TO DO: print the molecular weight of caffeine"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "7986dcba-1058-49f6-9788-5433288377bd",
-      "metadata": {
-        "id": "7986dcba-1058-49f6-9788-5433288377bd"
-      },
-      "source": [
-        "RDKit provides hundreds of molecular descriptors.\n",
-        "You can calculate all of the molecular descriptors for a molecule at once using `CalcMolDescriptors`.\n",
-        "\n",
-        "As an example of how we can apply molecular descriptors to make predictions, we will consider Lipinski's Rule of 5.\n",
-        "Lipinski's Rule of 5 is a **guideline** that helps determine if a drug is likely to be absorbed well by the body. It states that good oral drugs typically have no more than 5 hydrogen bond donors, 10 hydrogen bond acceptors, a molecular weight under 500 daltons, and a log P (measure of solubility) under 5.\n",
-        "\n",
-        "- Molecular Weight <= 500 Da\n",
-        "- No. Hydrogen Bond Donors <= 5\n",
-        "- No. Hydrogen Bond Acceptors <= 10\n",
-        "- LogP <= 5\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "988dcfa9-389a-42c4-bb9b-4f68666f4583",
-      "metadata": {
-        "id": "988dcfa9-389a-42c4-bb9b-4f68666f4583"
-      },
-      "outputs": [],
-      "source": [
-        "MW = Descriptors.MolWt(aspirin)\n",
-        "HBA = Descriptors.NOCount(aspirin)\n",
-        "HBD = Descriptors.NHOHCount(aspirin)\n",
-        "LogP = Descriptors.MolLogP(aspirin)\n",
-        "\n",
-        "rules = [ MW <= 500, HBD <=5, HBA <=10, LogP <=5 ]\n",
-        "print(rules)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "8cc4c878-c5c6-4cbc-9e10-91b9760b9201",
-      "metadata": {
-        "id": "8cc4c878-c5c6-4cbc-9e10-91b9760b9201"
-      },
-      "source": [
-        "Based on these rules, aspirin is expected to be well-absorbed by the body.\n",
-        "\n",
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h2>Final Challenge</h2>\n",
-        "\n",
-        "Check Lipinski's Rule of 5 for [insulin](https://pubchem.ncbi.nlm.nih.gov/compound/Insulin#section=Canonical-SMILES).\n",
-        "Do you expect that insulin will be well-absorbed when taken orally based on these criteria?\n",
-        "\n",
-        "</div>\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1c0aa9ee-1f21-40c6-ae04-86c6abdeb245",
-      "metadata": {
-        "id": "1c0aa9ee-1f21-40c6-ae04-86c6abdeb245"
-      },
-      "outputs": [],
-      "source": [
-        "# Create an RDKit mol object for insulin, using the SMILES string for insulin from PubChem\n",
-        "\n",
-        "insulin = Chem.MolFromSmiles(\"CC[C@@H](C)[C@H]1C(=O)N[C@@H]2CSSC[C@@H](C(=O)N[C@@H](CSSC[C@@H](C(=O)NCC(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@@H](CSSC[C@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC2=O)CO)CC(C)C)CC3=CC=C(C=C3)O)CCC(=O)N)CC(C)C)CCC(=O)O)CC(=O)N)CC4=CC=C(C=C4)O)C(=O)N[C@@H](CC(=O)N)C(=O)O)C(=O)NCC(=O)N[C@@H](CCC(=O)O)C(=O)N[C@@H](CCCNC(=N)N)C(=O)NCC(=O)N[C@@H](CC5=CC=CC=C5)C(=O)N[C@@H](CC6=CC=CC=C6)C(=O)N[C@@H](CC7=CC=C(C=C7)O)C(=O)N[C@@H]([C@H](C)O)C(=O)N8CCC[C@H]8C(=O)N[C@@H](CCCCN)C(=O)N[C@@H]([C@H](C)O)C(=O)O)C(C)C)CC(C)C)CC9=CC=C(C=C9)O)CC(C)C)C)CCC(=O)O)C(C)C)CC(C)C)CC2=CNC=N2)CO)NC(=O)[C@H](CC(C)C)NC(=O)[C@H](CC2=CNC=N2)NC(=O)[C@H](CCC(=O)N)NC(=O)[C@H](C(=O)N)NC(=O)[C@H](C(C)C)NC(=O)[C@H](CC2=CC=CC=C2)N)C(=O)N[C@H](C(=O)N[C@H](C(=O)N1)CO)[C@H](C)O)NC(=O)[C@H](CCC(=O)N)NC(=O)[C@H](CCC(=O)O)NC(=O)[C@H](C(C)C)NC(=O)[C@H]([C@H](C)CC)NC(=O)CN\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f00ab72a-2e36-4562-b5ad-e829a2a93e8b",
-      "metadata": {
-        "id": "f00ab72a-2e36-4562-b5ad-e829a2a93e8b"
-      },
-      "outputs": [],
-      "source": [
-        "# Determine the Lipinski descriptors for insulin using the RDKit mol object for insulin\n",
-        "\n",
-        "MW = Descriptors.MolWt(insulin)\n",
-        "HBA = Descriptors.NOCount(insulin)\n",
-        "HBD = Descriptors.NHOHCount(insulin)\n",
-        "LogP = Descriptors.MolLogP(insulin)\n",
-        "\n",
-        "print(MW, HBA, HBD, LogP)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "7c22fe39-8bb3-4476-a11f-56e4e8f6508d",
-      "metadata": {
-        "id": "7c22fe39-8bb3-4476-a11f-56e4e8f6508d"
-      },
-      "outputs": [],
-      "source": [
-        "# Determine how these descriptors compare with Lipinski's rule of 5\n",
-        "\n",
-        "rules = [ MW <= 500, HBD <=5, HBA <=10, LogP <=5 ]\n",
-        "print(rules)"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.2"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "10110027-0410-40ea-8950-8e4047699603",
+   "metadata": {
+    "id": "10110027-0410-40ea-8950-8e4047699603"
+   },
+   "source": [
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+    "</div>\n",
+    "\n",
+    "# Cheminformatics: Molecular Similarity and Molecular Descriptors\n",
+    "\n",
+    "<strong>Author(s):</strong> Jessica A. Nash, The Molecular Sciences Software Institute\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2>Overview</h2>\n",
+    "\n",
+    "<strong>Questions:</strong>\n",
+    "\n",
+    "- How are molecules represented on computers for cheminformatics applications?\n",
+    "\n",
+    "- How can I measure the similarity of two molecules?\n",
+    "\n",
+    "- How can I find out if a molecule contains a particular substructure?\n",
+    "\n",
+    "<strong>Objectives:</strong>\n",
+    "\n",
+    "- Learn about graph representation of molecules.\n",
+    "\n",
+    "- Learn about molecular fingerprints.\n",
+    "\n",
+    "- Use RDKit to measure molecular similarity.\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "Cheminformatics is often used in the context of molecular discovery.\n",
+    "For example, you might want to process a large number of molecules to find molecules that are similar to a target, or that contain a particular functional group.\n",
+    "But how can you tell if two molecules are similar?\n",
+    "\n",
+    "A chemist looking at two molecules might be able to make a judgment based on their chemical knowledge. However, when dealing with a large number of molecules, this problem can become intractable. There are ways to detect molecular similarity on a computer that allow fast comparison and processing of molecules.\n",
+    "\n",
+    "## Graph Representation of Molecules\n",
+    "\n",
+    "Graph theory is a branch of mathematics that studies the properties and applications of graphs, which are structures made up of nodes (or vertices) connected by edges (or lines).\n",
+    "A molecule can be represented as a graph where atoms are nodes and bonds are edges. This representation allows the use of various graph-based algorithms to analyze molecular structures.\n",
+    "The figure below (borrowed from Wikipedia) shows a graph with numbered nodes (circles) connected by edges (lines).\n",
+    "\n",
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/images/molecular_graph.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:300px;\">\n",
+    "</div>\n",
+    "\n",
+    "Image from [Wikipedia: Graph theory](https://en.wikipedia.org/wiki/Graph_theory)\n",
+    "\n",
+    "As a chemist, you probably don't have a hard time imagining a molecule as a graph. The atoms would be \"nodes\" in the graph, while the bonds would be \"edges\".\n",
+    "One can also represent bond order by changing the \"weight\" of graph edges.\n",
+    "In this view, one way to tell if molecules are the same is to check that their molecular graphs are the same.\n",
+    "\n",
+    "### Substructure Searches\n",
+    "\n",
+    "A substructure search is a cheminformatics technique used to identify molecules that contain a specific pattern or structure within a larger molecule.\n",
+    "\n",
+    "The figure below shows the beneze substructure matched in the aspirin molecule.\n",
+    "\n",
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/images/substructure.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:300px;\">\n",
+    "</div>\n",
+    "\n",
+    "One way this can be done is with graph representation and graph theory.\n",
+    "When doing substructure search using RDKit, it can check to see if the molecular graph for one molecule contains the molecular graph of a smaller molecule.\n",
+    "This is a concept called \"**subgraph isomorphism**\". You can see more about this topic in this [presentation](https://www.rdkit.org/UGM/2012/Landrum_RDKit_UGM.Fingerprints.Final.pptx.pdf).\n",
+    "\n",
+    "This is all very nice information, but you actually don't have to fully understand it in order to do a substructure search. In the cells below, we demonstrate searching molecules for a smaller structure using substructure search. As you can see from the cells, this functionality is very nicely built into RDKit.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nn2PUoVduv_5",
+   "metadata": {
+    "id": "nn2PUoVduv_5"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rdkit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a031ff5-bf4f-4c65-b79f-5ea81ae6fdac",
+   "metadata": {
+    "id": "7a031ff5-bf4f-4c65-b79f-5ea81ae6fdac"
+   },
+   "source": [
+    "## Substracture Matches with RDKit\n",
+    "\n",
+    "Now we will move to RDKit and start looking at substructure matches. We'll begin with the SMILES string for caffeine (CN1C=NC2=C1C(=O)N(C(=O)N2C)C) which can be obtained from [PubChem](https://pubchem.ncbi.nlm.nih.gov/).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a58f4581-13c4-478d-bafe-1e0846d3b412",
+   "metadata": {
+    "id": "a58f4581-13c4-478d-bafe-1e0846d3b412"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit import Chem\n",
+    "\n",
+    "caffeine = Chem.MolFromSmiles(\n",
+    "    \"CN1C=NC2=C1C(=O)N(C(=O)N2C)C\"\n",
+    ")  # TO DO: Get the SMILES string for caffeine from PubChem(https://pubchem.ncbi.nlm.nih.gov/)\n",
+    "carbonyl = Chem.MolFromSmiles(\n",
+    "    \"C=O\"\n",
+    ")  # TO DO: Create or find the SMILES string for a carbonyl group\n",
+    "\n",
+    "matches = caffeine.GetSubstructMatches(\n",
+    "    carbonyl\n",
+    ")  # Insert the variable that represents the substructure you want to find in caffeine in the parentheses\n",
+    "\n",
+    "caffeine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32a4c55b-362f-472b-a784-105b5c4fe015",
+   "metadata": {
+    "id": "32a4c55b-362f-472b-a784-105b5c4fe015"
+   },
+   "source": [
+    "As you can see above, we can define two molecules and search for one inside of the other.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Check Your Understanding</h3>\n",
+    "\n",
+    "Using the skills you've learned already, perform a substructure search for methyl groups in caffeine in the cell below.\n",
+    "\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efabcc57-46cf-4742-b39a-e0261307c07f",
+   "metadata": {
+    "id": "efabcc57-46cf-4742-b39a-e0261307c07f"
+   },
+   "outputs": [],
+   "source": [
+    "# put your code for a caffeine substructure search here\n",
+    "\n",
+    "caffeine = Chem.MolFromSmiles(\n",
+    "    \"CN1C=NC2=C1C(=O)N(C(=O)N2C)C\"\n",
+    ")  # TO DO: Insert the SMILES string for caffeine\n",
+    "methyl = Chem.MolFromSmiles(\"C\")  # TO DO: Insert the SMILES string for a methyl group\n",
+    "\n",
+    "matches = caffeine.GetSubstructMatches(methyl)  # Look for methyl groups in caffeine\n",
+    "\n",
+    "caffeine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd03244e-945a-4265-b544-10a2dbffd5e4",
+   "metadata": {
+    "id": "cd03244e-945a-4265-b544-10a2dbffd5e4"
+   },
+   "source": [
+    "From the substructure search in the cell above, you are probably seeing that you're not matching exactly what you want. In order to find just the methyl groups, we have to use yet another molecular representation.\n",
+    "\n",
+    "#### SMARTS Strings\n",
+    "\n",
+    "A [SMARTS (SMiles ARbitrary Target Specification)](https://en.wikipedia.org/wiki/SMILES_arbitrary_target_specification) string is a pattern-matching language for specifying substructures in molecules. It is similar to SMILES but has additional features for specifying atom and bond properties. In contrast to SMILES, SMARTS allows for specifying substructures based on patterns of atoms and bonds, rather than just specifying the exact arrangement of atoms and bonds in a molecule.\n",
+    "\n",
+    "In this case, we want to highlight the methyl group in caffeine, which contains a single carbon atom bonded to three hydrogen atoms. We can use a SMARTS string to define this substructure as `[CH3]`, which represents a carbon atom with three hydrogen atoms bonded to it.\n",
+    "\n",
+    "Using a SMARTS string is necessary in this case because simply searching for a single carbon atom with the code `carbon = Chem.MolFromSmiles('C')` highlights all carbons in the molecule, not just the methyl group. By using a SMARTS string, we can specify the exact substructure we want to highlight and avoid highlighting unintended parts of the molecule.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b5bba4e-91de-4c91-986b-049e0cac168c",
+   "metadata": {
+    "id": "1b5bba4e-91de-4c91-986b-049e0cac168c"
+   },
+   "outputs": [],
+   "source": [
+    "caffeine = Chem.MolFromSmiles(\n",
+    "    \"CN1C=NC2=C1C(=O)N(C(=O)N2C)C\"\n",
+    ")  # TO DO: enter the SMILES string for caffeine\n",
+    "methyl_pattern = Chem.MolFromSmarts(\n",
+    "    \"[CH3]\"\n",
+    ")  # The SMARTS string for the methyl group is [CH3]\n",
+    "\n",
+    "# Get the indices of the matching atoms\n",
+    "matches = caffeine.GetSubstructMatches(methyl_pattern)  # TO DO: Enter the match pattern\n",
+    "caffeine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89d4a8b5-0454-46bd-9805-8e72a60f08ef",
+   "metadata": {
+    "id": "89d4a8b5-0454-46bd-9805-8e72a60f08ef"
+   },
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Create an RDKit molecule object for aspirin. You can find its SMILES representation by using [PubChem](https://pubchem.ncbi.nlm.nih.gov/).\n",
+    "\n",
+    "Visualize the molecule, highlighting any carboxyl groups in the structure. Use a SMARTS string to define the carboxyl group substructure.\n",
+    "\n",
+    "**Important:** Unless you know the rules for writing SMARTS strings (which you would have learned somewhere else, because we didn't cover it), it's unlikely that you'll guess what the SMARTS for carboxyl is. You can see a list of SMARTS strings for different functional groups [at this link](https://www.daylight.com/dayhtml_tutorials/languages/smarts/smarts_examples.html).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03bf284b-6730-43b6-8c5b-242d095853eb",
+   "metadata": {
+    "id": "03bf284b-6730-43b6-8c5b-242d095853eb"
+   },
+   "outputs": [],
+   "source": [
+    "aspirin = Chem.MolFromSmiles(\n",
+    "    \"CC(=O)OC1=CC=CC=C1C(=O)O\"\n",
+    ")  # TO DO: insert the SMILES string for aspirin between the quote signs\n",
+    "carboxyl_pattern = Chem.MolFromSmarts(\n",
+    "    \"[CX3](=O)[OX2H1]\"\n",
+    ")  # TO DO: Go to https://www.daylight.com/dayhtml_tutorials/languages/smarts/smarts_examples.html to findthe SMARTS string for carboxyl group\n",
+    "\n",
+    "# Get the indices of the matching atoms\n",
+    "\n",
+    "matches = aspirin.GetSubstructMatches(\n",
+    "    carboxyl_pattern\n",
+    ")  # TO DO: insert the variable name for the carboxyl pattern in the parentheses\n",
+    "aspirin"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a25724d-2e54-4a1a-b5b8-3a0da72b8e97",
+   "metadata": {
+    "id": "4a25724d-2e54-4a1a-b5b8-3a0da72b8e97"
+   },
+   "source": [
+    "## Molecular Fingerprints\n",
+    "\n",
+    "Molecular fingerprints are representations of molecules that are usually bit strings, or vectors of 0's and 1's. Fingerprints are built by considering the molecular structure (often as a graph representation) and applying a certain algorithm to create the vector. The image below shows a representation of a molecular fingerprint. The molecule is separated into different parts with each part setting a bit (changing a 0 to a 1) in the fingerprint.\n",
+    "\n",
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/molssicheminfo/blob/master/images/molecular_fingerprint.png?raw=true\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+    "</div>\n",
+    "\n",
+    "Image from [Chemistry LibreTexts](https://chem.libretexts.org/Courses/Intercollegiate_Courses/Cheminformatics/06%3A_Molecular_Similarity/6.01%3A_Molecular_Descriptors) [Cheminformatics Course](https://chem.libretexts.org/Courses/Intercollegiate_Courses/Cheminformatics)\n",
+    "\n",
+    "The exact fingerprint will depend on the algorithm that is used to construct it.\n",
+    "There are many different fingerprinting algorithms. But they tend to fall into two types of groups - similarity or substructure fingerprints. A common similarity fingerprint that is used is the Morgan fingerprint. A common substructure fingerprint that is used is the [Daylight fingerprint](https://www.daylight.com/dayhtml/doc/theory/theory.finger.html) (the RDKFingerprint is a Daylight-like fingerprint).\n",
+    "\n",
+    "The cell below calculates the RDKit fingerprint for caffeine.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca97af7e-cc2c-49e1-ab71-7e8058106131",
+   "metadata": {
+    "id": "ca97af7e-cc2c-49e1-ab71-7e8058106131"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem import AllChem\n",
+    "\n",
+    "aspirin = Chem.MolFromSmiles(\n",
+    "    \"CC(=O)OC1=CC=CC=C1C(=O)O\"\n",
+    ")  # TO DO: Insert the SMILES string for aspirin\n",
+    "benzene = Chem.MolFromSmiles(\n",
+    "    \"c1ccccc1\"\n",
+    ")  # TO DO: Insert the SMILES string for benzene - Can you preduct it?\n",
+    "\n",
+    "aspirin_fingerprint = AllChem.RDKFingerprint(aspirin)\n",
+    "\n",
+    "type(aspirin_fingerprint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3ef1152-d5c1-40a9-a66d-0a0f3c83facc",
+   "metadata": {
+    "id": "c3ef1152-d5c1-40a9-a66d-0a0f3c83facc"
+   },
+   "source": [
+    "You usually wouldn't interact with a fingerprint directly, but using RDKit we can examine it to understand more about how it works.\n",
+    "We can print the bit string representation using `.ToBitString`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71d91ca4-4848-46ee-9441-9bb81bec48ae",
+   "metadata": {
+    "id": "71d91ca4-4848-46ee-9441-9bb81bec48ae"
+   },
+   "outputs": [],
+   "source": [
+    "aspirin_fingerprint.ToBitString()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c79828c2-5b84-43f0-bb2d-f04d95141d9a",
+   "metadata": {
+    "id": "c79828c2-5b84-43f0-bb2d-f04d95141d9a"
+   },
+   "source": [
+    "If you print the benzene string, you will see a string of the same length, but with fewer bits set.\n",
+    "There are fewer bits because there are fewer molecular patterns in the smaller molecule.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9018a8f0-0e32-4e32-8cad-377e5cfe5838",
+   "metadata": {
+    "id": "9018a8f0-0e32-4e32-8cad-377e5cfe5838"
+   },
+   "outputs": [],
+   "source": [
+    "benzene_fingerprint = AllChem.RDKFingerprint(\n",
+    "    benzene\n",
+    ")  # TO DO: Insert the variable that represents the benzene mol object\n",
+    "benzene_string = benzene_fingerprint.ToBitString()  # You need the parentheses after ToBitString because it is a method, but you don't need to insert anything in the parentheses in this case.\n",
+    "\n",
+    "print(benzene_string)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "781dd591-b789-4283-93b2-ffe684ee61c9",
+   "metadata": {
+    "id": "781dd591-b789-4283-93b2-ffe684ee61c9"
+   },
+   "source": [
+    "Using this bit string, we can do a number of different analyses.\n",
+    "For example, substructure searches using bit strings check that bits that are set in the smaller molecule are also set in the larger target molecule.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Exercise</h3>\n",
+    "\n",
+    "Fill in the for loop below to check that bits set in the aspirin fingerprint string are also set in the benzene fingerprint string.\n",
+    "\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0869b43-18dd-4714-af92-1de49932eb2b",
+   "metadata": {
+    "id": "e0869b43-18dd-4714-af92-1de49932eb2b"
+   },
+   "outputs": [],
+   "source": [
+    "aspirin_string = aspirin_fingerprint.ToBitString()\n",
+    "num_bits = len(benzene_string)\n",
+    "matches = 0\n",
+    "\n",
+    "for i in range(num_bits):\n",
+    "    if benzene_string[i] == \"1\":\n",
+    "        print(\n",
+    "            aspirin_string[i] == benzene_string[i]\n",
+    "        )  # TO DO: enter a boolean comparison of the aspirin string to the benzene string\n",
+    "        matches = +1  # TO DO: increment the counter\n",
+    "\n",
+    "print(\n",
+    "    f\"There are {matches} positions where the benzene fingerprint matches the aspirin fingerprint.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9778634e-0344-4d87-a406-c0ab48b8ff75",
+   "metadata": {
+    "id": "9778634e-0344-4d87-a406-c0ab48b8ff75"
+   },
+   "source": [
+    "The above output tells us that every bit that is set in the benzene fingerprint is also set in the aspirin target. Fingerprint substructure searches are often used for faster, but less accurate substructure searches, and are commonly used for screen large numbers of molecules quickly.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9e5ecb4-5348-4f3d-b519-4fbff21f666a",
+   "metadata": {
+    "id": "c9e5ecb4-5348-4f3d-b519-4fbff21f666a"
+   },
+   "source": [
+    "### Measuring Similarity\n",
+    "\n",
+    "Because the fingerprints are numbers, we can measure how similar two fingerprints are using different similarity metrics.\n",
+    "One common similarity metric is called the Tanimoto similarity.\n",
+    "The Tanimoto similarity is calculated as follows:\n",
+    "\n",
+    "$$\n",
+    "T(A, B) = \\frac{A \\cap B}{A + B - A \\cap B}\n",
+    "$$\n",
+    "\n",
+    "Where:\n",
+    "\n",
+    "- $A$ and $B$: are the sets of bits in the fingerprint vectors for molecules $A$ and $B$ respectively.\n",
+    "- $A \\cap B$: This represents the intersection of sets $A$ and $B$, i.e., the number of bits that are '1' (set) in both $A$ and $B$.\n",
+    "- $A + B$: This is the sum of all '1' bits in both $A$ and $B$.\n",
+    "- $A + B - A \\cap B$: This term represents the union of sets $A$ and $B$, calculated as the total number of unique '1' bits across both fingerprints.\n",
+    "\n",
+    "The Tanimoto similarity ranges from 0.0 to 1.0, with 1.0 representing identical fingerprints.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "820dd583-c661-4db5-b510-aa204e0c0f26",
+   "metadata": {
+    "id": "820dd583-c661-4db5-b510-aa204e0c0f26"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit import DataStructs\n",
+    "\n",
+    "DataStructs.TanimotoSimilarity(benzene_fingerprint, aspirin_fingerprint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75edf094-0dbb-4094-93bc-cf0cc113c51d",
+   "metadata": {
+    "id": "75edf094-0dbb-4094-93bc-cf0cc113c51d"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Exercise</h3>\n",
+    "\n",
+    "Use the Tanimoto similarity to measure if benzene is more similar to pyridine or aniline using the RDKit fingerprint. For this type of exercise, it is best to break it down in a series of steps. In this case:\n",
+    "\n",
+    "- Get the SMILES strings for aniline and pyridine from [PubChem](https://pubchem.ncbi.nlm.nih.gov/) and assign each to a variable.\n",
+    "- Use AllChem.RDKFingerprint to generate the fingerprint for each molecule.\n",
+    "- Use the TanimotoSimilarity function to compare each molecule to benzene.\n",
+    "\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a47675e2-4294-4625-a71a-4b411566f908",
+   "metadata": {
+    "id": "a47675e2-4294-4625-a71a-4b411566f908"
+   },
+   "outputs": [],
+   "source": [
+    "aniline = Chem.MolFromSmiles(\n",
+    "    \"C1=CC=C(C=C1)N\"\n",
+    ")  # TO DO: Get the SMILES string for aniline from PubChem(https://pubchem.ncbi.nlm.nih.gov/)\n",
+    "pyridine = Chem.MolFromSmiles(\n",
+    "    \"C1=CC=NC=C1\"\n",
+    ")  # TO DO: Get the SMILES string for pyridine from PubChem(https://pubchem.ncbi.nlm.nih.gov/)\n",
+    "\n",
+    "aniline_fingerprint = AllChem.RDKFingerprint(\n",
+    "    aniline\n",
+    ")  # TO DO: Generate the fingerprint for aniline\n",
+    "pyridine_fingerprint = AllChem.RDKFingerprint(\n",
+    "    pyridine\n",
+    ")  # TO DO: Generate the fingerprint for pyridine\n",
+    "\n",
+    "similarity = DataStructs.TanimotoSimilarity(\n",
+    "    benzene_fingerprint, aniline_fingerprint\n",
+    ")  # TO DO: Compare the fingerprints for benzene and aniline\n",
+    "print(f\"The Tanimoto similarity of benzene and aniline is {similarity}.\")\n",
+    "\n",
+    "similarity = DataStructs.TanimotoSimilarity(\n",
+    "    benzene_fingerprint, pyridine_fingerprint\n",
+    ")  # TO DO: Compare the fingerprints for benzene and pyridine\n",
+    "print(f\"The Tanimoto similarity of benzene and pyridine is {similarity}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92228613-2c40-46c0-823b-63ec2700da07",
+   "metadata": {
+    "id": "92228613-2c40-46c0-823b-63ec2700da07"
+   },
+   "source": [
+    "## Molecular Descriptors\n",
+    "\n",
+    "The fingerprints discussed above are examples of **molecular descriptors**.\n",
+    "\n",
+    "A molecular descriptor is a numerical value that represents some property of a molecule.\n",
+    "If we want to be able to create a model that describes chemical behavior, we have to be able to convert information about molecules into numerical representations.\n",
+    "This is where the concept of a molecular descriptor comes in.\n",
+    "\n",
+    "Descriptors can be 0 dimensional (molecular weight, number of heavy atoms, etc.), 1 dimensional (counts of atom types, hydrogen bond donors/acceptors), 2 dimensional (fingerprints, other graph representations), 3 dimensional (polar surface area). The dimensionality of the descriptor defines what kind of dimensional information you need about the molecule in order to define the descriptor. For example, the fingerprint, a 2D descriptor, depends on the connectivity, or 2 dimensional structure of the molecule.\n",
+    "\n",
+    "RDKit supports the calculation of many molecular descriptors. You can see a [full list of RDKit descriptors](https://www.rdkit.org/docs/GettingStartedInPython.html#list-of-available-descriptors) or [see the module documentation](https://www.rdkit.org/docs/source/rdkit.Chem.Descriptors.html).\n",
+    "\n",
+    "To get molecular descriptors from RDKit, we import the `Descriptors` module.\n",
+    "\n",
+    "```python\n",
+    "from rdkit.Chem import Descriptors\n",
+    "```\n",
+    "\n",
+    "To get a descriptor, you do\n",
+    "\n",
+    "```python\n",
+    "Descriptors.descriptor_name(molecule_variable)\n",
+    "\n",
+    "```\n",
+    "\n",
+    "For example, we can calculate the molecular weight of our caffeine molecule\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e860c2f-672b-419f-ab2c-ee58602ab422",
+   "metadata": {
+    "id": "6e860c2f-672b-419f-ab2c-ee58602ab422"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem import Descriptors\n",
+    "\n",
+    "caffeine_mol_wt = Descriptors.MolWt(\n",
+    "    caffeine\n",
+    ")  # TO DO: insert the name of the RDKit mol object for caffeine that you defined above\n",
+    "print(caffeine_mol_wt)  # TO DO: print the molecular weight of caffeine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7986dcba-1058-49f6-9788-5433288377bd",
+   "metadata": {
+    "id": "7986dcba-1058-49f6-9788-5433288377bd"
+   },
+   "source": [
+    "RDKit provides hundreds of molecular descriptors.\n",
+    "You can calculate all of the molecular descriptors for a molecule at once using `CalcMolDescriptors`.\n",
+    "\n",
+    "As an example of how we can apply molecular descriptors to make predictions, we will consider Lipinski's Rule of 5.\n",
+    "Lipinski's Rule of 5 is a **guideline** that helps determine if a drug is likely to be absorbed well by the body. It states that good oral drugs typically have no more than 5 hydrogen bond donors, 10 hydrogen bond acceptors, a molecular weight under 500 daltons, and a log P (measure of solubility) under 5.\n",
+    "\n",
+    "- Molecular Weight <= 500 Da\n",
+    "- No. Hydrogen Bond Donors <= 5\n",
+    "- No. Hydrogen Bond Acceptors <= 10\n",
+    "- LogP <= 5\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "988dcfa9-389a-42c4-bb9b-4f68666f4583",
+   "metadata": {
+    "id": "988dcfa9-389a-42c4-bb9b-4f68666f4583"
+   },
+   "outputs": [],
+   "source": [
+    "MW = Descriptors.MolWt(aspirin)\n",
+    "HBA = Descriptors.NOCount(aspirin)\n",
+    "HBD = Descriptors.NHOHCount(aspirin)\n",
+    "LogP = Descriptors.MolLogP(aspirin)\n",
+    "\n",
+    "rules = [MW <= 500, HBD <= 5, HBA <= 10, LogP <= 5]\n",
+    "print(rules)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cc4c878-c5c6-4cbc-9e10-91b9760b9201",
+   "metadata": {
+    "id": "8cc4c878-c5c6-4cbc-9e10-91b9760b9201"
+   },
+   "source": [
+    "Based on these rules, aspirin is expected to be well-absorbed by the body.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h2>Final Challenge</h2>\n",
+    "\n",
+    "Check Lipinski's Rule of 5 for [insulin](https://pubchem.ncbi.nlm.nih.gov/compound/Insulin#section=Canonical-SMILES).\n",
+    "Do you expect that insulin will be well-absorbed when taken orally based on these criteria?\n",
+    "\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c0aa9ee-1f21-40c6-ae04-86c6abdeb245",
+   "metadata": {
+    "id": "1c0aa9ee-1f21-40c6-ae04-86c6abdeb245"
+   },
+   "outputs": [],
+   "source": [
+    "# Create an RDKit mol object for insulin, using the SMILES string for insulin from PubChem\n",
+    "\n",
+    "insulin = Chem.MolFromSmiles(\n",
+    "    \"CC[C@@H](C)[C@H]1C(=O)N[C@@H]2CSSC[C@@H](C(=O)N[C@@H](CSSC[C@@H](C(=O)NCC(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@H](C(=O)N[C@@H](CSSC[C@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC(=O)[C@@H](NC2=O)CO)CC(C)C)CC3=CC=C(C=C3)O)CCC(=O)N)CC(C)C)CCC(=O)O)CC(=O)N)CC4=CC=C(C=C4)O)C(=O)N[C@@H](CC(=O)N)C(=O)O)C(=O)NCC(=O)N[C@@H](CCC(=O)O)C(=O)N[C@@H](CCCNC(=N)N)C(=O)NCC(=O)N[C@@H](CC5=CC=CC=C5)C(=O)N[C@@H](CC6=CC=CC=C6)C(=O)N[C@@H](CC7=CC=C(C=C7)O)C(=O)N[C@@H]([C@H](C)O)C(=O)N8CCC[C@H]8C(=O)N[C@@H](CCCCN)C(=O)N[C@@H]([C@H](C)O)C(=O)O)C(C)C)CC(C)C)CC9=CC=C(C=C9)O)CC(C)C)C)CCC(=O)O)C(C)C)CC(C)C)CC2=CNC=N2)CO)NC(=O)[C@H](CC(C)C)NC(=O)[C@H](CC2=CNC=N2)NC(=O)[C@H](CCC(=O)N)NC(=O)[C@H](C(=O)N)NC(=O)[C@H](C(C)C)NC(=O)[C@H](CC2=CC=CC=C2)N)C(=O)N[C@H](C(=O)N[C@H](C(=O)N1)CO)[C@H](C)O)NC(=O)[C@H](CCC(=O)N)NC(=O)[C@H](CCC(=O)O)NC(=O)[C@H](C(C)C)NC(=O)[C@H]([C@H](C)CC)NC(=O)CN\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f00ab72a-2e36-4562-b5ad-e829a2a93e8b",
+   "metadata": {
+    "id": "f00ab72a-2e36-4562-b5ad-e829a2a93e8b"
+   },
+   "outputs": [],
+   "source": [
+    "# Determine the Lipinski descriptors for insulin using the RDKit mol object for insulin\n",
+    "\n",
+    "MW = Descriptors.MolWt(insulin)\n",
+    "HBA = Descriptors.NOCount(insulin)\n",
+    "HBD = Descriptors.NHOHCount(insulin)\n",
+    "LogP = Descriptors.MolLogP(insulin)\n",
+    "\n",
+    "print(MW, HBA, HBD, LogP)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c22fe39-8bb3-4476-a11f-56e4e8f6508d",
+   "metadata": {
+    "id": "7c22fe39-8bb3-4476-a11f-56e4e8f6508d"
+   },
+   "outputs": [],
+   "source": [
+    "# Determine how these descriptors compare with Lipinski's rule of 5\n",
+    "\n",
+    "rules = [MW <= 500, HBD <= 5, HBA <= 10, LogP <= 5]\n",
+    "print(rules)"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/prep/Filled_Notebooks/E_pandas_seaborn.ipynb
+++ b/prep/Filled_Notebooks/E_pandas_seaborn.ipynb
@@ -1,799 +1,809 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "1Gl__1mt1BL4"
-      },
-      "source": [
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
-        "</div>\n",
-        "\n",
-        "\n",
-        "\n",
-        "Examining and Visualizing Data\n",
-        "=============================\n",
-        "\n",
-        "<strong>Author(s):</strong> Jessica A. Nash, The Molecular Sciences Software Institute\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "<h2>Overview</h2>\n",
-        "\n",
-        "<strong>Questions:</strong>\n",
-        "\n",
-        "* How can I use pandas to process data?\n",
-        "\n",
-        "* How can I visualize relationships between different parts of my data?\n",
-        "\n",
-        "<strong>Objectives:</strong>\n",
-        "\n",
-        "* Use pandas and seaborn to load and explore data\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "lNVJomRi1BL6"
-      },
-      "source": [
-        "[Pandas](https://pandas.pydata.org/docs/) is a Python library used for data analysis and manipulation. Within the world of data science, it is a ubiquitous and widely used library. If you are learning how to analyze data in Python, it will be almost impossible to avoid pandas.\n",
-        "\n",
-        "The central data structure of pandas is called a DataFrame. Pandas DataFrames work very closely with NumPy arrays and Pandas dataframes are specifically for data which is two dimensional (rows and columns). NumPy arrays, while similar in some ways, can work with higher dimensional data.\n",
-        "\n",
-        "Pandas is very powerful. In this session, we'll be learning how to access information in pandas dataframes and how to do some basic manipulation and analysis. We are going to be looking at a dataset which gives information about the elements in the periodic table."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!pip install pandas seaborn matplotlib rdkit"
-      ],
-      "metadata": {
-        "id": "F72xtliv1KkY"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Pandas Dataframes\n",
-        "\n",
-        "In this notebook, we will load from a comma separate file (.csv - kind of a simplified version of a spreadsheet) into a pandas dataframe, which is a two-dimensional array of data in rows and columns. In this notebooks we will take advantage of some of the features that are native to pandas dataframes for data analysis and plotting."
-      ],
-      "metadata": {
-        "id": "LZV-aEQ13TZS"
-      }
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "b7KUqqPf1BL6"
-      },
-      "outputs": [],
-      "source": [
-        "import pandas as pd\n",
-        "\n",
-        "from urllib.request import urlretrieve\n",
-        "url = (\"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/PubChemElements_all.csv\")\n",
-        "filename = \"PubChemElements_all.csv\"\n",
-        "urlretrieve(url, filename)\n",
-        "\n",
-        "df = pd.read_csv(filename)\n",
-        "df"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NHnp9uqX1BL7"
-      },
-      "source": [
-        "## Examining Data"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wE8N3exr1BL7"
-      },
-      "source": [
-        "Initially when loading data in, and also at certain points as we're working with it, we'll want to see what our dataframe looks like. You can see a preview of your dataframe using the `.head` function"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "CJIaWKHf1BL7"
-      },
-      "outputs": [],
-      "source": [
-        "df.head()         # This command will display the first five rows of the dataframe. Click the variable record on the left {x} to learn more about this dataframe."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "hpDhoZea1BL7"
-      },
-      "source": [
-        "The `.info` function will give information about the columns and the data type of those columns. The data type will become very important later as we work with data more."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "scrolled": true,
-        "id": "x3eBcLoG1BL7"
-      },
-      "outputs": [],
-      "source": [
-        "df.info()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5valH56E1BL8"
-      },
-      "source": [
-        "For this dataframe, we see that the first column, `AtomicNumber` has the data type of `int64`. Here, `int` means `integer` and `64` means `64 bit`.  The `64 bit` refers to the amount of computer memory the variable can occupy. It won't really be important for us. Similarly, `float64` means `64 bit floating point`. These are decimal numbers.\n",
-        "\n",
-        "The other column names which read `object` are not numeric. They might be strings or they might be something else. We'll discuss more later.\n",
-        "\n",
-        "The `describe` function can be used on a dataframe to quickly see statistics about columns with numerical data. If you look at the columns that statistics are computed for and compare to the data type shown from `info`, you will see that we only get statistics for columns which had `int64` or `float64` data types."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "-RsOeMAv1BL8"
-      },
-      "outputs": [],
-      "source": [
-        "df.describe()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Z1M6VIS21BL8"
-      },
-      "source": [
-        "This information is extremely useful for understanding the data. We can also easily visualize the distribution of each column using Pandas's ``hist`` function."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "padZJvd91BL8"
-      },
-      "outputs": [],
-      "source": [
-        "df.hist(figsize=(8,8), edgecolor='black', grid=False)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "i4gGStV81BL8"
-      },
-      "source": [
-        "## Accessing Data\n",
-        "\n",
-        "Pandas dataframes have names for rows (called the \"index\" in Pandas) and columns.\n",
-        "\n",
-        "Pandas dataframes have rows and columns, you can see how many rows and columns using `.shape`. This will return the shape as `(num_rows, num_columns)`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "VTjUSi9s1BL8"
-      },
-      "outputs": [],
-      "source": [
-        "df.shape"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jQNFLJk21BL8"
-      },
-      "source": [
-        "There are a few methods for accessing information in a Pandas dataframe, but the one that will be most important in this workshop is selecting particular columns of data."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "d0GzycHy1BL9"
-      },
-      "outputs": [],
-      "source": [
-        "df[\"AtomicNumber\"].head()          # You can select one column by putting the column header in the square brackets. The header is a string, so it must be in quotes."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ODTdsHzj1BL9"
-      },
-      "outputs": [],
-      "source": [
-        "df[[\"Symbol\", \"ElectronConfiguration\"]].head()           # To select multiple columns, put list in brackets"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qpSayfPS1BL9"
-      },
-      "source": [
-        "## Performing calculations with pandas: No more `for` loops!\n",
-        "\n",
-        "Both pandas and NumPy dataframes have the convenient feature that they can do element-wise operations and use something called `broadcasting`. This means that if you are doing something like subtracting a number, multiplying, etc to a column or dataframe of information, it can be done all at once instead of with a `for` loop. Consider if we wanted to calculate the melting point in degrees celsius for all of the elements.\n",
-        "\n",
-        "Instead of writing a `for` loop that does this, we can just write the following code. This will return a pandas Series (one dimensional dataframe)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "PSaWkwpb1BL9"
-      },
-      "outputs": [],
-      "source": [
-        "df['MeltingPoint'] - 273.15"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5uQx_WLb1BL9"
-      },
-      "source": [
-        "We could do this one two columns as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "3wrRpOL41BL9"
-      },
-      "outputs": [],
-      "source": [
-        "df[['MeltingPoint', 'BoilingPoint']] - 273.15"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VQyz3nrz1BL9"
-      },
-      "source": [
-        "We can save these in new dataframe columns"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "rkynyMMS1BL9"
-      },
-      "outputs": [],
-      "source": [
-        "df[[\"MeltingPointC\", \"BoilingPointC\"]] = df[['MeltingPoint', 'BoilingPoint']] - 273.15\n",
-        "df.head()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rJqiEad11BL9"
-      },
-      "source": [
-        "### The `.apply` method\n",
-        "\n",
-        "The `.apply` method in pandas is used to apply a function along a row or column of a dataframe.\n",
-        "This is useful when you have a custom function that you need to use on every value in a column, but there is not a NumPy or Pandas function for it.\n",
-        "\n",
-        "For example, we could apply the `len` function to our `Name` column to get the number of letters in the name for each element."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "oKzShBBv1BL-"
-      },
-      "outputs": [],
-      "source": [
-        "# Number of letters in name -\n",
-        "df[\"Name\"].apply(len)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "m_kPq_OQ1BL-"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-success\">\n",
-        "<strong>The .apply function</strong>\n",
-        "\n",
-        "Notice that when we use `.apply`, we write the <strong>name</strong> of the function we want to apply,\n",
-        "but we do not <strong>call</strong> the function.\n",
-        "If we were to call the `len` function, we would use parentheses `()` with an argument.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vzV4auDh1BL-"
-      },
-      "source": [
-        "## Using RDKit Functions with Pandas DataFrames\n",
-        "For an example more related to our work with RDKit, let's add some additional atomic data.\n",
-        "RDKit has the ability to get information about atoms.\n",
-        "We can create a periodic table with `Chem.GetPeriodicTable`, then use associated functions to get information about atoms."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "6qcsRNRz1BL-"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit import Chem\n",
-        "\n",
-        "# Initialize the periodic table\n",
-        "periodic_table = Chem.GetPeriodicTable()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dCrZ0fUd1BL-"
-      },
-      "source": [
-        "After we have a periodic table, we can apply functions from the periodic table to the atoms in our dataframe."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "PPRUFOa-1BL-"
-      },
-      "outputs": [],
-      "source": [
-        "df[\"NOuter\"] = df[\"Symbol\"].apply(periodic_table.GetNOuterElecs)\n",
-        "df.head()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TVyJsCUL1BL-"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Exercise</h3>\n",
-        "\n",
-        "Use the `tab` key on your periodic table object to check for other values you can calculate for atoms.\n",
-        "Pick one to add to your periodic table dataset.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "BUW7mA3p1BL-"
-      },
-      "outputs": [],
-      "source": [
-        "df[\"Default_Valence\"] = df[\"Symbol\"].apply(periodic_table.GetNOuterElecs)        # TO DO: Find a method that will give you the default valence for an element\n",
-        "df.iloc[21:31]                                                    # The df.iloc command lists the contents of those rows in the dataframe"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "AxG6533i1BL_"
-      },
-      "source": [
-        "We can save a CSV file with our newly calculated values using the `to_csv` function."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "hHVoMLIz1BL_"
-      },
-      "outputs": [],
-      "source": [
-        "df.to_csv(\"periodic_data_processed.csv\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "O9IUuGGp1BL_"
-      },
-      "source": [
-        "## Visualization\n",
-        "\n",
-        "Visualizing data helps in understanding relationships and patterns that might not be apparent from raw data. Here, we will use Seaborn, a statistical visualization library, to create plots from our periodic table dataset. Seaborn is built on top of matplotlib, so if we would like to adjust any of the plots seaborn makes, we can do that through the Matplotlib interface we've used before.\n",
-        "\n",
-        "We will start with a bar plot to show the ionization energy of elements across different group blocks:\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "xHvxbNcV1BL_"
-      },
-      "outputs": [],
-      "source": [
-        "import seaborn as sns\n",
-        "import matplotlib.pyplot as plt"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "wZ3UM43P1BL_"
-      },
-      "outputs": [],
-      "source": [
-        "sns.catplot(data=df, x=\"NOuter\", y=\"IonizationEnergy\", kind=\"bar\")\n",
-        "# Rotate x-axis labels\n",
-        "plt.xticks(rotation=45, ha='right')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YMgszpBj1BL_"
-      },
-      "source": [
-        "The plot above shows us periodic trends that we learned about in introductory chemistry. The two highest ionization energy categories correspond to elements with 2 valence electrons and 8 valence electrons, representing filled shells.\n",
-        "\n",
-        "Seaborn can also allow us to easily create scatter plots to visualize relationships between continuous variables. For example, we can create a scatter plot to show the relationship between ionization energy and atomic radius:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "K2XGYxiH1BME"
-      },
-      "outputs": [],
-      "source": [
-        "sns.scatterplot(data=df, x=\"AtomicRadius\", y=\"Electronegativity\", hue=\"GroupBlock\")\n",
-        "plt.title('Electronegativity vs. Atomic Radius')\n",
-        "plt.xlabel('Atomic Radius')\n",
-        "plt.ylabel('Electronegativity')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ufsnV5FQ1BME"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Exercise</h3>\n",
-        "\n",
-        "Create a few other categorical plots to observe periodic trends:\n",
-        "\n",
-        "1. Electronegativity vs. Group Block as a bar plot.\n",
-        "\n",
-        "2. Melting Point vs. Group Block as a bar plot.\n",
-        "\n",
-        "3. Ionization Energy vs. Atomic Number as a scatter plot colored by GroupBlock.\n",
-        "   \n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2TTmY-SS1BME"
-      },
-      "outputs": [],
-      "source": [
-        "sns.barplot(data=df, x=\"GroupBlock\", y=\"Electronegativity\")             # TO DO: Remember to put the dataframe column title in quotes, but not square brackets\n",
-        "plt.title('Electronegativity vs. Group Block')\n",
-        "plt.xlabel('Group Block')\n",
-        "plt.ylabel('Electronegativity')\n",
-        "plt.xticks(rotation=45)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "sCIw2xAh1BME"
-      },
-      "outputs": [],
-      "source": [
-        "sns.barplot(data=df, x=\"GroupBlock\", y=\"MeltingPoint\")             # TO DO: Remember to put the dataframe column title in quotes, but not square brackets\n",
-        "plt.title('Melting Point vs. Group Block')\n",
-        "plt.xlabel('Group Block')\n",
-        "plt.ylabel('Melting Point')\n",
-        "plt.xticks(rotation=45)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "vK-cP-bc1BMF"
-      },
-      "outputs": [],
-      "source": [
-        "sns.scatterplot(data=df, x=\"AtomicNumber\", y=\"IonizationEnergy\", hue=\"GroupBlock\")             # TO DO: Remember to put the dataframe column title in quotes, but not square brackets\n",
-        "plt.title('Melting Point vs. Atomic Number')\n",
-        "plt.xlabel('Atomic Number')\n",
-        "plt.ylabel('Melting Point')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "S9QADUad1BMF"
-      },
-      "source": [
-        "### Visualizing Correlation\n",
-        "\n",
-        "A common way to visualize relationships between different categories of data categories is with a correlation plot.\n",
-        "The correlation matrix provides insights into the relationships between the variables. A correlation value close to 1 indicates a strong positive relationship, while a correlation value close to -1 indicates a strong negative relationship. A correlation value close to 0 indicates no relationship between the features."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "_dbZX9Yc1BMF"
-      },
-      "outputs": [],
-      "source": [
-        "# Calculate the correlation matrix\n",
-        "corr = df.corr(numeric_only=True)\n",
-        "corr"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mhVE4b_D1BMF"
-      },
-      "source": [
-        "Seaborn can be used to create a heatmap to allow easier examination of the correlation of different variables."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "_7urDyWr1BMF"
-      },
-      "outputs": [],
-      "source": [
-        "# Create a heatmap\n",
-        "plt.figure(figsize=(10, 8))\n",
-        "sns.heatmap(corr, annot=True, cmap=\"coolwarm\", fmt=\".2f\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "eCsmiHY01BMF"
-      },
-      "source": [
-        "The heatmap uses a \"coolwarm\" color scheme where red indicates positive correlation and blue indicates negative correlation between variables. Strongly correlated pairs are represented by darker shades of red, while strongly inversely correlated pairs are represented by darker shades of blue."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ZIArXkd41BMF"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<h3>Final Challenge</h3>\n",
-        "\n",
-        "For this challenge, you will retrieve a file called `amino_acids.txt` that contains SMILES for the 20 naturally occurring amino acids. Your task for the final challenge of today is to combine skills and concepts you have learned today to build a dataframe for molecules and write a file. Your goal is to create a comma-separated value file with columns `SMILES`, `num_heavy` (number of heavy atoms), `molecular_weight`, and one other molecular descriptor of your choice for the molecules in the file.\n",
-        "\n",
-        "For this task, you will need to complete the following steps. The first three steps are already completed.\n",
-        "\n",
-        "1. Retrieve the file amino_acids.txt.\n",
-        "1. Read the data in the file and place the SMILES strings in a list.\n",
-        "1. Create a pandas dataframe, aadf, with the SMILES string as the first column.\n",
-        "1. Use the .apply function to add a new column to aadf that contains an RDKit mol object for each of the SMILES strings.\n",
-        "1. Use the .apply function to then add a column with the number of heavy atoms, a column with the molecular weight and a column with one other molecular descriptor of your choice for each molecule in aadf.\n",
-        "1. Save your file as `data/amino_acids_processed.csv`.\n",
-        "\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Eqve_OjC1BMF"
-      },
-      "source": [
-        "### Read SMILES from a text file\n",
-        "I will use the ```with open``` command to do this."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "7ujrXpeB1BMG"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit import Chem\n",
-        "from rdkit.Chem import Descriptors\n",
-        "import pandas as pd\n",
-        "from rdkit.Chem import PandasTools\n",
-        "\n",
-        "## This cell is provided for the challenge\n",
-        "\n",
-        "# Ensure molecules are rendered in the notebook\n",
-        "PandasTools.RenderImagesInAllDataFrames(images=True)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "url = (\"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/amino_acids.txt\")\n",
-        "filename = \"amino_acids.txt\"\n",
-        "urlretrieve(url, filename)"
-      ],
-      "metadata": {
-        "id": "zYBJIN5w3fPi"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "QA2YrDGV1BMG"
-      },
-      "outputs": [],
-      "source": [
-        "url = (\"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/amino_acids.txt\")\n",
-        "aa_file = \"amino_acids.txt\"\n",
-        "urlretrieve(url, aa_file)\n",
-        "\n",
-        "with open(aa_file,'r') as outfile:\n",
-        "    aasmiles = outfile.readlines()\n",
-        "\n",
-        "aasmiles_strip = []\n",
-        "for smiles in aasmiles:\n",
-        "    smiles = smiles.strip()\n",
-        "    aasmiles_strip.append(smiles)\n",
-        "\n",
-        "print(aasmiles_strip)\n",
-        "\n",
-        "aadf = pd.DataFrame(\n",
-        "    {'SMILES': aasmiles_strip})\n",
-        "\n",
-        "aadf\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Rbb47-d51BMG"
-      },
-      "source": [
-        "### Make an RDKit molecule for each SMILES\n",
-        "I did this before. This time, I'll add the SMILES string to the dataframe first, then use the apply function to create the RDKit molecules."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Bgi3HQaP1BMG"
-      },
-      "outputs": [],
-      "source": [
-        "# Create the list of molecules\n",
-        "\n",
-        "aadf['Molecule'] = aadf['SMILES'].apply(Chem.MolFromSmiles)\n",
-        "aadf"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Sx5jiRo31BMG"
-      },
-      "source": [
-        "### Write a file with the data\n",
-        "\n",
-        "Generate a .csv file from aadf."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "LjuP7LKJ1BMG"
-      },
-      "outputs": [],
-      "source": [
-        "outputfile = ('amino_acids_processed.csv')\n",
-        "aadf.to_csv(outputfile)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "QKdmd8V-1BMH"
-      },
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.2"
-    },
-    "colab": {
-      "provenance": []
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1Gl__1mt1BL4"
+   },
+   "source": [
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://github.com/MolSSI-Education/iqb-2025/blob/main/images/molssi_main_outline.png?raw=true\\\" style=\"display: block; margin: 0 auto; max-height:200px;\">\n",
+    "</div>\n",
+    "\n",
+    "\n",
+    "\n",
+    "Examining and Visualizing Data\n",
+    "=============================\n",
+    "\n",
+    "<strong>Author(s):</strong> Jessica A. Nash, The Molecular Sciences Software Institute\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<h2>Overview</h2>\n",
+    "\n",
+    "<strong>Questions:</strong>\n",
+    "\n",
+    "* How can I use pandas to process data?\n",
+    "\n",
+    "* How can I visualize relationships between different parts of my data?\n",
+    "\n",
+    "<strong>Objectives:</strong>\n",
+    "\n",
+    "* Use pandas and seaborn to load and explore data\n",
+    "\n",
+    "</div>"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "lNVJomRi1BL6"
+   },
+   "source": [
+    "[Pandas](https://pandas.pydata.org/docs/) is a Python library used for data analysis and manipulation. Within the world of data science, it is a ubiquitous and widely used library. If you are learning how to analyze data in Python, it will be almost impossible to avoid pandas.\n",
+    "\n",
+    "The central data structure of pandas is called a DataFrame. Pandas DataFrames work very closely with NumPy arrays and Pandas dataframes are specifically for data which is two dimensional (rows and columns). NumPy arrays, while similar in some ways, can work with higher dimensional data.\n",
+    "\n",
+    "Pandas is very powerful. In this session, we'll be learning how to access information in pandas dataframes and how to do some basic manipulation and analysis. We are going to be looking at a dataset which gives information about the elements in the periodic table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "F72xtliv1KkY"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install pandas seaborn matplotlib rdkit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LZV-aEQ13TZS"
+   },
+   "source": [
+    "## Pandas Dataframes\n",
+    "\n",
+    "In this notebook, we will load from a comma separate file (.csv - kind of a simplified version of a spreadsheet) into a pandas dataframe, which is a two-dimensional array of data in rows and columns. In this notebooks we will take advantage of some of the features that are native to pandas dataframes for data analysis and plotting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "b7KUqqPf1BL6"
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "from urllib.request import urlretrieve\n",
+    "\n",
+    "url = \"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/PubChemElements_all.csv\"\n",
+    "filename = \"PubChemElements_all.csv\"\n",
+    "urlretrieve(url, filename)\n",
+    "\n",
+    "df = pd.read_csv(filename)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NHnp9uqX1BL7"
+   },
+   "source": [
+    "## Examining Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wE8N3exr1BL7"
+   },
+   "source": [
+    "Initially when loading data in, and also at certain points as we're working with it, we'll want to see what our dataframe looks like. You can see a preview of your dataframe using the `.head` function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "CJIaWKHf1BL7"
+   },
+   "outputs": [],
+   "source": [
+    "df.head()  # This command will display the first five rows of the dataframe. Click the variable record on the left {x} to learn more about this dataframe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hpDhoZea1BL7"
+   },
+   "source": [
+    "The `.info` function will give information about the columns and the data type of those columns. The data type will become very important later as we work with data more."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "x3eBcLoG1BL7",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5valH56E1BL8"
+   },
+   "source": [
+    "For this dataframe, we see that the first column, `AtomicNumber` has the data type of `int64`. Here, `int` means `integer` and `64` means `64 bit`.  The `64 bit` refers to the amount of computer memory the variable can occupy. It won't really be important for us. Similarly, `float64` means `64 bit floating point`. These are decimal numbers.\n",
+    "\n",
+    "The other column names which read `object` are not numeric. They might be strings or they might be something else. We'll discuss more later.\n",
+    "\n",
+    "The `describe` function can be used on a dataframe to quickly see statistics about columns with numerical data. If you look at the columns that statistics are computed for and compare to the data type shown from `info`, you will see that we only get statistics for columns which had `int64` or `float64` data types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-RsOeMAv1BL8"
+   },
+   "outputs": [],
+   "source": [
+    "df.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Z1M6VIS21BL8"
+   },
+   "source": [
+    "This information is extremely useful for understanding the data. We can also easily visualize the distribution of each column using Pandas's ``hist`` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "padZJvd91BL8"
+   },
+   "outputs": [],
+   "source": [
+    "df.hist(figsize=(8, 8), edgecolor=\"black\", grid=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "i4gGStV81BL8"
+   },
+   "source": [
+    "## Accessing Data\n",
+    "\n",
+    "Pandas dataframes have names for rows (called the \"index\" in Pandas) and columns.\n",
+    "\n",
+    "Pandas dataframes have rows and columns, you can see how many rows and columns using `.shape`. This will return the shape as `(num_rows, num_columns)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VTjUSi9s1BL8"
+   },
+   "outputs": [],
+   "source": [
+    "df.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jQNFLJk21BL8"
+   },
+   "source": [
+    "There are a few methods for accessing information in a Pandas dataframe, but the one that will be most important in this workshop is selecting particular columns of data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "d0GzycHy1BL9"
+   },
+   "outputs": [],
+   "source": [
+    "df[\n",
+    "    \"AtomicNumber\"\n",
+    "].head()  # You can select one column by putting the column header in the square brackets. The header is a string, so it must be in quotes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ODTdsHzj1BL9"
+   },
+   "outputs": [],
+   "source": [
+    "df[\n",
+    "    [\"Symbol\", \"ElectronConfiguration\"]\n",
+    "].head()  # To select multiple columns, put list in brackets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qpSayfPS1BL9"
+   },
+   "source": [
+    "## Performing calculations with pandas: No more `for` loops!\n",
+    "\n",
+    "Both pandas and NumPy dataframes have the convenient feature that they can do element-wise operations and use something called `broadcasting`. This means that if you are doing something like subtracting a number, multiplying, etc to a column or dataframe of information, it can be done all at once instead of with a `for` loop. Consider if we wanted to calculate the melting point in degrees celsius for all of the elements.\n",
+    "\n",
+    "Instead of writing a `for` loop that does this, we can just write the following code. This will return a pandas Series (one dimensional dataframe)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PSaWkwpb1BL9"
+   },
+   "outputs": [],
+   "source": [
+    "df[\"MeltingPoint\"] - 273.15"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5uQx_WLb1BL9"
+   },
+   "source": [
+    "We could do this one two columns as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "3wrRpOL41BL9"
+   },
+   "outputs": [],
+   "source": [
+    "df[[\"MeltingPoint\", \"BoilingPoint\"]] - 273.15"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VQyz3nrz1BL9"
+   },
+   "source": [
+    "We can save these in new dataframe columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rkynyMMS1BL9"
+   },
+   "outputs": [],
+   "source": [
+    "df[[\"MeltingPointC\", \"BoilingPointC\"]] = df[[\"MeltingPoint\", \"BoilingPoint\"]] - 273.15\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rJqiEad11BL9"
+   },
+   "source": [
+    "### The `.apply` method\n",
+    "\n",
+    "The `.apply` method in pandas is used to apply a function along a row or column of a dataframe.\n",
+    "This is useful when you have a custom function that you need to use on every value in a column, but there is not a NumPy or Pandas function for it.\n",
+    "\n",
+    "For example, we could apply the `len` function to our `Name` column to get the number of letters in the name for each element."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "oKzShBBv1BL-"
+   },
+   "outputs": [],
+   "source": [
+    "# Number of letters in name -\n",
+    "df[\"Name\"].apply(len)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "m_kPq_OQ1BL-"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-success\">\n",
+    "<strong>The .apply function</strong>\n",
+    "\n",
+    "Notice that when we use `.apply`, we write the <strong>name</strong> of the function we want to apply,\n",
+    "but we do not <strong>call</strong> the function.\n",
+    "If we were to call the `len` function, we would use parentheses `()` with an argument.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vzV4auDh1BL-"
+   },
+   "source": [
+    "## Using RDKit Functions with Pandas DataFrames\n",
+    "For an example more related to our work with RDKit, let's add some additional atomic data.\n",
+    "RDKit has the ability to get information about atoms.\n",
+    "We can create a periodic table with `Chem.GetPeriodicTable`, then use associated functions to get information about atoms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6qcsRNRz1BL-"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit import Chem\n",
+    "\n",
+    "# Initialize the periodic table\n",
+    "periodic_table = Chem.GetPeriodicTable()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dCrZ0fUd1BL-"
+   },
+   "source": [
+    "After we have a periodic table, we can apply functions from the periodic table to the atoms in our dataframe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PPRUFOa-1BL-"
+   },
+   "outputs": [],
+   "source": [
+    "df[\"NOuter\"] = df[\"Symbol\"].apply(periodic_table.GetNOuterElecs)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TVyJsCUL1BL-"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Exercise</h3>\n",
+    "\n",
+    "Use the `tab` key on your periodic table object to check for other values you can calculate for atoms.\n",
+    "Pick one to add to your periodic table dataset.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "BUW7mA3p1BL-"
+   },
+   "outputs": [],
+   "source": [
+    "df[\"Default_Valence\"] = df[\"Symbol\"].apply(\n",
+    "    periodic_table.GetNOuterElecs\n",
+    ")  # TO DO: Find a method that will give you the default valence for an element\n",
+    "df.iloc[21:31]  # The df.iloc command lists the contents of those rows in the dataframe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AxG6533i1BL_"
+   },
+   "source": [
+    "We can save a CSV file with our newly calculated values using the `to_csv` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "hHVoMLIz1BL_"
+   },
+   "outputs": [],
+   "source": [
+    "df.to_csv(\"periodic_data_processed.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "O9IUuGGp1BL_"
+   },
+   "source": [
+    "## Visualization\n",
+    "\n",
+    "Visualizing data helps in understanding relationships and patterns that might not be apparent from raw data. Here, we will use Seaborn, a statistical visualization library, to create plots from our periodic table dataset. Seaborn is built on top of matplotlib, so if we would like to adjust any of the plots seaborn makes, we can do that through the Matplotlib interface we've used before.\n",
+    "\n",
+    "We will start with a bar plot to show the ionization energy of elements across different group blocks:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "xHvxbNcV1BL_"
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "wZ3UM43P1BL_"
+   },
+   "outputs": [],
+   "source": [
+    "sns.catplot(data=df, x=\"NOuter\", y=\"IonizationEnergy\", kind=\"bar\")\n",
+    "# Rotate x-axis labels\n",
+    "plt.xticks(rotation=45, ha=\"right\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "YMgszpBj1BL_"
+   },
+   "source": [
+    "The plot above shows us periodic trends that we learned about in introductory chemistry. The two highest ionization energy categories correspond to elements with 2 valence electrons and 8 valence electrons, representing filled shells.\n",
+    "\n",
+    "Seaborn can also allow us to easily create scatter plots to visualize relationships between continuous variables. For example, we can create a scatter plot to show the relationship between ionization energy and atomic radius:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "K2XGYxiH1BME"
+   },
+   "outputs": [],
+   "source": [
+    "sns.scatterplot(data=df, x=\"AtomicRadius\", y=\"Electronegativity\", hue=\"GroupBlock\")\n",
+    "plt.title(\"Electronegativity vs. Atomic Radius\")\n",
+    "plt.xlabel(\"Atomic Radius\")\n",
+    "plt.ylabel(\"Electronegativity\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ufsnV5FQ1BME"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Exercise</h3>\n",
+    "\n",
+    "Create a few other categorical plots to observe periodic trends:\n",
+    "\n",
+    "1. Electronegativity vs. Group Block as a bar plot.\n",
+    "\n",
+    "2. Melting Point vs. Group Block as a bar plot.\n",
+    "\n",
+    "3. Ionization Energy vs. Atomic Number as a scatter plot colored by GroupBlock.\n",
+    "   \n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2TTmY-SS1BME"
+   },
+   "outputs": [],
+   "source": [
+    "sns.barplot(\n",
+    "    data=df, x=\"GroupBlock\", y=\"Electronegativity\"\n",
+    ")  # TO DO: Remember to put the dataframe column title in quotes, but not square brackets\n",
+    "plt.title(\"Electronegativity vs. Group Block\")\n",
+    "plt.xlabel(\"Group Block\")\n",
+    "plt.ylabel(\"Electronegativity\")\n",
+    "plt.xticks(rotation=45)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "sCIw2xAh1BME"
+   },
+   "outputs": [],
+   "source": [
+    "sns.barplot(\n",
+    "    data=df, x=\"GroupBlock\", y=\"MeltingPoint\"\n",
+    ")  # TO DO: Remember to put the dataframe column title in quotes, but not square brackets\n",
+    "plt.title(\"Melting Point vs. Group Block\")\n",
+    "plt.xlabel(\"Group Block\")\n",
+    "plt.ylabel(\"Melting Point\")\n",
+    "plt.xticks(rotation=45)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "vK-cP-bc1BMF"
+   },
+   "outputs": [],
+   "source": [
+    "sns.scatterplot(\n",
+    "    data=df, x=\"AtomicNumber\", y=\"IonizationEnergy\", hue=\"GroupBlock\"\n",
+    ")  # TO DO: Remember to put the dataframe column title in quotes, but not square brackets\n",
+    "plt.title(\"Melting Point vs. Atomic Number\")\n",
+    "plt.xlabel(\"Atomic Number\")\n",
+    "plt.ylabel(\"Melting Point\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "S9QADUad1BMF"
+   },
+   "source": [
+    "### Visualizing Correlation\n",
+    "\n",
+    "A common way to visualize relationships between different categories of data categories is with a correlation plot.\n",
+    "The correlation matrix provides insights into the relationships between the variables. A correlation value close to 1 indicates a strong positive relationship, while a correlation value close to -1 indicates a strong negative relationship. A correlation value close to 0 indicates no relationship between the features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "_dbZX9Yc1BMF"
+   },
+   "outputs": [],
+   "source": [
+    "# Calculate the correlation matrix\n",
+    "corr = df.corr(numeric_only=True)\n",
+    "corr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mhVE4b_D1BMF"
+   },
+   "source": [
+    "Seaborn can be used to create a heatmap to allow easier examination of the correlation of different variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "_7urDyWr1BMF"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a heatmap\n",
+    "plt.figure(figsize=(10, 8))\n",
+    "sns.heatmap(corr, annot=True, cmap=\"coolwarm\", fmt=\".2f\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eCsmiHY01BMF"
+   },
+   "source": [
+    "The heatmap uses a \"coolwarm\" color scheme where red indicates positive correlation and blue indicates negative correlation between variables. Strongly correlated pairs are represented by darker shades of red, while strongly inversely correlated pairs are represented by darker shades of blue."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ZIArXkd41BMF"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<h3>Final Challenge</h3>\n",
+    "\n",
+    "For this challenge, you will retrieve a file called `amino_acids.txt` that contains SMILES for the 20 naturally occurring amino acids. Your task for the final challenge of today is to combine skills and concepts you have learned today to build a dataframe for molecules and write a file. Your goal is to create a comma-separated value file with columns `SMILES`, `num_heavy` (number of heavy atoms), `molecular_weight`, and one other molecular descriptor of your choice for the molecules in the file.\n",
+    "\n",
+    "For this task, you will need to complete the following steps. The first three steps are already completed.\n",
+    "\n",
+    "1. Retrieve the file amino_acids.txt.\n",
+    "1. Read the data in the file and place the SMILES strings in a list.\n",
+    "1. Create a pandas dataframe, aadf, with the SMILES string as the first column.\n",
+    "1. Use the .apply function to add a new column to aadf that contains an RDKit mol object for each of the SMILES strings.\n",
+    "1. Use the .apply function to then add a column with the number of heavy atoms, a column with the molecular weight and a column with one other molecular descriptor of your choice for each molecule in aadf.\n",
+    "1. Save your file as `data/amino_acids_processed.csv`.\n",
+    "\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Eqve_OjC1BMF"
+   },
+   "source": [
+    "### Read SMILES from a text file\n",
+    "I will use the ```with open``` command to do this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "7ujrXpeB1BMG"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit import Chem\n",
+    "import pandas as pd\n",
+    "from rdkit.Chem import PandasTools\n",
+    "\n",
+    "## This cell is provided for the challenge\n",
+    "\n",
+    "# Ensure molecules are rendered in the notebook\n",
+    "PandasTools.RenderImagesInAllDataFrames(images=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zYBJIN5w3fPi"
+   },
+   "outputs": [],
+   "source": [
+    "url = \"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/amino_acids.txt\"\n",
+    "filename = \"amino_acids.txt\"\n",
+    "urlretrieve(url, filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "QA2YrDGV1BMG"
+   },
+   "outputs": [],
+   "source": [
+    "url = \"https://raw.githubusercontent.com/MolSSI-Education/molssicheminfo/refs/heads/master/data/amino_acids.txt\"\n",
+    "aa_file = \"amino_acids.txt\"\n",
+    "urlretrieve(url, aa_file)\n",
+    "\n",
+    "with open(aa_file, \"r\") as outfile:\n",
+    "    aasmiles = outfile.readlines()\n",
+    "\n",
+    "aasmiles_strip = []\n",
+    "for smiles in aasmiles:\n",
+    "    smiles = smiles.strip()\n",
+    "    aasmiles_strip.append(smiles)\n",
+    "\n",
+    "print(aasmiles_strip)\n",
+    "\n",
+    "aadf = pd.DataFrame({\"SMILES\": aasmiles_strip})\n",
+    "\n",
+    "aadf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Rbb47-d51BMG"
+   },
+   "source": [
+    "### Make an RDKit molecule for each SMILES\n",
+    "I did this before. This time, I'll add the SMILES string to the dataframe first, then use the apply function to create the RDKit molecules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Bgi3HQaP1BMG"
+   },
+   "outputs": [],
+   "source": [
+    "# Create the list of molecules\n",
+    "\n",
+    "aadf[\"Molecule\"] = aadf[\"SMILES\"].apply(Chem.MolFromSmiles)\n",
+    "aadf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Sx5jiRo31BMG"
+   },
+   "source": [
+    "### Write a file with the data\n",
+    "\n",
+    "Generate a .csv file from aadf."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "LjuP7LKJ1BMG"
+   },
+   "outputs": [],
+   "source": [
+    "outputfile = \"amino_acids_processed.csv\"\n",
+    "aadf.to_csv(outputfile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "QKdmd8V-1BMH"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/solutions/01_Cheminfo_crash_course_with_solutions.ipynb
+++ b/solutions/01_Cheminfo_crash_course_with_solutions.ipynb
@@ -1,917 +1,934 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "7d06a1a8-a729-47c1-973a-3b6afa520f18",
-      "metadata": {
-        "id": "7d06a1a8-a729-47c1-973a-3b6afa520f18"
-      },
-      "source": [
-        "<div style=\"text-align:center;\">\n",
-        "  <img src=\"https://raw.githubusercontent.com/MolSSI-Education/molssi-cheminformatics/0895b9e2d810fc260aaff344286a84a1b7d18a51/custom/molssi_main_horizontal.png\" style=\"display: block; margin: 0 auto; max-height:100px;\">\n",
-        "</div>\n",
-        "\n",
-        "# Digital Representation of Molecules\n",
-        "This notebook is based on notebooks 01-04 from the [MolSSI Cheminformatics course](https://github.com/MolSSI-Education/molssi-cheminformatics), which was created by Jessica A. Nash from The Molecular Sciences Software Institute\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "350c2869-274d-4bab-87c9-aa06fbfd9f89",
-      "metadata": {
-        "cellView": "form",
-        "id": "350c2869-274d-4bab-87c9-aa06fbfd9f89"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Overview\n",
-        "%%html\n",
-        "<style>\n",
-        "div.alert {\n",
-        "    color: #0056b3;\n",
-        "    background-color: #d9edf7;\n",
-        "    border-left: 5px solid #31708f;\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em;\n",
-        "    line-height: 1.5;\n",
-        "}\n",
-        "div.alert ul {\n",
-        "    margin: 0.5em 0;\n",
-        "}\n",
-        "div.alert li {\n",
-        "    margin-bottom: 0.5em;\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "    <strong>Questions:</strong>\n",
-        "    <ul>\n",
-        "        <li>How are molecules represented on computers?</li>\n",
-        "        <li>What is a SMILES?</li>\n",
-        "        <li>What are common molecular file formats?</li>\n",
-        "   </ul>\n",
-        "\n",
-        "    <strong>Objectives:</strong>\n",
-        "    <ul>\n",
-        "        <li>Learn the basics of SMILES strings.</li>\n",
-        "        <li>Convert molecules from chemical formula and structures to SMILES strings.</li>\n",
-        "    </ul>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b8eb3cf1-79d9-40f6-a739-92b0ba19539e",
-      "metadata": {
-        "id": "b8eb3cf1-79d9-40f6-a739-92b0ba19539e"
-      },
-      "source": [
-        "## Molecular Representations of Biological Molecules for Computing\n",
-        "\n",
-        "In bioinformatics, if you work with genomics you are accustomed to working with DNA sequences. For example, this is a partial DNA sequence for human dihdydrofolate reductase, an important enzyme in nucelotide metabolism.\n",
-        "\n",
-        "```\n",
-        "GAATTCATGAAAACGTAGCTCGTCCTCAAAAAAAACAGAAGAGGAGTAATCATTTTAAGGGAGAAATATA\n",
-        "TACGAAAGGAACAAGATTTTGAAGCACCCAAGCTGCCACCTACATTAAAACACGGTAGGTGGCTAAACAC\n",
-        "CAGTCTTCAATGCCCTTCCACAGCCTCAGTCTGAAAAATACTGTGCAGGTGACCCAAGTGAGGGGTCACC\n",
-        "CTTGGGCTTTTCCTGTGGCAGTATCTCTGGTTTAAAAACAAACAAACGTACTTATTGCGTTGAAGGACGG\n",
-        "CAACAGGAAGGACTCCATGATTAGTCACATCTATACCATCCTAAGAAACTTTATCCACCCAAACTGTATT\n",
-        "TCAGACTTTATAATCTAAACTACAAAAAGTGTTCACTGGGGAACTGCACAATATGACTGCTTTTAACCGT\n",
-        "```\n",
-        "\n",
-        "The DNA sequence shown here is a simplified representation of a very complex 3D structure that is part of a chromosome, an enormously complex structure. The sequence that represents this gene can be used as a string in coding - computation with strings is orders of magnitude faster than computation with 3D structures. And we can still learn a great deal about this gene simply by exploring the sequence. Likewise we can represent the RNA transcribed from this sequence as a list of characters where T is replaced by U.\n",
-        "\n",
-        "If you study proteins or proteomics, you know that protein function depends on protein structure. Protein structures involve 20 (or more) building blocks so the sequences are more complex, but the principle of representing the protein as a simple string for ease with computing still applies. Here is the sequence of the dihydrofolate reductase protein that is coded in this gene sequence above.\n",
-        "\n",
-        "```\n",
-        "MVGSLNCIVAVSQNMGIGKNGDLPWPPLRNEFRYFQRMTTTSSVEGKQNLVIMGKKTWFSIPEKNRPLKG\n",
-        "RINLVLSRELKEPPQGAHFLSRSLDDALKLTEQPELANKVDMVWIVGGSSVYKEAMNHPGHLKLFVTRIM\n",
-        "QDFESDTFFPEIDLEKYKLLPEYPGVLSDVQEEKGIKYKFEVYEKND\n",
-        "```\n",
-        "\n",
-        "As we move into cheminformatics, we often want to convert small molecule structures, like the aspirin shown here, into strings for computing ease.\n",
-        "\n",
-        "![Aspirin.png](https://drive.google.com/uc?export=view&id=1hcWaacd-pIb09Wi9dceVSQIfkXgWC-vD)\n",
-        "\n",
-        "There are three well-known string conversions for small molecules, SMILES, InChI, and InChI Key. Here are the SMILES, InChI, and InChI Key strings for aspirin.\n",
-        "\n",
-        "SMILES: CC(=O)OC1=CC=CC=C1C(=O)O\n",
-        "\n",
-        "InChI: 1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)\n",
-        "\n",
-        "InChI Key: BSYNRYMUTXBXSQ-UHFFFAOYSA-N\n",
-        "\n",
-        "In this workshop we will use SMILES strings. SMILES syntax is explained below."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1a20ce5f-0392-40be-a64f-006929d49a5a",
-      "metadata": {
-        "id": "1a20ce5f-0392-40be-a64f-006929d49a5a"
-      },
-      "source": [
-        "## Simplified Molecular-Input Line-entry System: SMILES\n",
-        "\n",
-        "SMILES stands for \"Simplified Molecular-Input Line-Entry System\" and is a way to represent molecules as a string of characters.\n",
-        "\n",
-        "Consider the molecule ethanol. The image below shows a representation that we are used to seeing in chemistry:\n",
-        "\n",
-        "![ethanol](https://drive.google.com/uc?export=view&id=1pBnnNujVdkw43xpDOM27nzICgnn7EqJj)\n",
-        "\n",
-        "However, the SMILES representation of this molecule would be \"CCO\".\n",
-        "\n",
-        "You can read more about SMILES at [this tutorial](https://archive.epa.gov/med/med_archive_03/web/html/smiles.html), but rules for atoms and bonds are also repeated below.\n",
-        "\n",
-        "### Atoms\n",
-        "SMILES supports all elements in the periodic table. An atom is represented using its respective atomic symbol. Upper case letters refer to non-aromatic atoms; lower case letters refer to aromatic atoms. If the atomic symbol has more than one letter the second letter must be lower case.\n",
-        "\n",
-        "### Bonds\n",
-        "```\n",
-        "-\tSingle bond\n",
-        "=\tDouble bond\n",
-        "#\tTriple bond\n",
-        "*\tAromatic bond\n",
-        ".\tDisconnected structures\n",
-        "```\n",
-        "Single bonds are the default and therefore need not be entered. For example, 'CC' would mean that there is a non-aromatic carbon attached to another non-aromatic carbon by a single bond, and the computer would identify the structure as the chemical ethane. It is also assumed that the bond between two lower case atom symbols is aromatic. A blank terminates the SMILES string.\n",
-        "\n",
-        "### Branches\n",
-        "\n",
-        "A branch from a chain is specified by placing the SMILES symbol(s) for the branch between parenthesis. Some examples:\n",
-        "\n",
-        "```\n",
-        "\n",
-        "CC(O)C\t2-Propanol\n",
-        "CC(=O)C\t2-Propanone\n",
-        "```\n",
-        "\n",
-        "### Rings\n",
-        "\n",
-        "A ring is specified by placing a number directly after the SMILES symbol where the ring closure occurs. This number acts as a marker, indicating that the atoms with the same number are connected, thus forming a ring. For instance:\n",
-        "\n",
-        "```\n",
-        "C1CCCC1   cyclopentane\n",
-        "n1ccccc1  Pyridine\n",
-        "```\n",
-        "\n",
-        "### SMILES Examples\n",
-        "\n",
-        "![SMILES Example 1](https://drive.google.com/uc?export=view&id=1-MFSoAGwqOPiqIUD06reOkBPx4BTMhGC)\n",
-        "\n",
-        "![SMILES Example 2](https://drive.google.com/uc?export=view&id=18Ub9L98y8cL_lDLF9wl6pLQxCkt8JFqu)\n",
-        "\n",
-        "### Using Online Resources\n",
-        "Most of the time, you will not need to write a SMILES string by hand. You will be able to look up a molecule's SMILES string from a web database like [PubChem](https://pubchem.ncbi.nlm.nih.gov/).\n",
-        "\n",
-        "You can also use tools like this [molecule sketcher from the Protein Data Bank](https://www.rcsb.org/chemical-sketch)\n",
-        "to draw molecules and get their SMILES strings."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "928a5415-2bcb-4ef0-ac8a-1744714d8d3c",
-      "metadata": {
-        "cellView": "form",
-        "id": "928a5415-2bcb-4ef0-ac8a-1744714d8d3c"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Exercise\n",
-        "%%html\n",
-        "<style>\n",
-        "div.orange-alert {\n",
-        "    color: #854f00; /* Darker shade of orange for text */\n",
-        "    background-color: #ffe6cc; /* Light orange background */\n",
-        "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.orange-alert ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.orange-alert li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"orange-alert\">\n",
-        "\n",
-        "<strong>Exercise</strong>\n",
-        "<p>\n",
-        "Based on what you've learned about SMILES strings, answer the following questions:\n",
-        "</p>\n",
-        "    <ul>\n",
-        "        <li> What is the SMILES for ethanol?</li>\n",
-        "        <li> What is the SMILES for water?</li>\n",
-        "        <li> What is the SMILES for benzene?</li>\n",
-        "        <li> What molecule is represented by the SMILES O=C=O?</li>\n",
-        "        <li> What is the SMILES for an amide group?<//li>\n",
-        "        <li> What is the SMILES for a 4 membered carbon chain with an amide group on the second carbon?</li>\n",
-        "    </ul>\n",
-        "</p>\n",
-        "<p>Check your answers from this previous exercise using the PDB molecule sketcher. Notice that you can type in a SMILES string and have the sketcher draw the molecule for you.</p>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6dcdb914-bf20-425d-859c-44c250ca991a",
-      "metadata": {
-        "id": "6dcdb914-bf20-425d-859c-44c250ca991a"
-      },
-      "outputs": [],
-      "source": [
-        "# Fill in your answers here:\n",
-        "# 1. CCO\n",
-        "# 2. O\n",
-        "# 3. c1ccccc1\n",
-        "# 4. Carbon Dioxide\n",
-        "# 5. C(=O)N\n",
-        "# 6. CC(C(=O)N)CC\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "4842145a-676e-4f1f-9b55-8b8296a81301",
-      "metadata": {
-        "id": "4842145a-676e-4f1f-9b55-8b8296a81301"
-      },
-      "source": [
-        "## Molecular File Formats\n",
-        "\n",
-        "Molecules can also be represented using a number of different file formats. As you work more in chemistry, you may see a number of these. Sometimes you will have to pick a file format based on the software you are using or the molecular information you want to save.\n",
-        "\n",
-        "| File Format | Description                                                                 | Features                                                              | Common Uses                              |\n",
-        "|-------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------|------------------------------------------|\n",
-        "| SMILES      | Simplified Molecular Input Line Entry System                                | Line notation for representing molecular structures                   | Database               |\n",
-        "| InChI       | International Chemical Identifier                                           | Textual identifier for chemical substances                            | Databases             |\n",
-        "| MOL/SDF     | MDL MOLfile and Structure-Data File                                         | Contains 2D/3D coordinates, atoms, bonds                              | Structure visualization, cheminformatics |\n",
-        "| PDB         | Protein Data Bank format                                                    | Often used for 3D structures of proteins and nucleic acids,but can also be used for small molecules. Often does not contain molecule information, and cannot store partial charges.                           | Structural biology, bioinformatics       |\n",
-        "| XYZ         | Cartesian coordinates                                                       | Simple text format with atom types and 3D coordinates                 | Computational chemistry, molecular dynamics |     |\n",
-        "| CIF         | Crystallographic Information File                                           | Text file format for representing crystal structure data              | Crystallography                          |\n",
-        "| PQR         | Extended PDB format with partial charges and radii                          | Includes atomic coordinates, partial charges, and radii               | Electrostatics calculations              |\n",
-        "| PDBQT       | PDB format with torsion angles and charges used in AutoDock                 | Includes atomic coordinates, partial charges, torsion angles          | Molecular docking                        |\n",
-        "|MOL2   |Tripos Mol2 format|\tContains atomic coordinates, bonds, molecule types, substructures, and partial charges|\tMolecular modeling, cheminformatics, computational chemistry\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3db21944-72a0-4523-a87d-f702baa98a4b",
-      "metadata": {
-        "cellView": "form",
-        "id": "3db21944-72a0-4523-a87d-f702baa98a4b"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Introduction to RDKit Molecules\n",
-        "%%html\n",
-        "<style>\n",
-        "div.alert {\n",
-        "    color: #0056b3;\n",
-        "    background-color: #d9edf7;\n",
-        "    border-left: 5px solid #31708f;\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em;\n",
-        "    line-height: 1.5;\n",
-        "}\n",
-        "div.alert ul {\n",
-        "    margin: 0.5em 0;\n",
-        "}\n",
-        "div.alert li {\n",
-        "    margin-bottom: 0.5em;\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "    <strong>Questions:</strong>\n",
-        "    <ul>\n",
-        "        <li>What is RDKit?</li>\n",
-        "        <li>What is an RDKit mol object?</li>\n",
-        "        <li>What can I do with RDKit mol objects?</li>\n",
-        "   </ul>\n",
-        "\n",
-        "    <strong>Objectives:</strong>\n",
-        "    <ul>\n",
-        "        <li>Use RDKit to create mol objects in Python.</li>\n",
-        "    </ul>\n",
-        "\n",
-        "<p>\n",
-        "There are Python libraries that are made for working just with chemical data. One commonly\n",
-        "used library in Python for data science (or cheminformatics) is called\n",
-        "[RDKit](https://en.wikipedia.org/wiki/RDKit). RDKit is an open-source cheminformatics\n",
-        "library, primarily developed in C++ and has been under development since the year 2000.\n",
-        "We will be using the Python interface to RDKit, though there are interfaces in other languages.\n",
-        "</p>\n",
-        "\n",
-        "<p>\n",
-        "RDKit provides a molecule object that allows you to manipulate chemical structures. It has\n",
-        "capabilities for reading and writing molecular file formats, calculating molecular properties,\n",
-        "and performing substructure searches. In addition, it offers a wide range of cheminformatics\n",
-        "algorithms such as molecular fingerprint generation, similarity metrics calculation, and\n",
-        "molecular descriptor computation. This notebook introduces RDKit basics, but we will see more\n",
-        "of all of these topics in later notebooks.\n",
-        "</p>\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3949cd4d-3f71-4622-a774-bcf3542a74d8",
-      "metadata": {
-        "cellView": "form",
-        "id": "3949cd4d-3f71-4622-a774-bcf3542a74d8"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Python Skills - Python Objects\n",
-        "%%html\n",
-        "<style>\n",
-        "div.purple-box {\n",
-        "    color: #4b0082; /* Indigo for text */\n",
-        "    background-color: #f3e5f5; /* Light lavender background */\n",
-        "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-        "}\n",
-        "div.purple-box ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.purple-box li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"purple-box\">\n",
-        "    <p>\n",
-        "       Most of this functionality is achieved through the RDKit `mol` object. In Python,\n",
-        "we use the word \"object\" to refer to a variable type with associated data and methods.\n",
-        "One example of an object we have seen in notebooks is a list - we could also call it\n",
-        "a \"list object\". An object has `attributes` (data) and `methods`.\n",
-        "You access information about objects with the syntax\n",
-        "    </p>\n",
-        "<pre>\n",
-        "\n",
-        "object.data\n",
-        "\n",
-        "</pre>\n",
-        "\n",
-        "where data is the attribute name.\n",
-        "\n",
-        "You access object methods with the syntax\n",
-        "\n",
-        "<pre>\n",
-        "\n",
-        "object.method(arguments)\n",
-        "\n",
-        "</pre>\n",
-        "        For example, for a list \"`append` is a method that was covered in the introductory lesson.\n",
-        "<pre>\n",
-        "\n",
-        "my_list = []\n",
-        "my_list.append(1) # \"append\" is a method\n",
-        "\n",
-        "<pre>\n",
-        "</div>\n",
-        "\n",
-        "<p>\n",
-        "In this lesson, we will create and manipulate RDKit `mol` objects. RDKit `mol` objects represent molecules and have\n",
-        "attributes (data) and methods (actions) associated with molecules.\n",
-        "</p>\n",
-        "<p>\n",
-        "We are going to use a part of RDKit called `Chem`. To use `Chem`, we first have to import it.\n",
-        "</p>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "Xovgh3LcqJA2",
-      "metadata": {
-        "id": "Xovgh3LcqJA2"
-      },
-      "outputs": [],
-      "source": [
-        "from google.colab import output\n",
-        "output.clear()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3c5c13a5-b369-4188-8b13-356445deeb5a",
-      "metadata": {
-        "id": "3c5c13a5-b369-4188-8b13-356445deeb5a"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install rdkit\n",
-        "from rdkit import Chem"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d84d6c70-fd6e-41bf-81c6-7145d6f87b0e",
-      "metadata": {
-        "id": "d84d6c70-fd6e-41bf-81c6-7145d6f87b0e"
-      },
-      "source": [
-        "## Creating Molecules with RDKit\n",
-        "\n",
-        "Throughout this tutorial, it will be helpful to have access to the [RDKit documentation](https://www.rdkit.org/docs/index.html).\n",
-        "\n",
-        "To get information about molecules in RDKit, we have to first create objects representing molecules. RDKit has a molecule object that can be used to retrieve information or calculate properties. To create a molecule object, we have to communicate the molecule identity in a way that computers understand.\n",
-        "\n",
-        "We will use SMILES strings to create our objects, though RDKit also has methods for creating molecules from the file formats listed in the previous notebook.\n",
-        "\n",
-        "### Creating molecules using SMILES\n",
-        "\n",
-        "In the last lesson, we learned about molecular representations using SMILES strings. Now we will use SMILES strings to create molecule objects in RDKIT.\n",
-        "\n",
-        "We can create a representation of methane using RDKit by using the `MolFromSmiles` function in `rdkit.Chem`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "b9415ede-7ab5-4a35-89e8-a32d25dfe1b9",
-      "metadata": {
-        "id": "b9415ede-7ab5-4a35-89e8-a32d25dfe1b9"
-      },
-      "outputs": [],
-      "source": [
-        "methane = Chem.MolFromSmiles('C')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "851ae0d6-b0a2-4474-9402-5db4abf49b1c",
-      "metadata": {
-        "id": "851ae0d6-b0a2-4474-9402-5db4abf49b1c"
-      },
-      "outputs": [],
-      "source": [
-        "methane"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6c305149-481a-4e52-83bc-a24ab48f45bf",
-      "metadata": {
-        "cellView": "form",
-        "id": "6c305149-481a-4e52-83bc-a24ab48f45bf"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Check Your Understanding\n",
-        "%%html\n",
-        "<style>\n",
-        "div.orange-alert {\n",
-        "    color: #854f00; /* Darker shade of orange for text */\n",
-        "    background-color: #ffe6cc; /* Light orange background */\n",
-        "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "}\n",
-        "div.orange-alert ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.orange-alert li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"orange-alert\">\n",
-        "\n",
-        "<p> Create RDKit molecules for the following molecules. You can look up the SMILES strings on <a href=\"https://pubchem.ncbi.nlm.nih.gov/\">PubChem</a>:\n",
-        "<p>\n",
-        "    <ul>\n",
-        "        <li> Propane\n",
-        "        <li> Ethene\n",
-        "        <li> Cyclohexane\n",
-        "        <li> Benzene </li>\n",
-        "        <li> Acetic Acid\n",
-        "    </ul>\n",
-        "</p>\n",
-        "<p>Create variables for each molecule. The variable names should be the molecule name (all lowercase)</p>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "497025f0-e60a-42d1-a26e-77db46e5c495",
-      "metadata": {
-        "id": "497025f0-e60a-42d1-a26e-77db46e5c495"
-      },
-      "outputs": [],
-      "source": [
-        "# Your answers go here\n",
-        "propane = Chem.MolFromSmiles(\"CCC\")                # TO DO: Insert the SMILES string for propane: CCC\n",
-        "ethene = Chem.MolFromSmiles(\"C=C\")                 # TO DO: Insert the SMILES string for ethene\n",
-        "cyclohexane = Chem.MolFromSmiles(\"C1CCCCC1 \")      # TO DO: Call the method and insert the SMILES string for cyclohexane\n",
-        "benzene = Chem.MolFromSmiles(\"c1ccccc1\")           # TO DO: Call the method and insert the SMILES string for benzene\n",
-        "acetic_acid = Chem.MolFromSmiles(\"CC(=O)O\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f87d25a4-61b2-437a-a5a6-176a2a45a813",
-      "metadata": {
-        "id": "f87d25a4-61b2-437a-a5a6-176a2a45a813"
-      },
-      "outputs": [],
-      "source": [
-        "# Try visualizing your molecules here just by typing the name of the variable that refers to the RDKit mol object\n",
-        "acetic_acid"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from rdkit.Chem.Draw import IPythonConsole as ipc\n",
-        "from rdkit.Chem import Draw\n",
-        "\n",
-        "# Configuration for displaying in Jupyter notebooks\n",
-        "ipc.ipython_useSVG = True  # Use SVG for higher quality images\n",
-        "ipc.drawOptions.addAtomIndices = True  # Show atom indices\n",
-        "ipc.molSize = 250,250 # Set size of image"
-      ],
-      "metadata": {
-        "id": "4CzZhBBEGpGV"
-      },
-      "id": "4CzZhBBEGpGV",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "474fcdab-a904-4c66-8243-5a59de5ebf90",
-      "metadata": {
-        "id": "474fcdab-a904-4c66-8243-5a59de5ebf90",
-        "cellView": "form"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Working with RDKit Molecules\n",
-        "%%html\n",
-        "<style>\n",
-        "div.purple-box {\n",
-        "    color: #4b0082; /* Indigo for text */\n",
-        "    background-color: #f3e5f5; /* Light lavender background */\n",
-        "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em; /* Matches the surrounding text size */\n",
-        "    line-height: 1.5; /* Ensures readability */\n",
-        "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
-        "}\n",
-        "div.purple-box ul {\n",
-        "    margin: 0.5em 0; /* Space around the list */\n",
-        "}\n",
-        "div.purple-box li {\n",
-        "    margin-bottom: 0.5em; /* Space between list items */\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"purple-box\">\n",
-        "    <p>\n",
-        "RDKit molecule objects have a number of methods we can use to get more information about the molecule. In the next few cells, we'll look at some methods that can tell us some things about the molecules we've created. The next cell has settings for modifying drawing molecules. It adds labels of atom indices and sets the image size\n",
-        "When working with Python objects in the Jupyter notebook, you can\n",
-        "type a variable or object name to see the methods available on that object.\n",
-        "    </p>\n",
-        "    <p>\n",
-        "In the cell below, type\n",
-        "<pre>\n",
-        "  acetic_acid.\n",
-        "\n",
-        "</pre>\n",
-        "\n",
-        "Notice how there is a dot at the end\n",
-        "\n",
-        "    <pre>\n",
-        "      .\n",
-        "    </pre>\n",
-        "\n",
-        "Then press the `tab` key. A list of possible methods and attributes will come up.\n",
-        "\n",
-        "Look through the methods until you find one that gives you the number of atoms in the molecule.\n",
-        "\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "e1a331ad-3b4d-44e1-ad51-dc093008dacb",
-      "metadata": {
-        "id": "e1a331ad-3b4d-44e1-ad51-dc093008dacb"
-      },
-      "outputs": [],
-      "source": [
-        "# Pick a method that will tell you the number of atoms acetic acid has.\n",
-        "\n",
-        "x = acetic_acid.GetNumAtoms()                                  # TO DO: enter a . after acetic acid and then scroll down the list to find a method to give you the number of atoms\n",
-        "\n",
-        "print('Acetic acid has', x, 'heavy atoms.')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "56379e5a-44f0-4272-959d-91f652ba4128",
-      "metadata": {
-        "id": "56379e5a-44f0-4272-959d-91f652ba4128"
-      },
-      "source": [
-        "### Finding help\n",
-        "When you start working with RDKit mol objects, it will be an adjustment. This is a new type of variable and it will take time to adjust. One way to find help is to use a simple help command where the object of the help function is the name of the RDKit mol object. In the next cell, we will use help to learn more about the RDKit mol object, acetic_acid, that we just created."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1b7d32b7-f531-4a4f-b05e-4c6c51664d50",
-      "metadata": {
-        "id": "1b7d32b7-f531-4a4f-b05e-4c6c51664d50"
-      },
-      "outputs": [],
-      "source": [
-        "help(acetic_acid)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cc30f661-dc41-4c06-82cc-a4ae762d65e7",
-      "metadata": {
-        "id": "cc30f661-dc41-4c06-82cc-a4ae762d65e7"
-      },
-      "outputs": [],
-      "source": [
-        "# Add an argument to your function to get the total number of atoms in acetic_acid including hydrogens\n",
-        "\n",
-        "x = acetic_acid.GetNumAtoms()                             # This is the method we used in an earlier cell. Note that the parentheses are empty.\n",
-        "\n",
-        "y = acetic_acid.GetNumAtoms(onlyExplicit=False)           # TO DO: To include the hydrogens in the atom count, insert the phrase onlyExplicit = False in the parentheses.\n",
-        "\n",
-        "print(f\"There are {x} heavy atoms in acetic acid and {y} total atoms in acetic acid.\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a47eba18-f0a2-4d59-88c0-b58b1605d9d4",
-      "metadata": {
-        "cellView": "form",
-        "id": "a47eba18-f0a2-4d59-88c0-b58b1605d9d4"
-      },
-      "outputs": [],
-      "source": [
-        "# @title Examining and Visualizing Data\n",
-        "%%html\n",
-        "<style>\n",
-        "div.alert {\n",
-        "    color: #0056b3;\n",
-        "    background-color: #d9edf7;\n",
-        "    border-left: 5px solid #31708f;\n",
-        "    padding: 0.5em;\n",
-        "    font-size: 1.25em;\n",
-        "    line-height: 1.5;\n",
-        "}\n",
-        "div.alert ul {\n",
-        "    margin: 0.5em 0;\n",
-        "}\n",
-        "div.alert li {\n",
-        "    margin-bottom: 0.5em;\n",
-        "}\n",
-        "</style>\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">\n",
-        "    <strong>Questions:</strong>\n",
-        "    <ul>\n",
-        "        <li>How can I use pandas to work with molecules from rdkit?</li>\n",
-        "        <li>How can I visualize relationships between different parts of my data?</li>\n",
-        "   </ul>\n",
-        "\n",
-        "    <strong>Objectives:</strong>\n",
-        "    <ul>\n",
-        "        <li>Review the pandas dataframe</li>\n",
-        "        <li>Learn to visualize structures in a pandas dataframe</li>\n",
-        "        <li>Learn the <i>apply</i> tool for expanding a pandas dataframe</li>\n",
-        "    </ul>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a4cc10b7-5d18-4853-bfac-a2448f722414",
-      "metadata": {
-        "id": "a4cc10b7-5d18-4853-bfac-a2448f722414"
-      },
-      "source": [
-        "[Pandas](https://pandas.pydata.org/docs/) is a Python library used for data analysis and manipulation. Within the world of data science, it is a ubiquitous and widely used library. If you are learning how to analyze data in Python, it will be almost impossible to avoid pandas.\n",
-        "\n",
-        "The central data structure of pandas is called a DataFrame. Pandas DataFrames work very closely with NumPy arrays and Pandas dataframes are specifically for data which is two dimensional (rows and columns). NumPy arrays, while similar in some ways, can work with higher dimensional data.\n",
-        "\n",
-        "Pandas is very powerful. In this session, we'll be learning how to access information in pandas dataframes and how to do some basic manipulation and analysis. We are going to be looking at a dataset which gives information about the elements in the periodic table."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f2e82ae2-4050-4955-a205-5ed86e42cc2b",
-      "metadata": {
-        "id": "f2e82ae2-4050-4955-a205-5ed86e42cc2b"
-      },
-      "outputs": [],
-      "source": [
-        "import pandas as pd                                     # importing the pandas library\n",
-        "\n",
-        "from rdkit.Chem import PandasTools                      # importing rdkit functions to work with pandas\n",
-        "\n",
-        "PandasTools.RenderImagesInAllDataFrames(images=True)    # to display chemical structures in dataframes"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from urllib.request import urlretrieve                  # importing a method that enables retrieval of a text file from a URL\n",
-        "\n",
-        "url = (\"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/paul/data/nsaids.csv\")\n",
-        "\n",
-        "filename = \"nsaids.csv\"\n",
-        "\n",
-        "urlretrieve(url, filename)"
-      ],
-      "metadata": {
-        "id": "LzrEG54AKY-W"
-      },
-      "id": "LzrEG54AKY-W",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "id": "6ed0f50a-7b42-49dc-acc4-f68c4cedc1a6",
-      "metadata": {
-        "id": "6ed0f50a-7b42-49dc-acc4-f68c4cedc1a6"
-      },
-      "source": [
-        "## Loading a collection of small molecules\n",
-        "\n",
-        "In the next few cells, we'll read a text file that lists the SMILES strings for some nonsteroidal antiinflammatory drugs (NSAIDS) and then use them to start building a pandas dataframe. The SMILES strings for the NSAIDS can be found in [nsaids.txt](https://docs.google.com/document/d/1RQeVIFBMeq4SWTrRNfgZXRvaaRNXVknLxgVZfTbJUDs/edit?usp=drive_link).\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6e09ef49-ad83-4f81-a0da-c90c83f02d3b",
-      "metadata": {
-        "id": "6e09ef49-ad83-4f81-a0da-c90c83f02d3b"
-      },
-      "outputs": [],
-      "source": [
-        "nsaids_file = \"nsaids.csv\"\n",
-        "\n",
-        "nsaids_df = pd.read_csv(nsaids_file)\n",
-        "\n",
-        "nsaids_df"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "26a9b6b3-10ff-4594-b660-5b605ac30e2e",
-      "metadata": {
-        "id": "26a9b6b3-10ff-4594-b660-5b605ac30e2e"
-      },
-      "source": [
-        "### The `.apply` method\n",
-        "\n",
-        "The `.apply` method in pandas is used to apply a function along a row or column of a dataframe.\n",
-        "This is useful when you have a custom function that you need to use on every value in a column, but there is not a NumPy or Pandas function for it.\n",
-        "\n",
-        "For example, we could apply the `len` function to our `Name` column to get the number of letters in the name for each element.\n",
-        "\n",
-        "```python\n",
-        "# Number of letters in name -\n",
-        "df[\"Name\"].apply(len)\n",
-        "```\n",
-        "\n",
-        "We are going to use ```apply``` to add a new column to nsaid_df that contains the rdkit molecule for each of the NSAIDs."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fb693a02-58a2-467d-80fa-723d61f62219",
-      "metadata": {
-        "id": "fb693a02-58a2-467d-80fa-723d61f62219"
-      },
-      "outputs": [],
-      "source": [
-        "nsaids_df[\"Molecule\"] = nsaids_df[\"SMILES\"].apply(Chem.MolFromSmiles)\n",
-        "\n",
-        "nsaids_df.head()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "WqeeyIxPiF-7",
-      "metadata": {
-        "id": "WqeeyIxPiF-7"
-      },
-      "source": [
-        "At this point, nsaid_df contains two columns: the SMILES string and the molecule. We will go one step further and use ```apply``` to add another column to the dataframe that contains a descriptor based on the rdkit molecule. Before we can do that we need to import a new sublibrary from rdkit.Chem called Descriptors. Notice that the new columns will be based on the Molecule column, which contains rdkit mol objects."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "v7lK6asEid7Q",
-      "metadata": {
-        "id": "v7lK6asEid7Q"
-      },
-      "outputs": [],
-      "source": [
-        "from rdkit.Chem import Descriptors\n",
-        "from rdkit.Chem import Lipinski\n",
-        "nsaids_df[\"Mol Wt\"] = nsaids_df[\"Molecule\"].apply(Descriptors.MolWt)\n",
-        "nsaids_df[\"logP\"] = nsaids_df[\"Molecule\"].apply(Descriptors.MolLogP)\n",
-        "nsaids_df[\"HBD\"] = nsaids_df[\"Molecule\"].apply(Lipinski.NHOHCount)            # Number of hydrogen bond donors\n",
-        "nsaids_df[\"HBA\"] = nsaids_df[\"Molecule\"].apply(Lipinski.NOCount)              # Number of hydrogen bond acceptors\n",
-        "nsaids_df.head()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "nsaids_df.hist(figsize=(8,8), edgecolor='black', grid=False)"
-      ],
-      "metadata": {
-        "id": "WLO4ia4B4lXG"
-      },
-      "id": "WLO4ia4B4lXG",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "dWKNKdDVkJxn",
-      "metadata": {
-        "id": "dWKNKdDVkJxn"
-      },
-      "outputs": [],
-      "source": [
-        "nsaids_df.plot.bar(x='Name', y='Mol Wt', figsize=(10,5))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "LEfWBGaI5-EJ"
-      },
-      "id": "LEfWBGaI5-EJ",
-      "execution_count": null,
-      "outputs": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.2"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7d06a1a8-a729-47c1-973a-3b6afa520f18",
+   "metadata": {
+    "id": "7d06a1a8-a729-47c1-973a-3b6afa520f18"
+   },
+   "source": [
+    "<div style=\"text-align:center;\">\n",
+    "  <img src=\"https://raw.githubusercontent.com/MolSSI-Education/molssi-cheminformatics/0895b9e2d810fc260aaff344286a84a1b7d18a51/custom/molssi_main_horizontal.png\" style=\"display: block; margin: 0 auto; max-height:100px;\">\n",
+    "</div>\n",
+    "\n",
+    "# Digital Representation of Molecules\n",
+    "This notebook is based on notebooks 01-04 from the [MolSSI Cheminformatics course](https://github.com/MolSSI-Education/molssi-cheminformatics), which was created by Jessica A. Nash from The Molecular Sciences Software Institute\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "350c2869-274d-4bab-87c9-aa06fbfd9f89",
+   "metadata": {
+    "cellView": "form",
+    "id": "350c2869-274d-4bab-87c9-aa06fbfd9f89"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Overview\n",
+    "%%html\n",
+    "<style>\n",
+    "div.alert {\n",
+    "    color: #0056b3;\n",
+    "    background-color: #d9edf7;\n",
+    "    border-left: 5px solid #31708f;\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em;\n",
+    "    line-height: 1.5;\n",
+    "}\n",
+    "div.alert ul {\n",
+    "    margin: 0.5em 0;\n",
+    "}\n",
+    "div.alert li {\n",
+    "    margin-bottom: 0.5em;\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <strong>Questions:</strong>\n",
+    "    <ul>\n",
+    "        <li>How are molecules represented on computers?</li>\n",
+    "        <li>What is a SMILES?</li>\n",
+    "        <li>What are common molecular file formats?</li>\n",
+    "   </ul>\n",
+    "\n",
+    "    <strong>Objectives:</strong>\n",
+    "    <ul>\n",
+    "        <li>Learn the basics of SMILES strings.</li>\n",
+    "        <li>Convert molecules from chemical formula and structures to SMILES strings.</li>\n",
+    "    </ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8eb3cf1-79d9-40f6-a739-92b0ba19539e",
+   "metadata": {
+    "id": "b8eb3cf1-79d9-40f6-a739-92b0ba19539e"
+   },
+   "source": [
+    "## Molecular Representations of Biological Molecules for Computing\n",
+    "\n",
+    "In bioinformatics, if you work with genomics you are accustomed to working with DNA sequences. For example, this is a partial DNA sequence for human dihdydrofolate reductase, an important enzyme in nucelotide metabolism.\n",
+    "\n",
+    "```\n",
+    "GAATTCATGAAAACGTAGCTCGTCCTCAAAAAAAACAGAAGAGGAGTAATCATTTTAAGGGAGAAATATA\n",
+    "TACGAAAGGAACAAGATTTTGAAGCACCCAAGCTGCCACCTACATTAAAACACGGTAGGTGGCTAAACAC\n",
+    "CAGTCTTCAATGCCCTTCCACAGCCTCAGTCTGAAAAATACTGTGCAGGTGACCCAAGTGAGGGGTCACC\n",
+    "CTTGGGCTTTTCCTGTGGCAGTATCTCTGGTTTAAAAACAAACAAACGTACTTATTGCGTTGAAGGACGG\n",
+    "CAACAGGAAGGACTCCATGATTAGTCACATCTATACCATCCTAAGAAACTTTATCCACCCAAACTGTATT\n",
+    "TCAGACTTTATAATCTAAACTACAAAAAGTGTTCACTGGGGAACTGCACAATATGACTGCTTTTAACCGT\n",
+    "```\n",
+    "\n",
+    "The DNA sequence shown here is a simplified representation of a very complex 3D structure that is part of a chromosome, an enormously complex structure. The sequence that represents this gene can be used as a string in coding - computation with strings is orders of magnitude faster than computation with 3D structures. And we can still learn a great deal about this gene simply by exploring the sequence. Likewise we can represent the RNA transcribed from this sequence as a list of characters where T is replaced by U.\n",
+    "\n",
+    "If you study proteins or proteomics, you know that protein function depends on protein structure. Protein structures involve 20 (or more) building blocks so the sequences are more complex, but the principle of representing the protein as a simple string for ease with computing still applies. Here is the sequence of the dihydrofolate reductase protein that is coded in this gene sequence above.\n",
+    "\n",
+    "```\n",
+    "MVGSLNCIVAVSQNMGIGKNGDLPWPPLRNEFRYFQRMTTTSSVEGKQNLVIMGKKTWFSIPEKNRPLKG\n",
+    "RINLVLSRELKEPPQGAHFLSRSLDDALKLTEQPELANKVDMVWIVGGSSVYKEAMNHPGHLKLFVTRIM\n",
+    "QDFESDTFFPEIDLEKYKLLPEYPGVLSDVQEEKGIKYKFEVYEKND\n",
+    "```\n",
+    "\n",
+    "As we move into cheminformatics, we often want to convert small molecule structures, like the aspirin shown here, into strings for computing ease.\n",
+    "\n",
+    "![Aspirin.png](https://drive.google.com/uc?export=view&id=1hcWaacd-pIb09Wi9dceVSQIfkXgWC-vD)\n",
+    "\n",
+    "There are three well-known string conversions for small molecules, SMILES, InChI, and InChI Key. Here are the SMILES, InChI, and InChI Key strings for aspirin.\n",
+    "\n",
+    "SMILES: CC(=O)OC1=CC=CC=C1C(=O)O\n",
+    "\n",
+    "InChI: 1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)\n",
+    "\n",
+    "InChI Key: BSYNRYMUTXBXSQ-UHFFFAOYSA-N\n",
+    "\n",
+    "In this workshop we will use SMILES strings. SMILES syntax is explained below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a20ce5f-0392-40be-a64f-006929d49a5a",
+   "metadata": {
+    "id": "1a20ce5f-0392-40be-a64f-006929d49a5a"
+   },
+   "source": [
+    "## Simplified Molecular-Input Line-entry System: SMILES\n",
+    "\n",
+    "SMILES stands for \"Simplified Molecular-Input Line-Entry System\" and is a way to represent molecules as a string of characters.\n",
+    "\n",
+    "Consider the molecule ethanol. The image below shows a representation that we are used to seeing in chemistry:\n",
+    "\n",
+    "![ethanol](https://drive.google.com/uc?export=view&id=1pBnnNujVdkw43xpDOM27nzICgnn7EqJj)\n",
+    "\n",
+    "However, the SMILES representation of this molecule would be \"CCO\".\n",
+    "\n",
+    "You can read more about SMILES at [this tutorial](https://archive.epa.gov/med/med_archive_03/web/html/smiles.html), but rules for atoms and bonds are also repeated below.\n",
+    "\n",
+    "### Atoms\n",
+    "SMILES supports all elements in the periodic table. An atom is represented using its respective atomic symbol. Upper case letters refer to non-aromatic atoms; lower case letters refer to aromatic atoms. If the atomic symbol has more than one letter the second letter must be lower case.\n",
+    "\n",
+    "### Bonds\n",
+    "```\n",
+    "-\tSingle bond\n",
+    "=\tDouble bond\n",
+    "#\tTriple bond\n",
+    "*\tAromatic bond\n",
+    ".\tDisconnected structures\n",
+    "```\n",
+    "Single bonds are the default and therefore need not be entered. For example, 'CC' would mean that there is a non-aromatic carbon attached to another non-aromatic carbon by a single bond, and the computer would identify the structure as the chemical ethane. It is also assumed that the bond between two lower case atom symbols is aromatic. A blank terminates the SMILES string.\n",
+    "\n",
+    "### Branches\n",
+    "\n",
+    "A branch from a chain is specified by placing the SMILES symbol(s) for the branch between parenthesis. Some examples:\n",
+    "\n",
+    "```\n",
+    "\n",
+    "CC(O)C\t2-Propanol\n",
+    "CC(=O)C\t2-Propanone\n",
+    "```\n",
+    "\n",
+    "### Rings\n",
+    "\n",
+    "A ring is specified by placing a number directly after the SMILES symbol where the ring closure occurs. This number acts as a marker, indicating that the atoms with the same number are connected, thus forming a ring. For instance:\n",
+    "\n",
+    "```\n",
+    "C1CCCC1   cyclopentane\n",
+    "n1ccccc1  Pyridine\n",
+    "```\n",
+    "\n",
+    "### SMILES Examples\n",
+    "\n",
+    "![SMILES Example 1](https://drive.google.com/uc?export=view&id=1-MFSoAGwqOPiqIUD06reOkBPx4BTMhGC)\n",
+    "\n",
+    "![SMILES Example 2](https://drive.google.com/uc?export=view&id=18Ub9L98y8cL_lDLF9wl6pLQxCkt8JFqu)\n",
+    "\n",
+    "### Using Online Resources\n",
+    "Most of the time, you will not need to write a SMILES string by hand. You will be able to look up a molecule's SMILES string from a web database like [PubChem](https://pubchem.ncbi.nlm.nih.gov/).\n",
+    "\n",
+    "You can also use tools like this [molecule sketcher from the Protein Data Bank](https://www.rcsb.org/chemical-sketch)\n",
+    "to draw molecules and get their SMILES strings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "928a5415-2bcb-4ef0-ac8a-1744714d8d3c",
+   "metadata": {
+    "cellView": "form",
+    "id": "928a5415-2bcb-4ef0-ac8a-1744714d8d3c"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Exercise\n",
+    "%%html\n",
+    "<style>\n",
+    "div.orange-alert {\n",
+    "    color: #854f00; /* Darker shade of orange for text */\n",
+    "    background-color: #ffe6cc; /* Light orange background */\n",
+    "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.orange-alert ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.orange-alert li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"orange-alert\">\n",
+    "\n",
+    "<strong>Exercise</strong>\n",
+    "<p>\n",
+    "Based on what you've learned about SMILES strings, answer the following questions:\n",
+    "</p>\n",
+    "    <ul>\n",
+    "        <li> What is the SMILES for ethanol?</li>\n",
+    "        <li> What is the SMILES for water?</li>\n",
+    "        <li> What is the SMILES for benzene?</li>\n",
+    "        <li> What molecule is represented by the SMILES O=C=O?</li>\n",
+    "        <li> What is the SMILES for an amide group?<//li>\n",
+    "        <li> What is the SMILES for a 4 membered carbon chain with an amide group on the second carbon?</li>\n",
+    "    </ul>\n",
+    "</p>\n",
+    "<p>Check your answers from this previous exercise using the PDB molecule sketcher. Notice that you can type in a SMILES string and have the sketcher draw the molecule for you.</p>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6dcdb914-bf20-425d-859c-44c250ca991a",
+   "metadata": {
+    "id": "6dcdb914-bf20-425d-859c-44c250ca991a"
+   },
+   "outputs": [],
+   "source": [
+    "# Fill in your answers here:\n",
+    "# 1. CCO\n",
+    "# 2. O\n",
+    "# 3. c1ccccc1\n",
+    "# 4. Carbon Dioxide\n",
+    "# 5. C(=O)N\n",
+    "# 6. CC(C(=O)N)CC\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4842145a-676e-4f1f-9b55-8b8296a81301",
+   "metadata": {
+    "id": "4842145a-676e-4f1f-9b55-8b8296a81301"
+   },
+   "source": [
+    "## Molecular File Formats\n",
+    "\n",
+    "Molecules can also be represented using a number of different file formats. As you work more in chemistry, you may see a number of these. Sometimes you will have to pick a file format based on the software you are using or the molecular information you want to save.\n",
+    "\n",
+    "| File Format | Description                                                                 | Features                                                              | Common Uses                              |\n",
+    "|-------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------|------------------------------------------|\n",
+    "| SMILES      | Simplified Molecular Input Line Entry System                                | Line notation for representing molecular structures                   | Database               |\n",
+    "| InChI       | International Chemical Identifier                                           | Textual identifier for chemical substances                            | Databases             |\n",
+    "| MOL/SDF     | MDL MOLfile and Structure-Data File                                         | Contains 2D/3D coordinates, atoms, bonds                              | Structure visualization, cheminformatics |\n",
+    "| PDB         | Protein Data Bank format                                                    | Often used for 3D structures of proteins and nucleic acids,but can also be used for small molecules. Often does not contain molecule information, and cannot store partial charges.                           | Structural biology, bioinformatics       |\n",
+    "| XYZ         | Cartesian coordinates                                                       | Simple text format with atom types and 3D coordinates                 | Computational chemistry, molecular dynamics |     |\n",
+    "| CIF         | Crystallographic Information File                                           | Text file format for representing crystal structure data              | Crystallography                          |\n",
+    "| PQR         | Extended PDB format with partial charges and radii                          | Includes atomic coordinates, partial charges, and radii               | Electrostatics calculations              |\n",
+    "| PDBQT       | PDB format with torsion angles and charges used in AutoDock                 | Includes atomic coordinates, partial charges, torsion angles          | Molecular docking                        |\n",
+    "|MOL2   |Tripos Mol2 format|\tContains atomic coordinates, bonds, molecule types, substructures, and partial charges|\tMolecular modeling, cheminformatics, computational chemistry\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3db21944-72a0-4523-a87d-f702baa98a4b",
+   "metadata": {
+    "cellView": "form",
+    "id": "3db21944-72a0-4523-a87d-f702baa98a4b"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Introduction to RDKit Molecules\n",
+    "%%html\n",
+    "<style>\n",
+    "div.alert {\n",
+    "    color: #0056b3;\n",
+    "    background-color: #d9edf7;\n",
+    "    border-left: 5px solid #31708f;\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em;\n",
+    "    line-height: 1.5;\n",
+    "}\n",
+    "div.alert ul {\n",
+    "    margin: 0.5em 0;\n",
+    "}\n",
+    "div.alert li {\n",
+    "    margin-bottom: 0.5em;\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <strong>Questions:</strong>\n",
+    "    <ul>\n",
+    "        <li>What is RDKit?</li>\n",
+    "        <li>What is an RDKit mol object?</li>\n",
+    "        <li>What can I do with RDKit mol objects?</li>\n",
+    "   </ul>\n",
+    "\n",
+    "    <strong>Objectives:</strong>\n",
+    "    <ul>\n",
+    "        <li>Use RDKit to create mol objects in Python.</li>\n",
+    "    </ul>\n",
+    "\n",
+    "<p>\n",
+    "There are Python libraries that are made for working just with chemical data. One commonly\n",
+    "used library in Python for data science (or cheminformatics) is called\n",
+    "[RDKit](https://en.wikipedia.org/wiki/RDKit). RDKit is an open-source cheminformatics\n",
+    "library, primarily developed in C++ and has been under development since the year 2000.\n",
+    "We will be using the Python interface to RDKit, though there are interfaces in other languages.\n",
+    "</p>\n",
+    "\n",
+    "<p>\n",
+    "RDKit provides a molecule object that allows you to manipulate chemical structures. It has\n",
+    "capabilities for reading and writing molecular file formats, calculating molecular properties,\n",
+    "and performing substructure searches. In addition, it offers a wide range of cheminformatics\n",
+    "algorithms such as molecular fingerprint generation, similarity metrics calculation, and\n",
+    "molecular descriptor computation. This notebook introduces RDKit basics, but we will see more\n",
+    "of all of these topics in later notebooks.\n",
+    "</p>\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3949cd4d-3f71-4622-a774-bcf3542a74d8",
+   "metadata": {
+    "cellView": "form",
+    "id": "3949cd4d-3f71-4622-a774-bcf3542a74d8"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Python Skills - Python Objects\n",
+    "%%html\n",
+    "<style>\n",
+    "div.purple-box {\n",
+    "    color: #4b0082; /* Indigo for text */\n",
+    "    background-color: #f3e5f5; /* Light lavender background */\n",
+    "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+    "}\n",
+    "div.purple-box ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.purple-box li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"purple-box\">\n",
+    "    <p>\n",
+    "       Most of this functionality is achieved through the RDKit `mol` object. In Python,\n",
+    "we use the word \"object\" to refer to a variable type with associated data and methods.\n",
+    "One example of an object we have seen in notebooks is a list - we could also call it\n",
+    "a \"list object\". An object has `attributes` (data) and `methods`.\n",
+    "You access information about objects with the syntax\n",
+    "    </p>\n",
+    "<pre>\n",
+    "\n",
+    "object.data\n",
+    "\n",
+    "</pre>\n",
+    "\n",
+    "where data is the attribute name.\n",
+    "\n",
+    "You access object methods with the syntax\n",
+    "\n",
+    "<pre>\n",
+    "\n",
+    "object.method(arguments)\n",
+    "\n",
+    "</pre>\n",
+    "        For example, for a list \"`append` is a method that was covered in the introductory lesson.\n",
+    "<pre>\n",
+    "\n",
+    "my_list = []\n",
+    "my_list.append(1) # \"append\" is a method\n",
+    "\n",
+    "<pre>\n",
+    "</div>\n",
+    "\n",
+    "<p>\n",
+    "In this lesson, we will create and manipulate RDKit `mol` objects. RDKit `mol` objects represent molecules and have\n",
+    "attributes (data) and methods (actions) associated with molecules.\n",
+    "</p>\n",
+    "<p>\n",
+    "We are going to use a part of RDKit called `Chem`. To use `Chem`, we first have to import it.\n",
+    "</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Xovgh3LcqJA2",
+   "metadata": {
+    "id": "Xovgh3LcqJA2"
+   },
+   "outputs": [],
+   "source": [
+    "from google.colab import output\n",
+    "\n",
+    "output.clear()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c5c13a5-b369-4188-8b13-356445deeb5a",
+   "metadata": {
+    "id": "3c5c13a5-b369-4188-8b13-356445deeb5a"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rdkit\n",
+    "from rdkit import Chem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d84d6c70-fd6e-41bf-81c6-7145d6f87b0e",
+   "metadata": {
+    "id": "d84d6c70-fd6e-41bf-81c6-7145d6f87b0e"
+   },
+   "source": [
+    "## Creating Molecules with RDKit\n",
+    "\n",
+    "Throughout this tutorial, it will be helpful to have access to the [RDKit documentation](https://www.rdkit.org/docs/index.html).\n",
+    "\n",
+    "To get information about molecules in RDKit, we have to first create objects representing molecules. RDKit has a molecule object that can be used to retrieve information or calculate properties. To create a molecule object, we have to communicate the molecule identity in a way that computers understand.\n",
+    "\n",
+    "We will use SMILES strings to create our objects, though RDKit also has methods for creating molecules from the file formats listed in the previous notebook.\n",
+    "\n",
+    "### Creating molecules using SMILES\n",
+    "\n",
+    "In the last lesson, we learned about molecular representations using SMILES strings. Now we will use SMILES strings to create molecule objects in RDKIT.\n",
+    "\n",
+    "We can create a representation of methane using RDKit by using the `MolFromSmiles` function in `rdkit.Chem`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9415ede-7ab5-4a35-89e8-a32d25dfe1b9",
+   "metadata": {
+    "id": "b9415ede-7ab5-4a35-89e8-a32d25dfe1b9"
+   },
+   "outputs": [],
+   "source": [
+    "methane = Chem.MolFromSmiles(\"C\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "851ae0d6-b0a2-4474-9402-5db4abf49b1c",
+   "metadata": {
+    "id": "851ae0d6-b0a2-4474-9402-5db4abf49b1c"
+   },
+   "outputs": [],
+   "source": [
+    "methane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c305149-481a-4e52-83bc-a24ab48f45bf",
+   "metadata": {
+    "cellView": "form",
+    "id": "6c305149-481a-4e52-83bc-a24ab48f45bf"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Check Your Understanding\n",
+    "%%html\n",
+    "<style>\n",
+    "div.orange-alert {\n",
+    "    color: #854f00; /* Darker shade of orange for text */\n",
+    "    background-color: #ffe6cc; /* Light orange background */\n",
+    "    border-left: 5px solid #ff9933; /* Bright orange border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "}\n",
+    "div.orange-alert ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.orange-alert li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"orange-alert\">\n",
+    "\n",
+    "<p> Create RDKit molecules for the following molecules. You can look up the SMILES strings on <a href=\"https://pubchem.ncbi.nlm.nih.gov/\">PubChem</a>:\n",
+    "<p>\n",
+    "    <ul>\n",
+    "        <li> Propane\n",
+    "        <li> Ethene\n",
+    "        <li> Cyclohexane\n",
+    "        <li> Benzene </li>\n",
+    "        <li> Acetic Acid\n",
+    "    </ul>\n",
+    "</p>\n",
+    "<p>Create variables for each molecule. The variable names should be the molecule name (all lowercase)</p>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "497025f0-e60a-42d1-a26e-77db46e5c495",
+   "metadata": {
+    "id": "497025f0-e60a-42d1-a26e-77db46e5c495"
+   },
+   "outputs": [],
+   "source": [
+    "# Your answers go here\n",
+    "propane = Chem.MolFromSmiles(\"CCC\")  # TO DO: Insert the SMILES string for propane: CCC\n",
+    "ethene = Chem.MolFromSmiles(\"C=C\")  # TO DO: Insert the SMILES string for ethene\n",
+    "cyclohexane = Chem.MolFromSmiles(\n",
+    "    \"C1CCCCC1 \"\n",
+    ")  # TO DO: Call the method and insert the SMILES string for cyclohexane\n",
+    "benzene = Chem.MolFromSmiles(\n",
+    "    \"c1ccccc1\"\n",
+    ")  # TO DO: Call the method and insert the SMILES string for benzene\n",
+    "acetic_acid = Chem.MolFromSmiles(\"CC(=O)O\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f87d25a4-61b2-437a-a5a6-176a2a45a813",
+   "metadata": {
+    "id": "f87d25a4-61b2-437a-a5a6-176a2a45a813"
+   },
+   "outputs": [],
+   "source": [
+    "# Try visualizing your molecules here just by typing the name of the variable that refers to the RDKit mol object\n",
+    "acetic_acid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4CzZhBBEGpGV",
+   "metadata": {
+    "id": "4CzZhBBEGpGV"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem.Draw import IPythonConsole as ipc\n",
+    "\n",
+    "# Configuration for displaying in Jupyter notebooks\n",
+    "ipc.ipython_useSVG = True  # Use SVG for higher quality images\n",
+    "ipc.drawOptions.addAtomIndices = True  # Show atom indices\n",
+    "ipc.molSize = 250, 250  # Set size of image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "474fcdab-a904-4c66-8243-5a59de5ebf90",
+   "metadata": {
+    "cellView": "form",
+    "id": "474fcdab-a904-4c66-8243-5a59de5ebf90"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Working with RDKit Molecules\n",
+    "%%html\n",
+    "<style>\n",
+    "div.purple-box {\n",
+    "    color: #4b0082; /* Indigo for text */\n",
+    "    background-color: #f3e5f5; /* Light lavender background */\n",
+    "    border-left: 5px solid #7b1fa2; /* Medium purple border */\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em; /* Matches the surrounding text size */\n",
+    "    line-height: 1.5; /* Ensures readability */\n",
+    "    font-family: Arial, sans-serif; /* Clean, modern font */\n",
+    "}\n",
+    "div.purple-box ul {\n",
+    "    margin: 0.5em 0; /* Space around the list */\n",
+    "}\n",
+    "div.purple-box li {\n",
+    "    margin-bottom: 0.5em; /* Space between list items */\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"purple-box\">\n",
+    "    <p>\n",
+    "RDKit molecule objects have a number of methods we can use to get more information about the molecule. In the next few cells, we'll look at some methods that can tell us some things about the molecules we've created. The next cell has settings for modifying drawing molecules. It adds labels of atom indices and sets the image size\n",
+    "When working with Python objects in the Jupyter notebook, you can\n",
+    "type a variable or object name to see the methods available on that object.\n",
+    "    </p>\n",
+    "    <p>\n",
+    "In the cell below, type\n",
+    "<pre>\n",
+    "  acetic_acid.\n",
+    "\n",
+    "</pre>\n",
+    "\n",
+    "Notice how there is a dot at the end\n",
+    "\n",
+    "    <pre>\n",
+    "      .\n",
+    "    </pre>\n",
+    "\n",
+    "Then press the `tab` key. A list of possible methods and attributes will come up.\n",
+    "\n",
+    "Look through the methods until you find one that gives you the number of atoms in the molecule.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1a331ad-3b4d-44e1-ad51-dc093008dacb",
+   "metadata": {
+    "id": "e1a331ad-3b4d-44e1-ad51-dc093008dacb"
+   },
+   "outputs": [],
+   "source": [
+    "# Pick a method that will tell you the number of atoms acetic acid has.\n",
+    "\n",
+    "x = acetic_acid.GetNumAtoms()  # TO DO: enter a . after acetic acid and then scroll down the list to find a method to give you the number of atoms\n",
+    "\n",
+    "print(\"Acetic acid has\", x, \"heavy atoms.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56379e5a-44f0-4272-959d-91f652ba4128",
+   "metadata": {
+    "id": "56379e5a-44f0-4272-959d-91f652ba4128"
+   },
+   "source": [
+    "### Finding help\n",
+    "When you start working with RDKit mol objects, it will be an adjustment. This is a new type of variable and it will take time to adjust. One way to find help is to use a simple help command where the object of the help function is the name of the RDKit mol object. In the next cell, we will use help to learn more about the RDKit mol object, acetic_acid, that we just created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b7d32b7-f531-4a4f-b05e-4c6c51664d50",
+   "metadata": {
+    "id": "1b7d32b7-f531-4a4f-b05e-4c6c51664d50"
+   },
+   "outputs": [],
+   "source": [
+    "help(acetic_acid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc30f661-dc41-4c06-82cc-a4ae762d65e7",
+   "metadata": {
+    "id": "cc30f661-dc41-4c06-82cc-a4ae762d65e7"
+   },
+   "outputs": [],
+   "source": [
+    "# Add an argument to your function to get the total number of atoms in acetic_acid including hydrogens\n",
+    "\n",
+    "x = (\n",
+    "    acetic_acid.GetNumAtoms()\n",
+    ")  # This is the method we used in an earlier cell. Note that the parentheses are empty.\n",
+    "\n",
+    "y = acetic_acid.GetNumAtoms(\n",
+    "    onlyExplicit=False\n",
+    ")  # TO DO: To include the hydrogens in the atom count, insert the phrase onlyExplicit = False in the parentheses.\n",
+    "\n",
+    "print(f\"There are {x} heavy atoms in acetic acid and {y} total atoms in acetic acid.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a47eba18-f0a2-4d59-88c0-b58b1605d9d4",
+   "metadata": {
+    "cellView": "form",
+    "id": "a47eba18-f0a2-4d59-88c0-b58b1605d9d4"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Examining and Visualizing Data\n",
+    "%%html\n",
+    "<style>\n",
+    "div.alert {\n",
+    "    color: #0056b3;\n",
+    "    background-color: #d9edf7;\n",
+    "    border-left: 5px solid #31708f;\n",
+    "    padding: 0.5em;\n",
+    "    font-size: 1.25em;\n",
+    "    line-height: 1.5;\n",
+    "}\n",
+    "div.alert ul {\n",
+    "    margin: 0.5em 0;\n",
+    "}\n",
+    "div.alert li {\n",
+    "    margin-bottom: 0.5em;\n",
+    "}\n",
+    "</style>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <strong>Questions:</strong>\n",
+    "    <ul>\n",
+    "        <li>How can I use pandas to work with molecules from rdkit?</li>\n",
+    "        <li>How can I visualize relationships between different parts of my data?</li>\n",
+    "   </ul>\n",
+    "\n",
+    "    <strong>Objectives:</strong>\n",
+    "    <ul>\n",
+    "        <li>Review the pandas dataframe</li>\n",
+    "        <li>Learn to visualize structures in a pandas dataframe</li>\n",
+    "        <li>Learn the <i>apply</i> tool for expanding a pandas dataframe</li>\n",
+    "    </ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4cc10b7-5d18-4853-bfac-a2448f722414",
+   "metadata": {
+    "id": "a4cc10b7-5d18-4853-bfac-a2448f722414"
+   },
+   "source": [
+    "[Pandas](https://pandas.pydata.org/docs/) is a Python library used for data analysis and manipulation. Within the world of data science, it is a ubiquitous and widely used library. If you are learning how to analyze data in Python, it will be almost impossible to avoid pandas.\n",
+    "\n",
+    "The central data structure of pandas is called a DataFrame. Pandas DataFrames work very closely with NumPy arrays and Pandas dataframes are specifically for data which is two dimensional (rows and columns). NumPy arrays, while similar in some ways, can work with higher dimensional data.\n",
+    "\n",
+    "Pandas is very powerful. In this session, we'll be learning how to access information in pandas dataframes and how to do some basic manipulation and analysis. We are going to be looking at a dataset which gives information about the elements in the periodic table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2e82ae2-4050-4955-a205-5ed86e42cc2b",
+   "metadata": {
+    "id": "f2e82ae2-4050-4955-a205-5ed86e42cc2b"
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd  # importing the pandas library\n",
+    "\n",
+    "from rdkit.Chem import PandasTools  # importing rdkit functions to work with pandas\n",
+    "\n",
+    "PandasTools.RenderImagesInAllDataFrames(\n",
+    "    images=True\n",
+    ")  # to display chemical structures in dataframes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "LzrEG54AKY-W",
+   "metadata": {
+    "id": "LzrEG54AKY-W"
+   },
+   "outputs": [],
+   "source": [
+    "from urllib.request import (\n",
+    "    urlretrieve,\n",
+    ")  # importing a method that enables retrieval of a text file from a URL\n",
+    "\n",
+    "url = \"https://raw.githubusercontent.com/MolSSI-Education/iqb-2025/refs/heads/paul/data/nsaids.csv\"\n",
+    "\n",
+    "filename = \"nsaids.csv\"\n",
+    "\n",
+    "urlretrieve(url, filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ed0f50a-7b42-49dc-acc4-f68c4cedc1a6",
+   "metadata": {
+    "id": "6ed0f50a-7b42-49dc-acc4-f68c4cedc1a6"
+   },
+   "source": [
+    "## Loading a collection of small molecules\n",
+    "\n",
+    "In the next few cells, we'll read a text file that lists the SMILES strings for some nonsteroidal antiinflammatory drugs (NSAIDS) and then use them to start building a pandas dataframe. The SMILES strings for the NSAIDS can be found in [nsaids.txt](https://docs.google.com/document/d/1RQeVIFBMeq4SWTrRNfgZXRvaaRNXVknLxgVZfTbJUDs/edit?usp=drive_link).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e09ef49-ad83-4f81-a0da-c90c83f02d3b",
+   "metadata": {
+    "id": "6e09ef49-ad83-4f81-a0da-c90c83f02d3b"
+   },
+   "outputs": [],
+   "source": [
+    "nsaids_file = \"nsaids.csv\"\n",
+    "\n",
+    "nsaids_df = pd.read_csv(nsaids_file)\n",
+    "\n",
+    "nsaids_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26a9b6b3-10ff-4594-b660-5b605ac30e2e",
+   "metadata": {
+    "id": "26a9b6b3-10ff-4594-b660-5b605ac30e2e"
+   },
+   "source": [
+    "### The `.apply` method\n",
+    "\n",
+    "The `.apply` method in pandas is used to apply a function along a row or column of a dataframe.\n",
+    "This is useful when you have a custom function that you need to use on every value in a column, but there is not a NumPy or Pandas function for it.\n",
+    "\n",
+    "For example, we could apply the `len` function to our `Name` column to get the number of letters in the name for each element.\n",
+    "\n",
+    "```python\n",
+    "# Number of letters in name -\n",
+    "df[\"Name\"].apply(len)\n",
+    "```\n",
+    "\n",
+    "We are going to use ```apply``` to add a new column to nsaid_df that contains the rdkit molecule for each of the NSAIDs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb693a02-58a2-467d-80fa-723d61f62219",
+   "metadata": {
+    "id": "fb693a02-58a2-467d-80fa-723d61f62219"
+   },
+   "outputs": [],
+   "source": [
+    "nsaids_df[\"Molecule\"] = nsaids_df[\"SMILES\"].apply(Chem.MolFromSmiles)\n",
+    "\n",
+    "nsaids_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "WqeeyIxPiF-7",
+   "metadata": {
+    "id": "WqeeyIxPiF-7"
+   },
+   "source": [
+    "At this point, nsaid_df contains two columns: the SMILES string and the molecule. We will go one step further and use ```apply``` to add another column to the dataframe that contains a descriptor based on the rdkit molecule. Before we can do that we need to import a new sublibrary from rdkit.Chem called Descriptors. Notice that the new columns will be based on the Molecule column, which contains rdkit mol objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "v7lK6asEid7Q",
+   "metadata": {
+    "id": "v7lK6asEid7Q"
+   },
+   "outputs": [],
+   "source": [
+    "from rdkit.Chem import Descriptors\n",
+    "from rdkit.Chem import Lipinski\n",
+    "\n",
+    "nsaids_df[\"Mol Wt\"] = nsaids_df[\"Molecule\"].apply(Descriptors.MolWt)\n",
+    "nsaids_df[\"logP\"] = nsaids_df[\"Molecule\"].apply(Descriptors.MolLogP)\n",
+    "nsaids_df[\"HBD\"] = nsaids_df[\"Molecule\"].apply(\n",
+    "    Lipinski.NHOHCount\n",
+    ")  # Number of hydrogen bond donors\n",
+    "nsaids_df[\"HBA\"] = nsaids_df[\"Molecule\"].apply(\n",
+    "    Lipinski.NOCount\n",
+    ")  # Number of hydrogen bond acceptors\n",
+    "nsaids_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "WLO4ia4B4lXG",
+   "metadata": {
+    "id": "WLO4ia4B4lXG"
+   },
+   "outputs": [],
+   "source": [
+    "nsaids_df.hist(figsize=(8, 8), edgecolor=\"black\", grid=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dWKNKdDVkJxn",
+   "metadata": {
+    "id": "dWKNKdDVkJxn"
+   },
+   "outputs": [],
+   "source": [
+    "nsaids_df.plot.bar(x=\"Name\", y=\"Mol Wt\", figsize=(10, 5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "LEfWBGaI5-EJ",
+   "metadata": {
+    "id": "LEfWBGaI5-EJ"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/solutions/02_Cheminfo_crash_course_with_solutions.ipynb
+++ b/solutions/02_Cheminfo_crash_course_with_solutions.ipynb
@@ -51,7 +51,8 @@
    "source": [
     "%%capture\n",
     "import sys\n",
-    "IN_COLAB = 'google.colab' in sys.modules\n",
+    "\n",
+    "IN_COLAB = \"google.colab\" in sys.modules\n",
     "if IN_COLAB:\n",
     "    !pip install pandas mols2grid seaborn rdkit matplotlib useful_rdkit_utils scikit-learn ipywidgets"
    ]
@@ -114,7 +115,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.read_csv(\"https://raw.githubusercontent.com/PatWalters/practical_cheminformatics_tutorials/refs/heads/main/pdb/monomers_12285.tsv\",sep=\"\\t\")"
+    "df = pd.read_csv(\n",
+    "    \"https://raw.githubusercontent.com/PatWalters/practical_cheminformatics_tutorials/refs/heads/main/pdb/monomers_12285.tsv\",\n",
+    "    sep=\"\\t\",\n",
+    ")"
    ]
   },
   {
@@ -187,8 +191,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.rename(columns={'Ligand SMILES':'SMILES'},inplace=True)\n",
-    "df.rename(columns={'BindingDB Ligand Name':'Name'},inplace=True)"
+    "df.rename(columns={\"Ligand SMILES\": \"SMILES\"}, inplace=True)\n",
+    "df.rename(columns={\"BindingDB Ligand Name\": \"Name\"}, inplace=True)"
    ]
   },
   {
@@ -2095,7 +2099,7 @@
     }
    ],
    "source": [
-    "mols2grid.display(df,smiles_col=\"SMILES\",subset=[\"img\",\"IC50 (nM)\"])"
+    "mols2grid.display(df, smiles_col=\"SMILES\", subset=[\"img\", \"IC50 (nM)\"])"
    ]
   },
   {
@@ -2273,9 +2277,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.set(rc={'figure.figsize': (5,5 )})\n",
-    "sns.set_style('whitegrid')\n",
-    "sns.set_context('notebook')"
+    "sns.set(rc={\"figure.figsize\": (5, 5)})\n",
+    "sns.set_style(\"whitegrid\")\n",
+    "sns.set_context(\"notebook\")"
    ]
   },
   {
@@ -2373,7 +2377,7 @@
     }
    ],
    "source": [
-    "[f\"{x:.2f}\" for x in [df.pIC50.min(),df.pIC50.mean(),df.pIC50.max()]]"
+    "[f\"{x:.2f}\" for x in [df.pIC50.min(), df.pIC50.mean(), df.pIC50.max()]]"
    ]
   },
   {
@@ -2420,7 +2424,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[\"activity\"] = pd.cut(df.pIC50,bins=[0,6,7,100],labels=[\"low\",\"med\",\"high\"],right=False)"
+    "df[\"activity\"] = pd.cut(\n",
+    "    df.pIC50, bins=[0, 6, 7, 100], labels=[\"low\", \"med\", \"high\"], right=False\n",
+    ")"
    ]
   },
   {
@@ -2441,7 +2447,7 @@
     }
    ],
    "source": [
-    "ax = sns.histplot(x=\"pIC50\",hue=\"activity\",data=df,bins=np.arange(4,9,0.5))"
+    "ax = sns.histplot(x=\"pIC50\", hue=\"activity\", data=df, bins=np.arange(4, 9, 0.5))"
    ]
   },
   {
@@ -2467,7 +2473,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['mol'] = df.SMILES.apply(Chem.MolFromSmiles)"
+    "df[\"mol\"] = df.SMILES.apply(Chem.MolFromSmiles)"
    ]
   },
   {
@@ -2485,8 +2491,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['MW'] = df.mol.apply(uru.MolWt)\n",
-    "df['LogP'] = df.mol.apply(uru.MolLogP)"
+    "df[\"MW\"] = df.mol.apply(uru.MolWt)\n",
+    "df[\"LogP\"] = df.mol.apply(uru.MolLogP)"
    ]
   },
   {
@@ -2515,7 +2521,7 @@
     }
    ],
    "source": [
-    "ax = sns.scatterplot(x=\"MW\",y=\"LogP\",hue=\"activity\",data=df)\n",
+    "ax = sns.scatterplot(x=\"MW\", y=\"LogP\", hue=\"activity\", data=df)\n",
     "sns.move_legend(ax, \"upper left\", bbox_to_anchor=(1, 1))"
    ]
   },
@@ -2557,12 +2563,12 @@
     }
    ],
    "source": [
-    "# calculate the number of HB donors \n",
-    "df['HBD'] = df.mol.apply(uru.NumHDonors)\n",
+    "# calculate the number of HB donors\n",
+    "df[\"HBD\"] = df.mol.apply(uru.NumHDonors)\n",
     "# calcualte the number of HB acceptors\n",
-    "df['HBA'] = df.mol.apply(uru.NumHAcceptors)\n",
+    "df[\"HBA\"] = df.mol.apply(uru.NumHAcceptors)\n",
     "# make the scatterplot\n",
-    "sns.scatterplot(x=\"HBD\",y=\"HBA\",data=df)"
+    "sns.scatterplot(x=\"HBD\", y=\"HBA\", data=df)"
    ]
   },
   {
@@ -2581,7 +2587,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['mol'] = df[\"SMILES\"].apply(Chem.MolFromSmiles)"
+    "df[\"mol\"] = df[\"SMILES\"].apply(Chem.MolFromSmiles)"
    ]
   },
   {
@@ -2660,7 +2666,7 @@
     }
    ],
    "source": [
-    "uru.rd_set_image_size(300,300)\n",
+    "uru.rd_set_image_size(300, 300)\n",
     "df.mol.values[0].GetSubstructMatch(pat)\n",
     "df.mol.values[0]"
    ]
@@ -2680,7 +2686,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['Scaffold'] = df.mol.apply(GetScaffoldForMol)"
+    "df[\"Scaffold\"] = df.mol.apply(GetScaffoldForMol)"
    ]
   },
   {
@@ -2698,7 +2704,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['Scaffold_SMILES'] = df.Scaffold.apply(Chem.MolToSmiles)"
+    "df[\"Scaffold_SMILES\"] = df.Scaffold.apply(Chem.MolToSmiles)"
    ]
   },
   {
@@ -2785,7 +2791,7 @@
     }
    ],
    "source": [
-    "scaffold_counts_df = uru.value_counts_df(df,\"Scaffold_SMILES\")\n",
+    "scaffold_counts_df = uru.value_counts_df(df, \"Scaffold_SMILES\")\n",
     "scaffold_counts_df.head()"
    ]
   },
@@ -4659,8 +4665,13 @@
     }
    ],
    "source": [
-    "mols2grid.display(scaffold_counts_df,smiles_col=\"Scaffold_SMILES\",subset=[\"img\",\"count\"],size=(250,250),\n",
-    "                  n_items_per_page=6)"
+    "mols2grid.display(\n",
+    "    scaffold_counts_df,\n",
+    "    smiles_col=\"Scaffold_SMILES\",\n",
+    "    subset=[\"img\", \"count\"],\n",
+    "    size=(250, 250),\n",
+    "    n_items_per_page=6,\n",
+    ")"
    ]
   },
   {
@@ -6610,7 +6621,7 @@
    ],
    "source": [
     "df_lt5 = scaffold_counts_df.query(\"count < 5\")\n",
-    "mols2grid.display(df_lt5,smiles_col=\"Scaffold_SMILES\",subset=[\"img\",\"count\"])"
+    "mols2grid.display(df_lt5, smiles_col=\"Scaffold_SMILES\", subset=[\"img\", \"count\"])"
    ]
   },
   {
@@ -6629,13 +6640,15 @@
    "outputs": [],
    "source": [
     "output_list = []\n",
-    "for k,v in df.groupby('Scaffold_SMILES'):\n",
+    "for k, v in df.groupby(\"Scaffold_SMILES\"):\n",
     "    if len(v) > 5:\n",
     "        mol = Chem.MolFromSmiles(k)\n",
     "        mol_image = uru.mol_to_base64_image(mol)\n",
     "        boxplot_image = uru.boxplot_base64_image(v.pIC50.values)\n",
-    "        output_list.append([mol_image, len(v),boxplot_image])\n",
-    "output_df = pd.DataFrame(output_list,columns=[\"Scaffold\",\"Num Examples\",\"pIC50 Distribution\"])        "
+    "        output_list.append([mol_image, len(v), boxplot_image])\n",
+    "output_df = pd.DataFrame(\n",
+    "    output_list, columns=[\"Scaffold\", \"Num Examples\", \"pIC50 Distribution\"]\n",
+    ")"
    ]
   },
   {
@@ -6696,7 +6709,7 @@
     }
    ],
    "source": [
-    "HTML(output_df.sort_values(\"Num Examples\",ascending=False).to_html(escape=False))"
+    "HTML(output_df.sort_values(\"Num Examples\", ascending=False).to_html(escape=False))"
    ]
   },
   {
@@ -6716,7 +6729,7 @@
    "outputs": [],
    "source": [
     "smi2fp = uru.Smi2Fp()\n",
-    "df['morgan_fp'] = df.SMILES.apply(smi2fp.get_fp)"
+    "df[\"morgan_fp\"] = df.SMILES.apply(smi2fp.get_fp)"
    ]
   },
   {
@@ -6734,7 +6747,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['cluster'] = uru.taylor_butina_clustering(df.morgan_fp)"
+    "df[\"cluster\"] = uru.taylor_butina_clustering(df.morgan_fp)"
    ]
   },
   {
@@ -6805,7 +6818,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "columns_to_keep = [\"SMILES\",\"Name\",\"IC50 (nM)\",\"cluster\"]"
+    "columns_to_keep = [\"SMILES\", \"Name\", \"IC50 (nM)\", \"cluster\"]"
    ]
   },
   {
@@ -6929,7 +6942,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "unique_cluster_df[columns_to_keep].sort_values(\"cluster\").to_csv(\"US20240293380_examples.csv\",index=False)"
+    "unique_cluster_df[columns_to_keep].sort_values(\"cluster\").to_csv(\n",
+    "    \"US20240293380_examples.csv\", index=False\n",
+    ")"
    ]
   },
   {
@@ -7044,7 +7059,7 @@
     }
    ],
    "source": [
-    "df[columns_to_keep].sort_values(\"IC50 (nM)\",ascending=False).drop_duplicates(\"cluster\")"
+    "df[columns_to_keep].sort_values(\"IC50 (nM)\", ascending=False).drop_duplicates(\"cluster\")"
    ]
   },
   {

--- a/util.py
+++ b/util.py
@@ -2,13 +2,16 @@
 utility functions for the workshop.
 """
 
-def visualize_poses(protein_file, 
-                           pose_file, 
-                           cognate_file=None, 
-                           animate=True,
-                           cognate_color=None,
-                           pose_color=None,
-                           highlight_residues=None):
+
+def visualize_poses(
+    protein_file,
+    pose_file,
+    cognate_file=None,
+    animate=True,
+    cognate_color=None,
+    pose_color=None,
+    highlight_residues=None,
+):
     """
     Creates a 3D visualization of a protein with multiple ligand poses from a single SDF file.
 
@@ -38,9 +41,9 @@ def visualize_poses(protein_file,
 
     # Get colors
     if cognate_color is None:
-      cognate_color = "yellow"
+        cognate_color = "yellow"
     if pose_color is None:
-      pose_color = "green"
+        pose_color = "green"
 
     # Create the viewer
     v = py3Dmol.view()
@@ -50,19 +53,24 @@ def visualize_poses(protein_file,
         v.addModel(f.read())
 
     # Set protein style
-    v.setStyle({'cartoon': {}, 'stick': {'radius': 0.1}})
-    
+    v.setStyle({"cartoon": {}, "stick": {"radius": 0.1}})
+
     # Add VDW representation for highlighted residues if specified
     if highlight_residues:
         for res in highlight_residues:
-            v.addStyle({'model': 0, 'resi': str(res)}, 
-                       {'sphere': {'color': 'magenta', 'opacity': 0.7, 'scale': 0.7}})
+            v.addStyle(
+                {"model": 0, "resi": str(res)},
+                {"sphere": {"color": "magenta", "opacity": 0.7, "scale": 0.7}},
+            )
 
     # Add cognate ligand if provided
     if cognate_file:
         with open(cognate_file) as f:
             v.addModel(f.read())
-        v.setStyle({'model': 1}, {'stick': {'colorscheme': f'{cognate_color}Carbon', 'radius': 0.25}})
+        v.setStyle(
+            {"model": 1},
+            {"stick": {"colorscheme": f"{cognate_color}Carbon", "radius": 0.25}},
+        )
 
     # Add all poses from the SDF file
     model_offset = 1 if cognate_file else 0
@@ -72,12 +80,18 @@ def visualize_poses(protein_file,
     if animate:
         # Add all poses as animation frames
         v.addModelsAsFrames(pose_content)
-        v.setStyle({'model': model_offset + 1}, {'stick': {'colorscheme': f'{pose_color}Carbon'}})
-        v.animate({'interval': 1000})
+        v.setStyle(
+            {"model": model_offset + 1},
+            {"stick": {"colorscheme": f"{pose_color}Carbon"}},
+        )
+        v.animate({"interval": 1000})
     else:
         # Add as separate models
         v.addModel(pose_content)
-        v.setStyle({'model': model_offset + 1}, {'stick': {'colorscheme': f'{pose_color}Carbon'}})
+        v.setStyle(
+            {"model": model_offset + 1},
+            {"stick": {"colorscheme": f"{pose_color}Carbon"}},
+        )
 
     # Set view - zoom to the correct structure
     if cognate_file:
@@ -86,8 +100,8 @@ def visualize_poses(protein_file,
     else:
         # Zoom to docked poses if no cognate
         zoom_model = model_offset + 1
-    
-    v.zoomTo({'model': zoom_model})
+
+    v.zoomTo({"model": zoom_model})
     v.rotate(270)
 
     return v


### PR DESCRIPTION
I saw your nice effort linked by Pat's LinkedIn, but I noticed there's a major way to improve the tutorials in this repository - by using an automated code formatter.

New programmers are particularly susceptible to learning bad style (indentation, spacing, variable naming, etc.)

This PR runs `ruff format` and `ruff check --fix --unsafe-fixes`, then makes a few minor adjustments in places where there was invalid syntax (e.g., replacing blanks with ellipses)

Ideally, learners will see well-formatted code and learn to write code with good formatting themselves. Or even better, use automatic formatters!